### PR TITLE
feat: add Smartctl Exporter Grafana dashboard

### DIFF
--- a/k8s/observability/grafana/values.yaml
+++ b/k8s/observability/grafana/values.yaml
@@ -120,6 +120,11 @@ dashboards:
       gnetId: 13659
       revision: 1
       datasource: Prometheus
+    # Smartctl Exporter (SMART disk health) - https://grafana.com/grafana/dashboards/22604
+    smartctl-exporter:
+      gnetId: 22604
+      revision: 2
+      datasource: Prometheus
 
 downloadDashboards:
   env: {}


### PR DESCRIPTION
## Summary
- Grafana 대시보드 #22604 (Smartctl Exporter) 선언적 추가
- 기존 `gnetId` 패턴과 동일하게 values.yaml에 추가

## 대시보드 내용
- 디바이스별 온도 추이, SMART 상태
- G-Sense Error Rate 시계열 (Samsung HDD 충격 감지 추이)
- Pending Sector / Reallocated Sector 추이
- Power-On Hours, Load Cycle Count 등 전체 SMART attributes

## Test plan
- [ ] Grafana pod 재시작 후 "Provisioned" 폴더에 대시보드 표시 확인
- [ ] sdb/sdc 디바이스 선택 시 SMART 데이터 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)