### PR TITLE
chore: disable Seafile init mode

### DIFF
--- a/k8s/seafile/values.yaml
+++ b/k8s/seafile/values.yaml
@@ -1,5 +1,5 @@
 seafile:
-  initMode: true
+  initMode: false
 
   configs:
     image: seafileltd/seafile-mc:13.0-latest


### PR DESCRIPTION
## Summary
- Seafile 초기화 완료 확인 후 `initMode: false`로 변경

## Test plan
- [ ] ArgoCD sync 후 Seafile pod 정상 재시작 확인
- [ ] https://files.json-server.win 정상 접속 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)