### PR TITLE
feat: add CrowdSec IPS with Traefik bouncer plugin

### DIFF
--- a/k8s/argocd/applications/infra/crowdsec.yaml
+++ b/k8s/argocd/applications/infra/crowdsec.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: crowdsec
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    # Source 1: CrowdSec Helm chart
+    - repoURL: https://crowdsecurity.github.io/helm-charts
+      chart: crowdsec
+      targetRevision: 0.23.0
+      helm:
+        releaseName: crowdsec
+        valueFiles:
+          - $homelab/k8s/crowdsec/values.yaml
+    # Source 2: Homelab repo reference for values
+    - repoURL: https://github.com/manamana32321/homelab
+      targetRevision: main
+      ref: homelab
+    # Source 3: SealedSecret
+    - repoURL: https://github.com/manamana32321/homelab
+      targetRevision: main
+      path: k8s/crowdsec/manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: crowdsec
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/argocd/applications/infra/traefik.yaml
+++ b/k8s/argocd/applications/infra/traefik.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/manamana32321/homelab
+      targetRevision: main
+      path: k8s/traefik/manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s/argocd/applications/infra/traefik.yaml
+++ b/k8s/argocd/applications/infra/traefik.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: traefik
   namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   sources:

--- a/k8s/crowdsec/manifests/sealed-secret.yaml
+++ b/k8s/crowdsec/manifests/sealed-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: crowdsec-bouncer-key
+  namespace: crowdsec
+spec:
+  encryptedData:
+    BOUNCER_KEY_traefik: AgAB+xUXUrnCjNRw4S834WGO2/xPmYW4riWoLeKe3ySVGxrwGAjMCMgPTGvPGyMRsZ0oMNG+jK1tSy/nNtTfYLDnZninpXl3mq9cFAQOEZAwz9Us/JbENCjthU5OocSy4Cwa595v0b75BJGR9k4rLBdklpeW9zx5a/bZAK3psR+54+GZmxOcr9C3488yPpHjr9I1rLS/VCV2FpKjye7OhUPP7FSP9/qsyQ/zimvqKjxpPME+tMvww5VZU/bfxrLXZz1hp1T0xZFcpKl/rivri1QS4DRIMwR9wn0RLKUiENmoTuyRdFdKNlj2WejZ3gL0puoqbJPx1zM0ATMNVkBJ+2SuX1+uAQTAIeh1KXumkUyfV4z+lqEHF4MBYr7MNaERLFEXUId7gDSZtT9IBDa3z8JDZVD9ssIUzZRMptez5s37hiZsJKiQCZi0QCqNUipMk04GNEf03OoswIPM7ArTvlvbtfoQG6ROBd4D7wvapM2d/Q9bZZtcAShmGQ24X1TSU8Rl56jv2ZvWyze5BQva0NsDZmPt2/Mdb6DyXZ6DD6iI4AfXlAV8SaVs5V7/bwnMU7McjDh63zJREc+g5Umu5wQWVWHdRj1UwWB/9HiMy36RELbMm58P2yGU7Sl0ccTbGmT/X3RKRaH9ca9IHROrrPEaVw9IyCkDUPvaTOBOgc0Yn7uXD2xAH6bBSho+yh6VLeO75QCwX4PeB0IpP2UnhGyat3UVnX71re3s7RHMGVhGZRg9aMHc+I3Rm7EPNiGLo9jByIGNDgs6r5bqqlbBnUsU
+  template:
+    metadata:
+      name: crowdsec-bouncer-key
+      namespace: crowdsec

--- a/k8s/crowdsec/values.yaml
+++ b/k8s/crowdsec/values.yaml
@@ -1,0 +1,39 @@
+container_runtime: containerd
+
+agent:
+  acquisition:
+    - namespace: kube-system
+      podName: traefik-*
+      program: traefik
+  env:
+    - name: COLLECTIONS
+      value: "crowdsecurity/traefik crowdsecurity/http-cve"
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+lapi:
+  env:
+    - name: BOUNCER_KEY_traefik
+      valueFrom:
+        secretKeyRef:
+          name: crowdsec-bouncer-key
+          key: BOUNCER_KEY_traefik
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  persistentVolume:
+    data:
+      enabled: true
+      storageClassName: longhorn-ssd
+      size: 1Gi
+    config:
+      enabled: true
+      storageClassName: longhorn-ssd
+      size: 100Mi

--- a/k8s/traefik/manifests/helmchartconfig.yaml
+++ b/k8s/traefik/manifests/helmchartconfig.yaml
@@ -8,3 +8,14 @@ spec:
     providers:
       kubernetesCRD:
         allowCrossNamespace: true
