### PR TITLE
fix(health-hub): 날짜 필터 파라미터명 통일 (from/to → start_date/end_date)

### DIFF
--- a/health-hub-dashboard/lib/hooks/use-body.ts
+++ b/health-hub-dashboard/lib/hooks/use-body.ts
@@ -7,6 +7,6 @@ import type { BodyMeasurement } from "@/lib/types";
 export function useBody(from: string, to: string) {
   return useQuery({
     queryKey: ["body", from, to],
-    queryFn: () => apiFetch<BodyMeasurement[]>("/api/v1/body", { from, to }),
+    queryFn: () => apiFetch<BodyMeasurement[]>("/api/v1/body", { start_date: from, end_date: to }),
   });
 }

--- a/health-hub-dashboard/lib/hooks/use-exercises.ts
+++ b/health-hub-dashboard/lib/hooks/use-exercises.ts
@@ -8,6 +8,6 @@ export function useExercises(from: string, to: string) {
   return useQuery({
     queryKey: ["exercises", from, to],
     queryFn: () =>
-      apiFetch<ExerciseSession[]>("/api/v1/exercises", { from, to }),
+      apiFetch<ExerciseSession[]>("/api/v1/exercises", { start_date: from, end_date: to }),
   });
 }

--- a/health-hub-dashboard/lib/hooks/use-metrics.ts
+++ b/health-hub-dashboard/lib/hooks/use-metrics.ts
@@ -15,8 +15,8 @@ export function useMetrics(
     queryFn: () =>
       apiFetch<AggregatedMetric[]>("/api/v1/metrics", {
         type,
-        from,
-        to,
+        start_date: from,
+        end_date: to,
         interval,
       }),
   });

--- a/health-hub-dashboard/lib/hooks/use-sleep.ts
+++ b/health-hub-dashboard/lib/hooks/use-sleep.ts
@@ -7,6 +7,6 @@ import type { SleepSession } from "@/lib/types";
 export function useSleep(from: string, to: string) {
   return useQuery({
     queryKey: ["sleep", from, to],
-    queryFn: () => apiFetch<SleepSession[]>("/api/v1/sleep", { from, to }),
+    queryFn: () => apiFetch<SleepSession[]>("/api/v1/sleep", { start_date: from, end_date: to }),
   });
 }

