### PR TITLE
feat: add MinIO Console ingress for all tenants

### DIFF
--- a/cloudflare/dns.tf
+++ b/cloudflare/dns.tf
@@ -135,6 +135,33 @@ resource "cloudflare_record" "s3_staging" {
   comment = "MinIO S3 API (staging)"
 }
 
+resource "cloudflare_record" "minio_console" {
+  zone_id = cloudflare_zone.main.id
+  name    = "minio"
+  type    = "A"
+  content = var.default_ip
+  proxied = true
+  comment = "MinIO Console (production)"
+}
+
+resource "cloudflare_record" "minio_console_staging" {
+  zone_id = cloudflare_zone.main.id
+  name    = "minio-staging"
+  type    = "A"
+  content = var.default_ip
+  proxied = true
+  comment = "MinIO Console (staging)"
+}
+
+resource "cloudflare_record" "factorio_minio_console" {
+  zone_id = cloudflare_zone.main.id
+  name    = "factorio-minio"
+  type    = "A"
+  content = var.default_ip
+  proxied = true
+  comment = "Factorio MinIO Console"
+}
+
 resource "cloudflare_record" "claw" {
   zone_id = cloudflare_zone.main.id
   name    = "claw"

--- a/k8s/factorio-backup/ingress-console.yaml
+++ b/k8s/factorio-backup/ingress-console.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: factorio-minio-console
+  namespace: factorio
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - factorio-minio.json-server.win
+      secretName: factorio-minio-console-tls
+  rules:
+    - host: factorio-minio.json-server.win
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: factorio-backup-minio-console
+                port:
+                  number: 9001

--- a/k8s/factorio-backup/kustomization.yaml
+++ b/k8s/factorio-backup/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - sealed-secret.yaml
   - cronjob.yaml
+  - ingress-console.yaml

--- a/k8s/minio-tenants/overlays/production/ingress-console.yaml
+++ b/k8s/minio-tenants/overlays/production/ingress-console.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-console
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - minio.json-server.win
+      secretName: minio-console-tls
+  rules:
+    - host: minio.json-server.win
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minio-console
+                port:
+                  number: 9090

--- a/k8s/minio-tenants/overlays/production/kustomization.yaml
+++ b/k8s/minio-tenants/overlays/production/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - sealed-secret.yaml
   - sealed-secret-s3-credentials.yaml
   - ingress.yaml
+  - ingress-console.yaml

--- a/k8s/minio-tenants/overlays/staging/ingress-console.yaml
+++ b/k8s/minio-tenants/overlays/staging/ingress-console.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-console
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - minio-staging.json-server.win
+      secretName: minio-console-tls
+  rules:
+    - host: minio-staging.json-server.win
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minio-console
+                port:
+                  number: 9090

--- a/k8s/minio-tenants/overlays/staging/kustomization.yaml
+++ b/k8s/minio-tenants/overlays/staging/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - sealed-secret.yaml
   - sealed-secret-s3-credentials.yaml
   - ingress.yaml
+  - ingress-console.yaml


### PR DESCRIPTION
## Summary
- Add Ingress resources to expose MinIO Console (admin UI) for all 3 MinIO instances
  - `minio.json-server.win` → production tenant (port 9090)
  - `minio-staging.json-server.win` → staging tenant (port 9090)
  - `factorio-minio.json-server.win` → factorio standalone (port 9001)
- Add corresponding Cloudflare DNS A records via Terraform

## Test plan
- [ ] `terraform plan` → 3 DNS records to add
- [ ] `terraform apply` → DNS records created
- [ ] ArgoCD sync → Ingress + TLS certificates provisioned
- [ ] Access each console URL in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)