### PR TITLE
feat: add OpenCampus study agent for OpenClaw

### DIFF
--- a/k8s/openclaw/manifests/configmap.yaml
+++ b/k8s/openclaw/manifests/configmap.yaml
@@ -39,6 +39,14 @@ data:
               "botToken": "${TELEGRAM_BOT_TOKEN_JARVIS}",
               "dmPolicy": "allowlist",
               "allowFrom": ["8126749721"]
+            },
+            "study": {
+              "botToken": "${TELEGRAM_BOT_TOKEN_STUDY}",
+              "dmPolicy": "allowlist",
+              "allowFrom": ["8126749721"],
+              "groupPolicy": "allowlist",
+              "groupAllowFrom": ["8126749721"],
+              "streaming": "partial"
             }
           }
         },
@@ -95,6 +103,15 @@ data:
             "groupChat": {
               "mentionPatterns": ["자비스", "자비스야"]
             }
+          },
+          {
+            "id": "study",
+            "name": "OpenCampus",
+            "workspace": "~/.openclaw/workspace-study",
+            "model": "anthropic/claude-opus-4-6",
+            "groupChat": {
+              "mentionPatterns": ["opencampus", "학업"]
+            }
           }
         ]
       },
@@ -117,6 +134,13 @@ data:
           "match": {
             "channel": "telegram",
             "accountId": "jarvis"
+          }
+        },
+        {
+          "agentId": "study",
+          "match": {
+            "channel": "telegram",
+            "accountId": "study"
           }
         }
       ]

--- a/k8s/openclaw/manifests/deployment.yaml
+++ b/k8s/openclaw/manifests/deployment.yaml
@@ -22,6 +22,32 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
       initContainers:
+        - name: setup-workspace-study
+          image: python:3.13-slim
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e
+              WORKSPACE=/home/node/.openclaw/workspace-study
+              MARKER="$WORKSPACE/.installed"
+              apt-get update -qq && apt-get install -y -qq git ffmpeg > /dev/null 2>&1
+              if [ ! -d "$WORKSPACE/.git" ]; then
+                echo "Cloning opencampus repo..."
+                git clone https://github.com/manamana32321/opencampus.git "$WORKSPACE"
+              else
+                echo "Updating opencampus repo..."
+                cd "$WORKSPACE" && git pull --ff-only || true
+              fi
+              if [ ! -f "$MARKER" ] || [ "$WORKSPACE/requirements.txt" -nt "$MARKER" ]; then
+                echo "Installing Python dependencies..."
+                pip install --target="$WORKSPACE/.pylibs" -r "$WORKSPACE/requirements.txt" -q
+                touch "$MARKER"
+              fi
+              chown -R 1000:1000 "$WORKSPACE"
+              echo "Workspace ready."
+          volumeMounts:
+            - name: openclaw-home
+              mountPath: /home/node
         - name: setup-gogcli
           image: alpine:3.21
           command: ["sh", "-c"]


### PR DESCRIPTION
## Summary
- OpenClaw에 학업용 **OpenCampus** 에이전트 추가
- `setup-workspace-study` init container: opencampus repo 클론 + Python 의존성 설치 (git, ffmpeg 포함)
- Telegram `study` 계정 설정 (DM/그룹 allowlist, streaming: partial)
- 에이전트 라우팅: telegram/study → OpenCampus agent (claude-opus-4-6)

## Test plan
- [ ] ArgoCD sync 후 init container 로그 확인 (`setup-workspace-study`)
- [ ] Telegram study 봇으로 메시지 전송 테스트
- [ ] workspace-study 디렉토리에 opencampus repo 클론 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)