### PR TITLE
feat(openclaw): 자비스 kubectl 읽기 전용 권한 부여

### DIFF
--- a/k8s/openclaw/Dockerfile
+++ b/k8s/openclaw/Dockerfile
@@ -13,4 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN npm install -g @googleworkspace/cli
 
+# kubectl for Jarvis K8s readonly access (#84)
+RUN curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+  -o /usr/local/bin/kubectl \
+  && chmod +x /usr/local/bin/kubectl
+
 USER node

--- a/k8s/openclaw/manifests/deployment.yaml
+++ b/k8s/openclaw/manifests/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: openclaw
     spec:
+      serviceAccountName: jarvis
       nodeSelector:
         kubernetes.io/hostname: json-server-1
       securityContext:

--- a/k8s/openclaw/manifests/rbac.yaml
+++ b/k8s/openclaw/manifests/rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jarvis
+  namespace: openclaw
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jarvis-readonly
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "services", "endpoints", "events", "namespaces", "nodes", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "replicasets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jarvis-readonly-binding
+subjects:
+  - kind: ServiceAccount
+    name: jarvis
+    namespace: openclaw
+roleRef:
+  kind: ClusterRole
+  name: jarvis-readonly
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary
- `openclaw` namespace에 `jarvis` ServiceAccount + `jarvis-readonly` ClusterRole(읽기 전용) 생성
- OpenClaw Deployment에 `serviceAccountName: jarvis` 연결 (in-cluster auth)
- Docker 이미지에 kubectl 바이너리 추가

## 권한 범위
| 접근 가능 | 접근 불가 |
|-----------|-----------|
| pods, pods/log, events | **secrets** |
| deployments, statefulsets, replicasets, daemonsets | **configmaps** |
| services, endpoints, nodes, namespaces | CRD (ArgoCD Application 등) |
| jobs, cronjobs, ingresses, PVC | 모든 write 작업 (create/update/delete) |

## 이슈 원안 대비 변경점
| 항목 | [#84 원안](https://github.com/manamana32321/homelab/issues/84) | 이 PR |
|------|-------------|---------|
| Namespace | `default` | `openclaw` (실제 pod 위치) |
| 인증 방식 | Secret 기반 토큰 + kubeconfig 수동 생성 | `serviceAccountName` in-cluster auth (자동) |
| ConfigMap 접근 | 포함 | **제외** (디버깅 불필요, 설정 노출 위험) |
| PVC 접근 | 미포함 | **추가** (스토리지 문제 진단용) |
| kubectl 설치 | 미언급 | Dockerfile에 추가 |

## 머지 후 검증 (Task 4)
```bash
# RBAC 리소스 확인
kubectl get sa jarvis -n openclaw
kubectl get clusterrole jarvis-readonly

# kubectl 동작 확인
kubectl exec -n openclaw deploy/openclaw -- kubectl get pods -A

# 읽기 전용 제한 확인
kubectl exec -n openclaw deploy/openclaw -- kubectl get secrets -A  # Forbidden 예상
```

## Test plan
- [ ] GitHub Actions `openclaw-image.yaml` 빌드 성공
- [ ] ArgoCD sync 후 RBAC 리소스 생성 확인
- [ ] pod 내부 kubectl 동작 확인 (pods, logs, events)
- [ ] secrets/configmaps 접근 차단 확인
- [ ] write 작업 차단 확인

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)