### PR TITLE
feat: centralized Authentik forward auth for admin services

### DIFF
--- a/cloudflare/dns.tf
+++ b/cloudflare/dns.tf
@@ -155,22 +155,22 @@ resource "cloudflare_record" "s3_staging" {
   comment = "MinIO S3 API (staging)"
 }
 
-resource "cloudflare_record" "minio_console" {
+resource "cloudflare_record" "amang_minio_console" {
   zone_id = cloudflare_zone.main.id
-  name    = "minio"
+  name    = "amang-minio-console"
   type    = "A"
   content = var.default_ip
   proxied = true
-  comment = "MinIO Console (production)"
+  comment = "AMANG MinIO Console (production)"
 }
 
-resource "cloudflare_record" "minio_console_staging" {
+resource "cloudflare_record" "amang_minio_console_staging" {
   zone_id = cloudflare_zone.main.id
-  name    = "minio-staging"
+  name    = "amang-minio-console-staging"
   type    = "A"
   content = var.default_ip
   proxied = true
-  comment = "MinIO Console (staging)"
+  comment = "AMANG MinIO Console (staging)"
 }
 
 resource "cloudflare_record" "claw" {

--- a/k8s/authentik/manifests/blueprint-cloudbeaver.yaml
+++ b/k8s/authentik/manifests/blueprint-cloudbeaver.yaml
@@ -122,6 +122,258 @@ data:
           failure_result: false
           negate: false
 
+      # Factorio Admin
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: factorio-admin-provider
+        attrs:
+          name: factorio-admin-provider
+          mode: forward_single
+          external_host: https://factorio-admin.json-server.win
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: factorio-admin
+        attrs:
+          name: Factorio Admin
+          slug: factorio-admin
+          meta_launch_url: https://factorio-admin.json-server.win
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, factorio-admin-provider]]
+          policy_engine_mode: any
+
+      - model: authentik_policies.policybinding
+        state: present
+        identifiers:
+          order: 0
+          target: !Find [authentik_core.application, [slug, factorio-admin]]
+          group: !Find [authentik_core.group, [name, authentik Admins]]
+        attrs:
+          enabled: true
+          order: 0
+          timeout: 30
+          failure_result: false
+          negate: false
+
+      # Factorio MinIO Console
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: factorio-minio-provider
+        attrs:
+          name: factorio-minio-provider
+          mode: forward_single
+          external_host: https://factorio-minio.json-server.win
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: factorio-minio
+        attrs:
+          name: Factorio MinIO
+          slug: factorio-minio
+          meta_launch_url: https://factorio-minio.json-server.win
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, factorio-minio-provider]]
+          policy_engine_mode: any
+
+      - model: authentik_policies.policybinding
+        state: present
+        identifiers:
+          order: 0
+          target: !Find [authentik_core.application, [slug, factorio-minio]]
+          group: !Find [authentik_core.group, [name, authentik Admins]]
+        attrs:
+          enabled: true
+          order: 0
+          timeout: 30
+          failure_result: false
+          negate: false
+
+      # Frigate
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: frigate-provider
+        attrs:
+          name: frigate-provider
+          mode: forward_single
+          external_host: https://frigate.json-server.win
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: frigate
+        attrs:
+          name: Frigate
+          slug: frigate
+          meta_launch_url: https://frigate.json-server.win
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, frigate-provider]]
+          policy_engine_mode: any
+
+      - model: authentik_policies.policybinding
+        state: present
+        identifiers:
+          order: 0
+          target: !Find [authentik_core.application, [slug, frigate]]
+          group: !Find [authentik_core.group, [name, authentik Admins]]
+        attrs:
+          enabled: true
+          order: 0
+          timeout: 30
+          failure_result: false
+          negate: false
+
+      # Headlamp (K8s Dashboard)
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: headlamp-provider
+        attrs:
+          name: headlamp-provider
+          mode: forward_single
+          external_host: https://k8s.json-server.win
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: headlamp
+        attrs:
+          name: Headlamp
+          slug: headlamp
+          meta_launch_url: https://k8s.json-server.win
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, headlamp-provider]]
+          policy_engine_mode: any
+
+      - model: authentik_policies.policybinding
+        state: present
+        identifiers:
+          order: 0
+          target: !Find [authentik_core.application, [slug, headlamp]]
+          group: !Find [authentik_core.group, [name, authentik Admins]]
+        attrs:
+          enabled: true
+          order: 0
+          timeout: 30
+          failure_result: false
+          negate: false
+
+      # Prometheus
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: prometheus-provider
+        attrs:
+          name: prometheus-provider
+          mode: forward_single
+          external_host: https://prometheus.json-server.win
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: prometheus
+        attrs:
+          name: Prometheus
+          slug: prometheus
+          meta_launch_url: https://prometheus.json-server.win
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, prometheus-provider]]
+          policy_engine_mode: any
+
+      - model: authentik_policies.policybinding
+        state: present
+        identifiers:
+          order: 0
+          target: !Find [authentik_core.application, [slug, prometheus]]
+          group: !Find [authentik_core.group, [name, authentik Admins]]
+        attrs:
+          enabled: true
+          order: 0
+          timeout: 30
+          failure_result: false
+          negate: false
+
+      # AMANG MinIO Console (Production)
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: amang-minio-console-provider
+        attrs:
+          name: amang-minio-console-provider
+          mode: forward_single
+          external_host: https://amang-minio-console.json-server.win
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: amang-minio-console
+        attrs:
+          name: AMANG MinIO Console
+          slug: amang-minio-console
+          meta_launch_url: https://amang-minio-console.json-server.win
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, amang-minio-console-provider]]
+          policy_engine_mode: any
+
+      - model: authentik_policies.policybinding
+        state: present
+        identifiers:
+          order: 0
+          target: !Find [authentik_core.application, [slug, amang-minio-console]]
+          group: !Find [authentik_core.group, [name, authentik Admins]]
+        attrs:
+          enabled: true
+          order: 0
+          timeout: 30
+          failure_result: false
+          negate: false
+
+      # AMANG MinIO Console (Staging)
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: amang-minio-console-staging-provider
+        attrs:
+          name: amang-minio-console-staging-provider
+          mode: forward_single
+          external_host: https://amang-minio-console-staging.json-server.win
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: amang-minio-console-staging
+        attrs:
+          name: AMANG MinIO Console (Staging)
+          slug: amang-minio-console-staging
+          meta_launch_url: https://amang-minio-console-staging.json-server.win
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, amang-minio-console-staging-provider]]
+          policy_engine_mode: any
+
+      - model: authentik_policies.policybinding
+        state: present
+        identifiers:
+          order: 0
+          target: !Find [authentik_core.application, [slug, amang-minio-console-staging]]
+          group: !Find [authentik_core.group, [name, authentik Admins]]
+        attrs:
+          enabled: true
+          order: 0
+          timeout: 30
+          failure_result: false
+          negate: false
+
       # Embedded Outpost (모든 forward auth provider를 포함)
       - model: authentik_outposts.outpost
         state: present
