### PR TITLE
feat: add 30-day retention for telemetry stack

### DIFF
--- a/k8s/observability/loki/values.yaml
+++ b/k8s/observability/loki/values.yaml
@@ -24,6 +24,10 @@ loki:
   #     secretAccessKey: # TODO: inject from secret
   #     s3ForcePathStyle: true
   #     insecure: true
+  limits_config:
+    retention_period: 30d
+  compactor:
+    retention_enabled: true
   schemaConfig:
     configs:
       - from: 2025-08-15

--- a/k8s/observability/prometheus/values.yaml
+++ b/k8s/observability/prometheus/values.yaml
@@ -5,6 +5,18 @@ grafana:
   enabled: false
 
 prometheus:
+  prometheusSpec:
+    retention: 30d
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: local-path-hdd-samsung
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 20Gi
+    nodeSelector:
+      kubernetes.io/hostname: json-server-1
   ingress:
     enabled: true
     hosts:

--- a/k8s/observability/tempo/values.yaml
+++ b/k8s/observability/tempo/values.yaml
@@ -9,6 +9,9 @@ tempo:
         grpc:
           endpoint: "0.0.0.0:4317"
 
+  compactor:
+    compaction:
+      block_retention: 720h    # 30d
   storage:
     trace:
       backend: local


### PR DESCRIPTION
## Summary
- **Prometheus**: 20Gi PVC 추가 (`local-path-hdd-samsung`, json-server-1) + `retention: 30d` (기존: emptyDir, 10d 기본값)
- **Loki**: `limits_config.retention_period: 30d` + `compactor.retention_enabled: true` (기존: 무제한)
- **Tempo**: `compactor.compaction.block_retention: 720h` (기존: 무제한)

## Test plan
- [ ] ArgoCD sync 후 Prometheus StatefulSet에 PVC 바인딩 확인
- [ ] Loki compactor 로그에서 retention 활성화 확인
- [ ] Tempo compactor 설정 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)