+    logs:
+      access:
+        enabled: true
+        format: json
+    additionalArguments:
+      - "--entrypoints.websecure.http.middlewares=kube-system-crowdsec-bouncer@kubernetescrd"
+    experimental:
+      plugins:
+        bouncer:
+          moduleName: github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin
+          version: v1.5.1

--- a/k8s/traefik/manifests/middleware-crowdsec.yaml
+++ b/k8s/traefik/manifests/middleware-crowdsec.yaml
@@ -1,0 +1,17 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: crowdsec-bouncer
+  namespace: kube-system
+spec:
+  plugin:
+    bouncer:
+      enabled: true
+      crowdsecMode: stream
+      crowdsecLapiScheme: http
+      crowdsecLapiHost: crowdsec-lapi.crowdsec.svc.cluster.local:8080
+      # Internal cluster key — Traefik plugin CRDs do not support secretKeyRef.
+      # The same key is sealed in k8s/crowdsec/manifests/sealed-secret.yaml.
+      crowdsecLapiKey: ad51ab1251b670b6231b1940d7a227ff78062f08c5bd876f2bf525b542484e0b
+      updateIntervalSeconds: 60
+      defaultDecisionSeconds: 60


### PR DESCRIPTION
## Summary
- [CrowdSec](https://crowdsec.net/) IPS 배포 — 커뮤니티 기반 IP 평판 + 행동 분석으로 악성 트래픽 차단
- Traefik bouncer plugin (streaming mode)으로 websecure entrypoint 전역 적용
- Traefik access log 활성화 (JSON) → CrowdSec agent가 실시간 분석

### #91 대비 차이점 (plugin-blockpath vs CrowdSec)

| | plugin-blockpath (#94) | CrowdSec (이 PR) |
|---|---|---|
| **차단 방식** | 정적 regex 경로 매칭 | IP 평판 + 행동 분석 |
| **차단 대상** | 알려진 경로만 | 알려진 IP + 새로운 공격 패턴 |
| **커뮤니티** | 없음 (수동 관리) | 15,000+ 악성 IP 실시간 공유 |
| **CVE 대응** | 불가 | `http-cve` collection (Log4Shell 등) |
| **리소스** | 없음 | LAPI 1 pod (~256MB) + Agent |
| **유지보수** | regex 수동 추가 | 자동 업데이트 |

### 아키텍처
```
Traefik access log → CrowdSec Agent (로그 파싱)
                         ↓
                     CrowdSec LAPI (판단 + 커뮤니티 sync)
                         ↑
Traefik ← bouncer plugin (streaming cache, 60s 갱신)
```

### 배포되는 리소스
| 리소스 | 네임스페이스 | 설명 |
|--------|-------------|------|
| CrowdSec Helm (LAPI + Agent) | `crowdsec` | 로그 분석 엔진 |
| SealedSecret `crowdsec-bouncer-key` | `crowdsec` | Bouncer API key |
| Middleware `crowdsec-bouncer` | `kube-system` | Traefik plugin CRD |
| HelmChartConfig | `kube-system` | Access log + plugin 등록 |
| ArgoCD App `crowdsec` | `argocd` | Helm chart 관리 |
| ArgoCD App `traefik` | `argocd` | Traefik manifests 관리 |

### 알려진 제약
- Bouncer API key가 Middleware CRD에 평문으로 포함됨 (Traefik plugin은 `secretKeyRef` 미지원)
- CrowdSec Console 등록은 머지 후 수동 설정 (`cscli console enroll`)

### 주의사항
- HelmChartConfig 변경으로 Traefik pod 재시작 (잠깐 ingress 중단)
- Access log 활성화로 Traefik 로그 볼륨 증가 → Promtail/Loki 부하 고려

## Test plan
- [ ] ArgoCD sync 후 CrowdSec LAPI + Agent pod Running 확인
- [ ] `kubectl exec -n crowdsec <lapi-pod> -- cscli bouncers list` → traefik bouncer 등록 확인
- [ ] `kubectl exec -n crowdsec <lapi-pod> -- cscli decisions list` → 커뮤니티 blocklist 수신 확인
- [ ] Traefik pod 정상 재시작 + access log 출력 확인
- [ ] 기존 서비스 (grafana, argocd 등) 정상 접근 확인
- [ ] `curl -k https://<service>/.env` 요청 후 CrowdSec 로그에 탐지 기록 확인

## 머지 후 TODO
- [ ] CrowdSec Console 등록 (app.crowdsec.net → enrollment key → `cscli console enroll`)
- [ ] Grafana CrowdSec 대시보드 추가
- [ ] Alertmanager 연동 (ban 이벤트 → Telegram 알림)
- [ ] #94 (plugin-blockpath) PR close

🤖 Generated with [Claude Code](https://claude.com/claude-code)