@@ -135,3 +387,10 @@ data:
           providers:
             - !Find [authentik_providers_proxy.proxyprovider, [name, cloudbeaver-provider]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, longhorn-provider]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, factorio-admin-provider]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, factorio-minio-provider]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, frigate-provider]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, headlamp-provider]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, prometheus-provider]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, amang-minio-console-provider]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, amang-minio-console-staging-provider]]

--- a/k8s/authentik/manifests/blueprint-github-source.yaml
+++ b/k8s/authentik/manifests/blueprint-github-source.yaml
@@ -9,6 +9,22 @@ data:
     metadata:
       name: "GitHub OAuth Source"
     entries:
+      # GitHub username → authentik Admins 자동 매핑
+      - model: authentik_sources_oauth.oauthsourcepropertymapping
+        state: present
+        identifiers:
+          name: github-admin-group-mapping
+        attrs:
+          name: github-admin-group-mapping
+          expression: |
+            ADMIN_GITHUB_USERNAMES = ["manamana32321"]
+
+            github_login = info.get("login", "")
+
+            if github_login in ADMIN_GITHUB_USERNAMES:
+                return ["authentik Admins"]
+            return []
+
       - model: authentik_sources_oauth.oauthsource
         state: present
         identifiers:
@@ -23,6 +39,8 @@ data:
           additional_scopes: "read:org"
           authentication_flow: !Find [authentik_flows.flow, [slug, default-source-authentication]]
           enrollment_flow: !Find [authentik_flows.flow, [slug, default-source-enrollment]]
+          group_property_mappings:
+            - !Find [authentik_sources_oauth.oauthsourcepropertymapping, [name, github-admin-group-mapping]]
 
       # 로그인 페이지에 GitHub 버튼 표시
       - model: authentik_stages_identification.identificationstage

--- a/k8s/factorio-admin/deployment.yaml
+++ b/k8s/factorio-admin/deployment.yaml
@@ -125,7 +125,9 @@ metadata:
   namespace: factorio
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-dns01
+    traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
 spec:
+  ingressClassName: traefik
   tls:
     - hosts:
         - factorio-admin.json-server.win

--- a/k8s/factorio-backup/ingress-console.yaml
+++ b/k8s/factorio-backup/ingress-console.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: factorio
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-dns01
+    traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
 spec:
   ingressClassName: traefik
   tls:

--- a/k8s/frigate/values.yaml
+++ b/k8s/frigate/values.yaml
@@ -83,6 +83,7 @@ ingress:
   ingressClassName: traefik
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-dns01
+    traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
   hosts:
     - host: frigate.json-server.win
       paths:

