### PR TITLE
feat: add SMART disk monitoring for HDD health

### DIFF
--- a/k8s/argocd/applications/observability/smartctl-exporter.yaml
+++ b/k8s/argocd/applications/observability/smartctl-exporter.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: smartctl-exporter
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://prometheus-community.github.io/helm-charts
+      chart: prometheus-smartctl-exporter
+      targetRevision: 0.16.0
+      helm:
+        valueFiles:
+          - $homelab/k8s/observability/smartctl-exporter/values.yaml
+    - repoURL: https://github.com/manamana32321/homelab
+      targetRevision: main
+      ref: homelab
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: observability
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -58,6 +58,36 @@ spec:
             summary: "Disk almost full: {{ $labels.instance }} {{ $labels.mountpoint }}"
             description: "{{ $labels.mountpoint }} on {{ $labels.instance }} is {{ $value | humanizePercentage }} full."
 
+    # SMART 디스크 건강 알림 (ATA HDD 특화 — NVMe 기본 알림은 smartctl-exporter chart에 내장)
+    - name: smart
+      rules:
+        - alert: DiskPendingSectors
+          expr: smartctl_device_attribute{attribute_name="Current_Pending_Sector"} > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pending sectors: {{ $labels.device }} ({{ $labels.instance }})"
+            description: "{{ $labels.device }} has {{ $value }} pending sector(s). Potential disk failure."
+
+        - alert: DiskReallocatedSectors
+          expr: smartctl_device_attribute{attribute_name="Reallocated_Sector_Ct"} > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Reallocated sectors: {{ $labels.device }} ({{ $labels.instance }})"
+            description: "{{ $labels.device }} has {{ $value }} reallocated sector(s)."
+
+        - alert: DiskReallocatedSectorsCritical
+          expr: smartctl_device_attribute{attribute_name="Reallocated_Sector_Ct"} > 100
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "CRITICAL: Many reallocated sectors on {{ $labels.device }}"
+            description: "{{ $labels.device }} has {{ $value }} reallocated sectors. Replace disk."
+
     # 리소스 알림 (kube-prometheus-stack 기본 NodeMemory rule은 예측 기반이라 직관적이지 않음)
     - name: resources
       rules:

--- a/k8s/observability/smartctl-exporter/values.yaml
+++ b/k8s/observability/smartctl-exporter/values.yaml
@@ -1,0 +1,45 @@
+config:
+  devices:
+    - /dev/sdb
+    - /dev/sdc
+
+common:
+  config:
+    collect_not_more_than_period: 300s
+
+nodeSelector:
+  kubernetes.io/hostname: json-server-1
+
+serviceMonitor:
+  enabled: true
+  extraLabels:
+    release: prometheus
+  interval: 5m
+  scrapeTimeout: 30s
+
+prometheusRules:
+  enabled: true
+  extraLabels:
+    release: prometheus
+  rules:
+    smartCTLDeviceMediaErrors:
+      enabled: true
+    smartCTLDeviceCriticalWarning:
+      enabled: true
+    smartCTLDeviceAvailableSpareUnderThreshold:
+      enabled: true
+    smartCTLDeviceStatus:
+      enabled: true
+    smartCTLDInterfaceSlow:
+      enabled: false
+    smartCTLDDeviceTemperature:
+      enabled: true
+      expr: smartctl_device_temperature{temperature_type="current"} > 55
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 64Mi


### PR DESCRIPTION
## Summary
- smartctl-exporter 배포 (json-server-1 전용, /dev/sdb + /dev/sdc)
- ServiceMonitor + PrometheusRules (built-in NVMe alerts + custom ATA alerts)
- 커스텀 알림: DiskPendingSectors, DiskReallocatedSectors, DiskReallocatedSectorsCritical

## Background
Samsung HDD (sdc)에서 Current_Pending_Sector: 2, G-Sense: 14544 발견.
r_await 83ms로 Grafana 등 서비스 응답 지연 원인. 향후 추이 모니터링 필요.

## Changes
- `k8s/observability/smartctl-exporter/values.yaml` — Helm values
- `k8s/argocd/applications/observability/smartctl-exporter.yaml` — ArgoCD Application
- `k8s/observability/prometheus/manifests/alert-rules.yaml` — SMART alert rules 추가

## Post-merge
- Grafana에서 Dashboard ID `22604` 임포트 (Smartctl Exporter)
- DiskPendingSectors 알림 즉시 firing 예상 (sdc pending sector 2개, known issue)

## Test plan
- [ ] smartctl-exporter pod Running 확인 (json-server-1)
- [ ] `smartctl_device_attribute` 메트릭 Prometheus에서 조회 가능
- [ ] Grafana 대시보드에서 G-Sense, Temperature 추이 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)