--- a/health-hub/cmd/mcp/main.go
+++ b/health-hub/cmd/mcp/main.go
@@ -94,9 +94,9 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 	// get_steps
 	s.AddTool(
 		mcp.NewTool("get_steps",
-			mcp.WithDescription("걸음수 조회. 시간대별 집계를 반환합니다. 데이터는 2018-12부터 존재. 장기간 분석 시 from을 반드시 과거 날짜로 설정하세요."),
-			mcp.WithString("from", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간 분석 시 '2018-01-01' 사용.")),
-			mcp.WithString("to", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
+			mcp.WithDescription("걸음수 조회. 시간대별 집계를 반환합니다. 데이터는 2018-12부터 존재. 장기간 분석 시 start_date를 반드시 과거 날짜로 설정하세요."),
+			mcp.WithString("start_date", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간 분석 시 '2018-01-01' 사용.")),
+			mcp.WithString("end_date", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
 			mcp.WithString("interval", mcp.Description("집계 간격: 1h, 1d, 1w, 1month, 1y. 기본 1d. 장기간은 1month 또는 1y 권장.")),
 		),
 		makeMetricHandler(repo, "steps"),
@@ -105,9 +105,9 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 	// get_heart_rate
 	s.AddTool(
 		mcp.NewTool("get_heart_rate",
-			mcp.WithDescription("심박수 조회. 평균/최소/최대를 시간대별로 반환합니다. 데이터는 2022-06부터 존재. 장기간 분석 시 from을 반드시 과거 날짜로 설정하세요."),
-			mcp.WithString("from", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간 분석 시 '2022-01-01' 사용.")),
-			mcp.WithString("to", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
+			mcp.WithDescription("심박수 조회. 평균/최소/최대를 시간대별로 반환합니다. 데이터는 2022-06부터 존재. 장기간 분석 시 start_date를 반드시 과거 날짜로 설정하세요."),
+			mcp.WithString("start_date", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간 분석 시 '2022-01-01' 사용.")),
+			mcp.WithString("end_date", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
 			mcp.WithString("interval", mcp.Description("집계 간격: 5m, 1h, 1d, 1month, 1y. 기본 1h. 장기간은 1month 또는 1y 권장.")),
 		),
 		makeMetricHandler(repo, "heart_rate"),
@@ -116,9 +116,9 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 	// get_sleep
 	s.AddTool(
 		mcp.NewTool("get_sleep",
-			mcp.WithDescription("수면 기록 조회. 세션별 시작/종료/시간/단계 정보를 반환합니다. 데이터는 2022-07부터 존재. 장기간 분석 시 from을 반드시 과거 날짜로 설정하세요."),
-			mcp.WithString("from", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간 분석 시 '2022-01-01' 사용.")),
-			mcp.WithString("to", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
+			mcp.WithDescription("수면 기록 조회. 세션별 시작/종료/시간/단계 정보를 반환합니다. 데이터는 2022-07부터 존재. 장기간 분석 시 start_date를 반드시 과거 날짜로 설정하세요."),
+			mcp.WithString("start_date", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간 분석 시 '2022-01-01' 사용.")),
+			mcp.WithString("end_date", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			from, to := parseRange(req)
@@ -137,9 +137,9 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 	// get_exercises
 	s.AddTool(
 		mcp.NewTool("get_exercises",
-			mcp.WithDescription("운동 기록 조회. 종류, 시간, 칼로리, 거리 등을 반환합니다. 데이터는 2018-12부터 존재. 장기간 분석 시 from을 반드시 과거 날짜로 설정하세요."),
-			mcp.WithString("from", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간 분석 시 '2018-01-01' 사용.")),
-			mcp.WithString("to", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
+			mcp.WithDescription("운동 기록 조회. 종류, 시간, 칼로리, 거리 등을 반환합니다. 데이터는 2018-12부터 존재. 장기간 분석 시 start_date를 반드시 과거 날짜로 설정하세요."),
+			mcp.WithString("start_date", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간 분석 시 '2018-01-01' 사용.")),
+			mcp.WithString("end_date", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			from, to := parseRange(req)
@@ -158,13 +158,13 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 	// get_weight
 	s.AddTool(
 		mcp.NewTool("get_weight",
-			mcp.WithDescription("체중 및 체성분 기록 조회. 데이터는 2018-12부터 존재 (363건). 장기간 트렌드 분석 시 from을 반드시 과거 날짜로 설정하세요."),
-			mcp.WithString("from", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 30일 전. 전체 기간 분석 시 '2018-01-01' 사용.")),
-			mcp.WithString("to", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
+			mcp.WithDescription("체중 및 체성분 기록 조회. 데이터는 2018-12부터 존재 (363건). 장기간 트렌드 분석 시 start_date를 반드시 과거 날짜로 설정하세요."),
+			mcp.WithString("start_date", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 30일 전. 전체 기간 분석 시 '2018-01-01' 사용.")),
+			mcp.WithString("end_date", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			fromStr := req.GetString("from", "")
-			toStr := req.GetString("to", "")
+			fromStr := req.GetString("start_date", "")
+			toStr := req.GetString("end_date", "")
 			from, to := defaults(fromStr, toStr, 30)
 			measurements, err := repo.QueryBodyMeasurements(ctx, model.TimeRangeQuery{From: from, To: to})
 			if err != nil {
@@ -182,8 +182,8 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 	s.AddTool(
 		mcp.NewTool("get_spo2",
 			mcp.WithDescription("산소포화도(SpO2) 조회. HC Webhook 데이터만 존재 (2026-03~)."),
-			mcp.WithString("from", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전.")),
-			mcp.WithString("to", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
+			mcp.WithString("start_date", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전.")),
+			mcp.WithString("end_date", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
 			mcp.WithString("interval", mcp.Description("집계 간격: 1h, 1d. 기본 1d.")),
 		),
 		makeMetricHandler(repo, "spo2"),
@@ -192,9 +192,9 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 	// get_calories
 	s.AddTool(
 		mcp.NewTool("get_calories",
-			mcp.WithDescription("소모 칼로리 조회. 데이터는 2018-12부터 존재. 장기간 분석 시 from을 과거 날짜로 설정하세요."),
-			mcp.WithString("from", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간: '2018-01-01'.")),
-			mcp.WithString("to", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
+			mcp.WithDescription("소모 칼로리 조회. 데이터는 2018-12부터 존재. 장기간 분석 시 start_date를 과거 날짜로 설정하세요."),
+			mcp.WithString("start_date", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간: '2018-01-01'.")),
+			mcp.WithString("end_date", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
 			mcp.WithString("interval", mcp.Description("집계 간격: 1h, 1d, 1month, 1y. 기본 1d.")),
 		),
 		makeMetricHandler(repo, "calories"),
@@ -203,9 +203,9 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 	// get_distance
 	s.AddTool(
 		mcp.NewTool("get_distance",
-			mcp.WithDescription("이동 거리 조회 (미터 단위). 데이터는 2018-12부터 존재. 장기간 분석 시 from을 과거 날짜로 설정하세요."),
-			mcp.WithString("from", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간: '2018-01-01'.")),
-			mcp.WithString("to", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
+			mcp.WithDescription("이동 거리 조회 (미터 단위). 데이터는 2018-12부터 존재. 장기간 분석 시 start_date를 과거 날짜로 설정하세요."),
+			mcp.WithString("start_date", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전. 전체 기간: '2018-01-01'.")),
+			mcp.WithString("end_date", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
 			mcp.WithString("interval", mcp.Description("집계 간격: 1h, 1d, 1month, 1y. 기본 1d.")),
 		),
 		makeMetricHandler(repo, "distance"),
@@ -277,8 +277,8 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 	s.AddTool(
 		mcp.NewTool("get_meals",
 			mcp.WithDescription("식단/식사 기록을 조회합니다. 음식명, 영양소, 메모 등을 반환합니다."),
-			mcp.WithString("from", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전.")),
-			mcp.WithString("to", mcp.Description("종료일. 생략하면 현재.")),
+			mcp.WithString("start_date", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전.")),
+			mcp.WithString("end_date", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
 			mcp.WithString("meal_type", mcp.Description("필터: breakfast, lunch, dinner, snack. 생략하면 전체.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -457,8 +457,8 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 	s.AddTool(
 		mcp.NewTool("get_notes",
 			mcp.WithDescription("건강 메모/특이사항을 조회합니다."),
-			mcp.WithString("from", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전.")),
-			mcp.WithString("to", mcp.Description("종료일. 생략하면 현재.")),
+			mcp.WithString("start_date", mcp.Description("시작일 (YYYY-MM-DD). 생략하면 7일 전.")),
+			mcp.WithString("end_date", mcp.Description("종료일 (YYYY-MM-DD). 생략하면 현재.")),
 			mcp.WithString("category", mcp.Description("필터: symptom, condition, memo. 생략하면 전체.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -500,8 +500,8 @@ func makeMetricHandler(repo *db.Repository, metricType string) server.ToolHandle
 }
 
 func parseRange(req mcp.CallToolRequest) (time.Time, time.Time) {
-	fromStr := req.GetString("from", "")
-	toStr := req.GetString("to", "")
+	fromStr := req.GetString("start_date", "")
+	toStr := req.GetString("end_date", "")
 	return defaults(fromStr, toStr, 7)
 }
 

--- a/health-hub/internal/api/handlers.go
+++ b/health-hub/internal/api/handlers.go
@@ -80,8 +80,8 @@ func (h *handler) ingest(w http.ResponseWriter, r *http.Request) {
 }
 
 func parseTimeRange(r *http.Request) (from, to time.Time, err error) {
-	fromStr := r.URL.Query().Get("from")
-	toStr := r.URL.Query().Get("to")
+	fromStr := r.URL.Query().Get("start_date")
+	toStr := r.URL.Query().Get("end_date")
 
 	if fromStr == "" {
 		from = time.Now().AddDate(0, 0, -7) // default: last 7 days


### PR DESCRIPTION
## Summary
- MCP 도구 스키마, REST API query params, 대시보드 hooks의 날짜 필터 파라미터명을 `from`/`to` → `start_date`/`end_date`로 통일
- LLM이 MCP 스키마의 `from`/`to` 대신 학습 데이터 기반 이름(`date`, `start_date` 등)을 사용하여 날짜 필터가 무시되던 버그 수정

## Root Cause
MCP 도구 스키마에 `from`/`to`로 정의되어 있었으나, LLM이 학습 데이터의 prior를 따라 `start_date`/`end_date`, `date` 등의 이름으로 호출 → `GetString("from", "")`이 빈 문자열 반환 → 기본값(최근 7일)으로 fallback

## Changes
| 레이어 | 파일 | 변경 |
|--------|------|------|
| MCP 서버 | `health-hub/cmd/mcp/main.go` | 10개 조회 도구 스키마 + parseRange/get_weight 핸들러 |
| REST API | `health-hub/internal/api/handlers.go` | `parseTimeRange()` query param key |
| 대시보드 | `health-hub-dashboard/lib/hooks/use-*.ts` (4개) | apiFetch params |

## Test plan
- [ ] MCP: `get_steps(start_date="2024-01-01", end_date="2024-12-31", interval="1month")` → 해당 범위 데이터 반환 확인
- [ ] MCP: `get_meals(start_date="2026-04-10")` → 해당 날짜 식단만 반환 확인
- [ ] REST: `GET /api/v1/metrics?type=steps&start_date=2024-01-01&end_date=2024-12-31&interval=1month` 정상 동작
- [ ] 대시보드: 날짜 범위 선택 시 차트 데이터 정상 로드

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)