--- a/k8s/headlamp/values.yaml
+++ b/k8s/headlamp/values.yaml
@@ -10,6 +10,7 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-dns01
     traefik.ingress.kubernetes.io/redirect-entry-point: https
+    traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
   hosts:
     - host: k8s.json-server.win
       paths:

--- a/k8s/minio-tenants/overlays/production/ingress-console.yaml
+++ b/k8s/minio-tenants/overlays/production/ingress-console.yaml
@@ -4,14 +4,15 @@ metadata:
   name: minio-console
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-dns01
+    traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
 spec:
   ingressClassName: traefik
   tls:
     - hosts:
-        - minio.json-server.win
+        - amang-minio-console.json-server.win
       secretName: minio-console-tls
   rules:
-    - host: minio.json-server.win
+    - host: amang-minio-console.json-server.win
       http:
         paths:
           - path: /

--- a/k8s/minio-tenants/overlays/staging/ingress-console.yaml
+++ b/k8s/minio-tenants/overlays/staging/ingress-console.yaml
@@ -4,14 +4,15 @@ metadata:
   name: minio-console
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-dns01
+    traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
 spec:
   ingressClassName: traefik
   tls:
     - hosts:
-        - minio-staging.json-server.win
+        - amang-minio-console-staging.json-server.win
       secretName: minio-console-tls
   rules:
-    - host: minio-staging.json-server.win
+    - host: amang-minio-console-staging.json-server.win
       http:
         paths:
           - path: /

--- a/k8s/observability/prometheus/values.yaml
+++ b/k8s/observability/prometheus/values.yaml
@@ -85,9 +85,9 @@ prometheus:
               - https://auth.json-server.win
               - https://frigate.json-server.win
               - https://amang-api.json-server.win
-              - https://minio.json-server.win
+              - https://amang-minio-console.json-server.win
               - https://amang-api-staging.json-server.win
-              - https://minio-staging.json-server.win
+              - https://amang-minio-console-staging.json-server.win
             labels:
               source: coral
         relabel_configs:
@@ -127,6 +127,7 @@ prometheus:
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-dns01
       traefik.ingress.kubernetes.io/redirect-entry-point: https
+      traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
     ingressClassName: traefik
     tls:
       - hosts:


### PR DESCRIPTION
## Summary
- 자체 인증 없는 관리 도구 7개에 Authentik forward auth (Admins only) 적용
  - Factorio Admin, Factorio MinIO Console, Frigate, Headlamp, Prometheus, AMANG MinIO Console (prod/staging)
- GitHub OAuth login 시 `manamana32321` → `authentik Admins` 자동 그룹 매핑
- MinIO Console 서브도메인 변경: `minio.*` → `amang-minio-console.*`

## Changes
| 파일 | 변경 |
|------|------|
| `blueprint-cloudbeaver.yaml` | 7개 신규 provider/app/binding + Outpost에 9개 provider |
| `blueprint-github-source.yaml` | `group_property_mappings` + admin auto-assign |
| 7개 ingress 파일 | `authentik-forwardauth` middleware annotation |
| `dns.tf` | MinIO Console 도메인 rename |
| `prometheus/values.yaml` | Blackbox exporter 타겟 URL 업데이트 |

## Architecture
```
계층 1: Authentik Forward Auth
├── CloudBeaver (db.*) → skku-amang org 멤버 ✅ 기존
├── Longhorn (longhorn.*) → Admins only ✅ 기존
├── Factorio Admin (factorio-admin.*) → Admins only 🆕
├── Factorio MinIO (factorio-minio.*) → Admins only 🆕
├── Frigate (frigate.*) → Admins only 🆕
├── Headlamp (k8s.*) → Admins only 🆕
├── Prometheus (prometheus.*) → Admins only 🆕
├── AMANG MinIO Console (amang-minio-console.*) → Admins only 🆕
└── AMANG MinIO Console Staging (amang-minio-console-staging.*) → Admins only 🆕
```

## Test plan
- [ ] ArgoCD sync 확인 (blueprint ConfigMap 변경 감지)
- [ ] Authentik worker 로그에서 blueprint apply 성공 확인
- [ ] 각 앱 접근 시 Authentik 로그인 페이지로 리다이렉트 확인
- [ ] GitHub 로그인 후 manamana32321이 Admins 그룹에 자동 추가되는지 확인
- [ ] Admins 그룹 유저가 모든 관리 앱 접근 가능한지 확인
- [ ] 비-Admin 유저가 관리 앱 접근 시 거부되는지 확인
- [ ] MinIO Console 새 도메인 (amang-minio-console.*) 접근 확인
- [ ] Terraform plan으로 DNS 변경 확인 (별도 적용 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)