### PR TITLE
feat: set longhorn-ssd as default StorageClass

### DIFF
--- a/k8s/storage/longhorn/manifests/local-path-override.yaml
+++ b/k8s/storage/longhorn/manifests/local-path-override.yaml
@@ -1,0 +1,12 @@
+# K3s 기본 local-path StorageClass의 default 해제
+# K3s가 재시작 시 default로 복원하지만, ArgoCD selfHeal이 다시 false로 되돌림
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/k8s/storage/longhorn/manifests/storage-class.yaml
+++ b/k8s/storage/longhorn/manifests/storage-class.yaml
@@ -1,13 +1,12 @@
 # Longhorn StorageClass
-# longhorn-ssd: server1+server2 SSD 풀, replication=2
-# local-path는 default에서 해제 필요 (Phase 6 시 수동으로)
+# longhorn-ssd: server1+server2 SSD 풀, replication=2, default SC
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: longhorn-ssd
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Retain


### PR DESCRIPTION
## Summary
- `longhorn-ssd`를 default StorageClass로 설정
- K3s 기본 `local-path` SC의 default를 해제하는 override 매니페스트 추가
- ArgoCD selfHeal이 K3s 재시작 후에도 default 상태를 유지

## 배경
storageClassName 미지정 시 `local-path`가 사용되어 노드 종속적 PVC가 생성되는 실수 방지

## Test plan
- [ ] ArgoCD sync 후 `kubectl get sc` — `longhorn-ssd (default)` 확인
- [ ] `local-path`에 `(default)` 없는지 확인
- [ ] K3s 재시작 후에도 default 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)