### PR TITLE
fix: correct Git repository URL in ArgoCD application

### DIFF
--- a/k8s/argocd/applications/factorio/application.yaml
+++ b/k8s/argocd/applications/factorio/application.yaml
@@ -10,7 +10,7 @@ spec:
     server: https://kubernetes.default.svc
   sources:
     # Git manifests (secrets, pvc, ofsm)
-    - repoURL: https://github.com/jasonljit/homelab.git
+    - repoURL: https://github.com/manamana32321/homelab.git
       targetRevision: main
       path: k8s/argocd/applications/factorio
       directory:


### PR DESCRIPTION
## Summary
ArgoCD Application에서 Git repo URL 수정

- `jasonljit/homelab` → `manamana32321/homelab`

🤖 Generated with [Claude Code](https://claude.com/claude-code)