### PR TITLE
fix(alert): suppress sdc DiskPendingSectors for ≤2 pending sectors

### DIFF
--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -62,7 +62,12 @@ spec:
     - name: smart
       rules:
         - alert: DiskPendingSectors
-          expr: smartctl_device_attribute{attribute_name="Current_Pending_Sector", attribute_value_type="raw"} > 0
+          # TODO(2026-12): sdc 디스크 교체 후 원복 — 기존: > 0
+          # sdc는 pending 2개가 물리적으로 복구 불가 상태이므로 3개 이상만 알림
+          expr: >-
+            smartctl_device_attribute{attribute_name="Current_Pending_Sector", attribute_value_type="raw"} > 0
+            unless
+            (smartctl_device_attribute{attribute_name="Current_Pending_Sector", attribute_value_type="raw", device="sdc"} <= 2)
           for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
## 변경 사항
sdc에 물리적으로 복구 불가능한 pending sector 2개가 있어서, 해당 디스크는 3개 이상일 때만 알림이 발생하도록 수정.

- sdc ≤2개: 알림 억제 ✅
- sdc ≥3개: 알림 발생 ✅  
- 다른 디스크: 기존대로 >0 유지 ✅

## TODO
- [ ] sdc 디스크 교체 후 원복 (2026년 말 목표)