### PR TITLE
refactor: K8s/coral blackbox probing 역할 분리

### DIFF
--- a/coral/monitoring/blackbox.yml
+++ b/coral/monitoring/blackbox.yml
@@ -7,12 +7,3 @@ modules:
       follow_redirects: true
       preferred_ip_protocol: ip4
       fail_if_not_ssl: true
-  http_any_response:
-    prober: http
-    timeout: 10s
-    http:
-      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
-      valid_status_codes: [200, 301, 302, 400, 401, 403, 404]
-      follow_redirects: false
-      preferred_ip_protocol: ip4
-      fail_if_not_ssl: true

--- a/coral/monitoring/prometheus.yml
+++ b/coral/monitoring/prometheus.yml
@@ -12,6 +12,8 @@ alerting:
             - alertmanager:9093
 
 scrape_configs:
+  # 외부 경로 헬스체크 (DNS → Cloudflare → 라우터 → Traefik → TLS)
+  # 대표 1개로 전체 외부 경로 상태 확인 (K8s blackbox와 동일 전략)
   - job_name: blackbox-http
     metrics_path: /probe
     params:
@@ -19,38 +21,6 @@ scrape_configs:
     static_configs:
       - targets:
           - https://argocd.json-server.win
-          - https://grafana.json-server.win
-          - https://prometheus.json-server.win
-          - https://photos.json-server.win
-          - https://files.json-server.win
-          - https://ha.json-server.win
-          - https://claw.json-server.win
-          - https://k8s.json-server.win
-          - https://auth.json-server.win
-          - https://frigate.json-server.win
-          - https://api.amang.json-server.win
-          - https://minio.amang.json-server.win
-          - https://api.amang.staging.json-server.win
-          - https://minio.amang.staging.json-server.win
-    relabel_configs:
-      - source_labels: [__address__]
-        target_label: __param_target
-      - source_labels: [__param_target]
-        target_label: instance
-      - target_label: __address__
-        replacement: blackbox-exporter:9115
-
-  - job_name: blackbox-s3
-    metrics_path: /probe
-    params:
-      module: [http_any_response]
-    static_configs:
-      - targets:
-          - https://s3.amang.json-server.win
-          - https://s3.amang.staging.json-server.win
-          - https://db.json-server.win
-          - https://otel.json-server.win
-          - https://longhorn.json-server.win
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/homelab.code-workspace
+++ b/homelab.code-workspace
@@ -12,6 +12,10 @@
       "name": "홈랩 · authentik-central-auth",
       "path": "../authentik-central-auth",
     },
+    {
+      "name": "홈랩 · blackbox-probing-cleanup",
+      "path": "../blackbox-probing-cleanup",
+    },
   ],
   "settings": {
     "terminal.integrated.cwd": "${workspaceFolder:홈랩 · main}",

--- a/k8s/observability/blackbox-exporter/values.yaml
+++ b/k8s/observability/blackbox-exporter/values.yaml
@@ -67,13 +67,11 @@ serviceMonitor:
     module: http_2xx
 
   targets:
-    # --- 외부 경로 헬스체크 (DNS → Cloudflare → 라우터 → Traefik → TLS) ---
-    # 대표 1개로 전체 외부 경로 상태 확인
-    - name: external-route
-      url: https://argocd.json-server.win
-      module: http_2xx
-
     # --- 내부 서비스 헬스체크 (ClusterIP, 서비스 자체 health) ---
+    # 외부 경로 헬스체크는 coral이 담당 (독립 관측점)
+    - name: argocd
+      url: http://argocd-server.argocd.svc.cluster.local
+      module: http_2xx_no_tls
     - name: grafana
       url: http://grafana.observability.svc.cluster.local/login
       module: http_2xx_no_tls

--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -29,31 +29,13 @@ spec:
             description: "Certificate for {{ $labels.instance }} expires in {{ $value | humanize }} days."
 
         - alert: SlowResponse
-          expr: avg_over_time(probe_duration_seconds{source!="coral", target!="external-route"}[5m]) > 3
+          expr: avg_over_time(probe_duration_seconds{source!="coral"}[5m]) > 3
           for: 5m
           labels:
             severity: warning
           annotations:
             summary: "Slow response: {{ $labels.instance }}"
             description: "{{ $labels.instance }} avg response time is {{ $value | humanize }}s over last 5 minutes."
-
-        - alert: ExternalRouteDown
-          expr: probe_success{target="external-route", source!="coral"} == 0
-          for: 5m
-          labels:
-            severity: critical
-          annotations:
-            summary: "External route is down (DNS/Cloudflare/Traefik/TLS)"
-            description: "https://argocd.json-server.win unreachable for 5 minutes. Check DNS, Cloudflare, router, Traefik, or TLS."
-
-        - alert: ExternalRouteSlow
-          expr: avg_over_time(probe_duration_seconds{target="external-route", source!="coral"}[5m]) > 10
-          for: 5m
-          labels:
-            severity: warning
-          annotations:
-            summary: "External route slow ({{ $value | humanize }}s)"
-            description: "External route avg response > 10s. Network or Traefik issue."
 
     # 스토리지 알림 (kube-prometheus-stack 기본에 PVC/디스크 임계치 rule 없음)
     - name: storage


### PR DESCRIPTION
## Summary
- K8s blackbox: ArgoCD를 외부 URL → 내부 FQDN으로 변경 (내부 서비스 health 전담)
- Coral blackbox: argocd 1개만 외부 probing (독립 관측점으로 외부 경로 전담)
- `ExternalRouteDown`/`ExternalRouteSlow` alert rule 삭제 (coral이 담당)
- Coral `http_any_response` 모듈 및 `blackbox-s3` job 제거

## Test plan
- [ ] ArgoCD sync 후 K8s blackbox ServiceMonitor에 argocd 내부 타겟 확인
- [ ] Coral GitHub Actions 배포 성공 확인
- [ ] Prometheus에서 `probe_success{target="argocd"}` 메트릭 정상 수집 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)