### PR TITLE
feat(health-hub): 체성분 데이터 지원 (body_fat, lean_mass, skeletal_muscle)

### DIFF
--- a/health-hub/cmd/mcp/main.go
+++ b/health-hub/cmd/mcp/main.go
@@ -381,12 +381,14 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 		},
 	)
 
-	// add_weight — 체중 수동 입력
+	// add_weight — 체중/체성분 수동 입력
 	s.AddTool(
 		mcp.NewTool("add_weight",
-			mcp.WithDescription("체중을 수동으로 기록합니다."),
+			mcp.WithDescription("체중 및 체성분을 수동으로 기록합니다."),
 			mcp.WithNumber("weight_kg", mcp.Description("체중 (kg). 필수."), mcp.Required()),
 			mcp.WithNumber("body_fat_pct", mcp.Description("체지방률 (%). 모르면 생략.")),
+			mcp.WithNumber("body_fat_mass_kg", mcp.Description("체지방량 (kg). 모르면 생략.")),
+			mcp.WithNumber("skeletal_muscle_mass_kg", mcp.Description("골격근량 (kg). 모르면 생략.")),
 			mcp.WithString("time", mcp.Description("측정 시간 (RFC3339). 생략하면 현재 시각.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -403,6 +405,12 @@ func registerTools(s *server.MCPServer, repo *db.Repository) {
 
 			if v, ok := args["body_fat_pct"].(float64); ok {
 				bm.BodyFatPct = &v
+			}
+			if v, ok := args["body_fat_mass_kg"].(float64); ok {
+				bm.BodyFatMassKg = &v
+			}
+			if v, ok := args["skeletal_muscle_mass_kg"].(float64); ok {
+				bm.SkeletalMuscleMassKg = &v
 			}
 			if v := req.GetString("time", ""); v != "" {
 				if t, err := time.Parse(time.RFC3339, v); err == nil {

--- a/health-hub/internal/api/hc_webhook.go
+++ b/health-hub/internal/api/hc_webhook.go
@@ -32,6 +32,8 @@ type hcWebhookPayload struct {
 	BloodPressure    []hcBloodPressure   `json:"blood_pressure"`
 	BodyTemperature  []hcBodyTemp        `json:"body_temperature"`
 	RespiratoryRate  []hcRespiratoryRate `json:"respiratory_rate"`
+	BodyFat          []hcBodyFat         `json:"body_fat"`
+	LeanBodyMass     []hcLeanBodyMass    `json:"lean_body_mass"`
 }
 
 type hcSteps struct {
@@ -121,6 +123,16 @@ type hcBodyTemp struct {
 type hcRespiratoryRate struct {
 	Rate float64 `json:"rate"`
 	Time string  `json:"time"`
+}
+
+type hcBodyFat struct {
+	Percentage float64 `json:"percentage"`
+	Time       string  `json:"time"`
+}
+
+type hcLeanBodyMass struct {
+	Kilograms float64 `json:"kilograms"`
+	Time      string  `json:"time"`
 }
 
 func parseTime(s string) time.Time {
@@ -307,13 +319,27 @@ func (h *handler) hcWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 	result.Nutrition = n
 
-	// Convert weight → body measurements
+	// Convert weight + body composition → body measurements
 	var body []model.BodyMeasurement
 	for _, wt := range payload.Weight {
 		kg := wt.Kilograms
 		body = append(body, model.BodyMeasurement{
 			Time:     parseTime(wt.Time),
 			WeightKg: &kg,
+		})
+	}
+	for _, bf := range payload.BodyFat {
+		pct := bf.Percentage
+		body = append(body, model.BodyMeasurement{
+			Time:       parseTime(bf.Time),
+			BodyFatPct: &pct,
+		})
+	}
+	for _, lm := range payload.LeanBodyMass {
+		kg := lm.Kilograms
+		body = append(body, model.BodyMeasurement{
+			Time:       parseTime(lm.Time),
+			LeanMassKg: &kg,
 		})
 	}
 	n, err = h.repo.InsertBodyMeasurements(ctx, body)

--- a/health-hub/internal/db/migrations/005_body_composition.sql
+++ b/health-hub/internal/db/migrations/005_body_composition.sql
@@ -1,0 +1,2 @@
+ALTER TABLE body_measurements ADD COLUMN IF NOT EXISTS skeletal_muscle_mass_kg DOUBLE PRECISION;
+ALTER TABLE body_measurements ADD COLUMN IF NOT EXISTS body_fat_mass_kg DOUBLE PRECISION;

--- a/health-hub/internal/db/repository.go
+++ b/health-hub/internal/db/repository.go
@@ -264,9 +264,15 @@ func (r *Repository) QueryNutritionByType(ctx context.Context, q model.TimeRange
 // InsertBodyMeasurement inserts a single body measurement and returns the time.
 func (r *Repository) InsertBodyMeasurement(ctx context.Context, m model.BodyMeasurement) error {
 	_, err := r.pool.Exec(ctx,
-		`INSERT INTO body_measurements (time, weight_kg, body_fat_pct, lean_mass_kg) VALUES ($1, $2, $3, $4)
-		ON CONFLICT (time) DO UPDATE SET weight_kg = EXCLUDED.weight_kg, body_fat_pct = EXCLUDED.body_fat_pct, lean_mass_kg = EXCLUDED.lean_mass_kg`,
-		m.Time, m.WeightKg, m.BodyFatPct, m.LeanMassKg)
+		`INSERT INTO body_measurements (time, weight_kg, body_fat_pct, lean_mass_kg, skeletal_muscle_mass_kg, body_fat_mass_kg)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (time) DO UPDATE SET
+			weight_kg = COALESCE(EXCLUDED.weight_kg, body_measurements.weight_kg),
+			body_fat_pct = COALESCE(EXCLUDED.body_fat_pct, body_measurements.body_fat_pct),
+			lean_mass_kg = COALESCE(EXCLUDED.lean_mass_kg, body_measurements.lean_mass_kg),
+			skeletal_muscle_mass_kg = COALESCE(EXCLUDED.skeletal_muscle_mass_kg, body_measurements.skeletal_muscle_mass_kg),
+			body_fat_mass_kg = COALESCE(EXCLUDED.body_fat_mass_kg, body_measurements.body_fat_mass_kg)`,
+		m.Time, m.WeightKg, m.BodyFatPct, m.LeanMassKg, m.SkeletalMuscleMassKg, m.BodyFatMassKg)
 	return err
 }
 
@@ -319,13 +325,18 @@ func (r *Repository) InsertBodyMeasurements(ctx context.Context, measurements []
 		return 0, nil
 	}
 
-	query := `INSERT INTO body_measurements (time, weight_kg, body_fat_pct, lean_mass_kg)
-		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (time) DO UPDATE SET weight_kg = EXCLUDED.weight_kg, body_fat_pct = EXCLUDED.body_fat_pct, lean_mass_kg = EXCLUDED.lean_mass_kg`
+	query := `INSERT INTO body_measurements (time, weight_kg, body_fat_pct, lean_mass_kg, skeletal_muscle_mass_kg, body_fat_mass_kg)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (time) DO UPDATE SET
+			weight_kg = COALESCE(EXCLUDED.weight_kg, body_measurements.weight_kg),
+			body_fat_pct = COALESCE(EXCLUDED.body_fat_pct, body_measurements.body_fat_pct),
+			lean_mass_kg = COALESCE(EXCLUDED.lean_mass_kg, body_measurements.lean_mass_kg),
+			skeletal_muscle_mass_kg = COALESCE(EXCLUDED.skeletal_muscle_mass_kg, body_measurements.skeletal_muscle_mass_kg),
+			body_fat_mass_kg = COALESCE(EXCLUDED.body_fat_mass_kg, body_measurements.body_fat_mass_kg)`
 
 	batch := &pgx.Batch{}
 	for _, m := range measurements {
-		batch.Queue(query, m.Time, m.WeightKg, m.BodyFatPct, m.LeanMassKg)
+		batch.Queue(query, m.Time, m.WeightKg, m.BodyFatPct, m.LeanMassKg, m.SkeletalMuscleMassKg, m.BodyFatMassKg)
 	}
 
 	br := r.pool.SendBatch(ctx, batch)
@@ -456,7 +467,7 @@ func (r *Repository) QueryNutritionRecords(ctx context.Context, q model.TimeRang
 // QueryBodyMeasurements returns body measurements in a time range.
 func (r *Repository) QueryBodyMeasurements(ctx context.Context, q model.TimeRangeQuery) ([]model.BodyMeasurement, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT time, weight_kg, body_fat_pct, lean_mass_kg
+		SELECT time, weight_kg, body_fat_pct, lean_mass_kg, skeletal_muscle_mass_kg, body_fat_mass_kg
 		FROM body_measurements
 		WHERE time >= $1 AND time < $2
 		ORDER BY time DESC`, q.From, q.To)
@@ -468,7 +479,7 @@ func (r *Repository) QueryBodyMeasurements(ctx context.Context, q model.TimeRang
 	var results []model.BodyMeasurement
 	for rows.Next() {
 		var m model.BodyMeasurement
-		if err := rows.Scan(&m.Time, &m.WeightKg, &m.BodyFatPct, &m.LeanMassKg); err != nil {
+		if err := rows.Scan(&m.Time, &m.WeightKg, &m.BodyFatPct, &m.LeanMassKg, &m.SkeletalMuscleMassKg, &m.BodyFatMassKg); err != nil {
 			return nil, fmt.Errorf("scan body: %w", err)
 		}
 		results = append(results, m)

--- a/health-hub/internal/model/health.go
+++ b/health-hub/internal/model/health.go
@@ -64,10 +64,12 @@ type HealthNote struct {
 
 // BodyMeasurement represents weight and body composition.
 type BodyMeasurement struct {
-	Time       time.Time `json:"time"`
-	WeightKg   *float64  `json:"weight_kg,omitempty"`
-	BodyFatPct *float64  `json:"body_fat_pct,omitempty"`
-	LeanMassKg *float64  `json:"lean_mass_kg,omitempty"`
+	Time                 time.Time `json:"time"`
+	WeightKg             *float64  `json:"weight_kg,omitempty"`
+	BodyFatPct           *float64  `json:"body_fat_pct,omitempty"`
+	BodyFatMassKg        *float64  `json:"body_fat_mass_kg,omitempty"`
+	SkeletalMuscleMassKg *float64  `json:"skeletal_muscle_mass_kg,omitempty"`
+	LeanMassKg           *float64  `json:"lean_mass_kg,omitempty"`
 }
 
 // IngestPayload is the request body from Tasker.


### PR DESCRIPTION
## Summary
- HC Webhook에서 `body_fat`, `lean_body_mass` 키 파싱 → `body_measurements` 테이블에 저장
- DB 스키마에 `skeletal_muscle_mass_kg`, `body_fat_mass_kg` 컬럼 추가 (migration 005)
- MCP `add_weight` 도구에 `body_fat_mass_kg`, `skeletal_muscle_mass_kg` 파라미터 추가
- COALESCE upsert로 체중/체지방이 다른 타임스탬프로 들어와도 기존 값 보존

## Background
HC Webhook 앱(v1.5.1)이 `body_fat`, `lean_body_mass`, `bone_mass` 키를 지원하지만, 앱 설정 저장 버그로 현재 데이터가 전송되지 않는 상태. 서버 쪽을 먼저 준비하여 앱이 수정되면 즉시 동작하도록 함.

골격근량(`skeletal_muscle_mass_kg`)은 Health Connect에 없는 삼성헬스 자체 측정값 → MCP `add_weight`로 수동 입력만 가능.

## Changes
| 파일 | 변경 |
|------|------|
| `migrations/005_body_composition.sql` | 새 컬럼 2개 |
| `model/health.go` | BodyMeasurement에 필드 추가 |
| `repository.go` | INSERT/UPSERT/SELECT 확장 (COALESCE 패턴) |
| `hc_webhook.go` | body_fat, lean_body_mass 파싱 |
| `cmd/mcp/main.go` | add_weight 파라미터 확장 |

## Test plan
- [ ] MCP: `add_weight(weight_kg=77.5, body_fat_pct=23.1, skeletal_muscle_mass_kg=34.2, body_fat_mass_kg=18.0)` → DB 저장 확인
- [ ] MCP: `get_weight(start_date="2026-04-01")` → 새 필드 포함 응답 확인
- [ ] REST: `GET /api/v1/body?start_date=2026-04-01` → 새 필드 포함
- [ ] Webhook: body_fat/lean_body_mass 키가 포함된 payload 전송 시 정상 파싱 (앱 수정 후)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)