### PR TITLE
fix(observability): increase Promtail memory limit to 256Mi

### DIFF
--- a/k8s/observability/promtail/values.yaml
+++ b/k8s/observability/promtail/values.yaml
@@ -7,7 +7,7 @@ service:
 resources:
   limits:
     cpu: 200m
-    memory: 128Mi
+    memory: 256Mi
   requests:
     cpu: 100m
     memory: 128Mi


### PR DESCRIPTION
## Summary
- Promtail DaemonSet의 메모리 limit을 128Mi → 256Mi로 증설
- json-server-2에서 빈번한 재배포로 누적된 pod 로그 디렉토리 watch 시 OOMKilled 발생

## Test plan
- [ ] ArgoCD sync 후 Promtail pod가 json-server-2에서 Running 상태 확인
- [ ] `kubectl top pod -l app.kubernetes.io/name=promtail -n observability`로 메모리 사용량 모니터링

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)