### PR TITLE
feat(traefik): add bot scan path blocking middleware

### DIFF
--- a/k8s/argocd/applications/infra/traefik.yaml
+++ b/k8s/argocd/applications/infra/traefik.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/manamana32321/homelab
+      targetRevision: main
+      path: k8s/traefik/manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s/traefik/manifests/helmchartconfig.yaml
+++ b/k8s/traefik/manifests/helmchartconfig.yaml
@@ -8,3 +8,10 @@ spec:
     providers:
       kubernetesCRD:
         allowCrossNamespace: true
+    additionalArguments:
+      - "--entrypoints.websecure.http.middlewares=kube-system-bot-block@kubernetescrd"
+    experimental:
+      plugins:
+        blockpath:
+          moduleName: github.com/traefik/plugin-blockpath
+          version: v0.2.1

--- a/k8s/traefik/manifests/middleware-bot-block.yaml
+++ b/k8s/traefik/manifests/middleware-bot-block.yaml
@@ -1,0 +1,22 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: bot-block
+  namespace: kube-system
+spec:
+  plugin:
+    blockpath:
+      regex:
+        # Environment variable files
+        - "(?i)^/\\.env.*"
+        # WordPress probes
+        - "(?i)^/wp-"
+        - "(?i)/wlwmanifest\\.xml"
+        # PHP probes
+        - "(?i)^/phpinfo"
+        - "(?i)^/_profiler"
+        - "(?i)\\.php$"
+        # Configuration file probes
+        - "(?i)^/settings\\.ini"
+        - "(?i)^/config\\.json"
+        - "(?i)^/web\\.config"


### PR DESCRIPTION
## Summary
- Traefik 공식 [plugin-blockpath](https://github.com/traefik/plugin-blockpath) v0.2.1로 봇 스캔 경로 차단
- websecure entrypoint 기본 미들웨어로 등록 → 클러스터 전체 서비스에 자동 적용
- ArgoCD Application 추가 (`k8s/traefik/manifests/`)

### 차단 대상 패턴
| 카테고리 | 패턴 | 예시 |
|---------|------|------|
| 환경변수 | `(?i)^/\.env.*` | `.env`, `.env.prod`, `/api/.env` |
| WordPress | `(?i)^/wp-`, `(?i)/wlwmanifest\.xml` | `/wp-includes/`, `/wp-admin/` |
| PHP | `(?i)^/phpinfo`, `(?i)^/_profiler`, `(?i)\.php$` | `/phpinfo.php`, `/_profiler/phpinfo` |
| 설정파일 | `(?i)^/settings\.ini`, `(?i)^/config\.json`, `(?i)^/web\.config` | `/settings.ini` |

### 동작 방식
```
Client → Traefik (websecure) → bot-block middleware → 매칭 시 403 Forbidden
                                                    → 미매칭 시 → 백엔드 서비스
```

### 주의사항
- HelmChartConfig 변경으로 K3s Helm controller가 Traefik pod를 재시작합니다 (잠깐 ingress 중단)
- 기존 authentik-forwardauth 미들웨어와 충돌 없음 (bot-block이 entrypoint 레벨에서 먼저 실행)

## Test plan
- [ ] ArgoCD sync 후 Traefik pod 정상 재시작 확인
- [ ] `kubectl describe middleware bot-block -n kube-system`으로 CRD 생성 확인
- [ ] `curl -k https://<service>/.env` → 403 응답 확인
- [ ] `curl -k https://<service>/` → 정상 200 응답 확인
- [ ] Grafana/Prometheus 등 기존 서비스 접근 정상 확인

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)