### PR TITLE
fix: reflector startup probe 실패 해결

### DIFF
--- a/k8s/reflector/values.yaml
+++ b/k8s/reflector/values.yaml
@@ -1,7 +1,16 @@
 resources:
   limits:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
   requests:
     cpu: 50m
-    memory: 64Mi
+    memory: 128Mi
+
+startupProbe:
+  httpGet:
+    path: /health/ready
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 10


### PR DESCRIPTION
## Summary
- reflector가 raspi-1(ARM64)에서 startup probe 반복 실패로 CrashLoopBackOff
- memory limit 128Mi → 256Mi, startup probe failureThreshold 10으로 조정

## Test plan
- [ ] ArgoCD sync 확인
- [ ] reflector pod Running 상태 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)