### PR TITLE
chore: SME Tour blackbox probe + ArgoCD App

### DIFF
--- a/k8s/argocd/applications/apps/sme-tour-engine.yaml
+++ b/k8s/argocd/applications/apps/sme-tour-engine.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sme-tour-engine
+  namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: engine=ghcr.io/manamana32321/sme-tour-engine
+    argocd-image-updater.argoproj.io/engine.update-strategy: digest
+    argocd-image-updater.argoproj.io/engine.allow-tags: regexp:^latest$
+    argocd-image-updater.argoproj.io/write-back-method: git
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/manamana32321/sme-tour
+    targetRevision: main
+    path: k8s
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: sme-tour
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/observability/blackbox-exporter/values.yaml
+++ b/k8s/observability/blackbox-exporter/values.yaml
@@ -117,3 +117,6 @@ serviceMonitor:
     - name: health-hub
       url: http://health-hub.health-hub.svc.cluster.local:8080/healthz
       module: http_2xx_no_tls
+    - name: sme-tour-engine
+      url: http://sme-tour-engine.sme-tour.svc.cluster.local/healthz
+      module: http_2xx_no_tls


### PR DESCRIPTION
## Summary
- Blackbox Exporter에 `sme-tour-engine` healthz probe 추가
- ArgoCD Application을 git으로 선언적 관리 (기존 kubectl apply → yaml)

## Changes
1. `k8s/observability/blackbox-exporter/values.yaml`: sme-tour-engine target 추가
2. `k8s/argocd/applications/apps/sme-tour-engine.yaml`: Application CR + Image Updater annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)