### PR TITLE
fix: disable go2rtc to reduce raspi-1 CPU overload

### DIFF
--- a/k8s/frigate/manifests/go2rtc-deployment.yaml
+++ b/k8s/frigate/manifests/go2rtc-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: go2rtc
   namespace: frigate
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
## Summary
- go2rtc replicas 0으로 변경 (웹캠 ffmpeg가 raspi-1 CPU 53% 점유)
- raspi-1 load average 6+ → Authentik, ArgoCD 등 동일 노드 서비스 응답 지연 원인

## Context
- 웹캠 스트리밍 실험 일시 중단, 나중에 재개 시 replicas 1로 복원
- Frigate 자체는 json-server-1(GPU)에서 동작하므로 영향 없음

## Test plan
- [ ] ArgoCD sync 후 go2rtc pod 종료 확인
- [ ] raspi-1 load average 정상화 확인 (< 4)
- [ ] Authentik 응답 속도 개선 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)