### PR TITLE
refactor: S3 백업 Intelligent-Tiering 전환 + 라이브러리 재생성

### DIFF
--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -19,21 +19,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "immich_backup" {
     }
   }
 
-  # Media: transition to Glacier IR after 7 days
-  # rclone syncs to Standard to avoid expensive GIR request costs ($0.01/1K vs $0.0004/1K)
-  rule {
-    id     = "media-to-glacier-ir"
-    status = "Enabled"
-
-    filter {
-      prefix = "media/"
-    }
-
-    transition {
-      days          = 7
-      storage_class = "GLACIER_IR"
-    }
-  }
 }
 
 resource "aws_s3_bucket_public_access_block" "immich_backup" {
@@ -67,20 +52,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "seafile_backup" {
     }
   }
 
-  # Media: transition to Glacier IR after 7 days
-  rule {
-    id     = "media-to-glacier-ir"
-    status = "Enabled"
-
-    filter {
-      prefix = "media/"
-    }
-
-    transition {
-      days          = 7
-      storage_class = "GLACIER_IR"
-    }
-  }
 }
 
 resource "aws_s3_bucket_public_access_block" "seafile_backup" {

--- a/k8s/immich/manifests/media-backup-cronjob.yaml
+++ b/k8s/immich/manifests/media-backup-cronjob.yaml
@@ -44,11 +44,13 @@ spec:
                   region = ap-northeast-2
                   location_constraint = ap-northeast-2
                   no_check_bucket = true
+                  storage_class = INTELLIGENT_TIERING
                   CONF
 
                   # Sync library to S3
                   # ionice idle class: Seafile과 동일 디스크(Seagate 1TB) 경합 방지
                   ionice -c 3 rclone sync /library s3:immich-backup-json-server/media/ \
+                    --s3-no-head \
                     --s3-no-check-bucket \
                     --fast-list \
                     --transfers 2 \

--- a/k8s/seafile/manifests/media-backup-cronjob.yaml
+++ b/k8s/seafile/manifests/media-backup-cronjob.yaml
@@ -49,6 +49,7 @@ spec:
                   CONF
 
                   # Sync only 내 라이브러리 + 녹음 libraries to S3
+                  # --s3-no-head 불필요: S3 기존 데이터 삭제 후 전부 IT 오브젝트 (HEAD $0.005/1K)
                   # ionice idle class: Seafile과 동일 디스크(Seagate 1TB) 경합 방지
                   ionice -c 3 rclone sync /seafile-data s3:seafile-backup-json-server/media/ \
                     --filter "+ seafile/seafile-data/storage/*/66a1e14f-8c91-45c8-ace8-b3c7f03ac63e/**" \

--- a/k8s/seafile/manifests/media-backup-cronjob.yaml
+++ b/k8s/seafile/manifests/media-backup-cronjob.yaml
@@ -45,13 +45,14 @@ spec:
                   region = ap-northeast-2
                   location_constraint = ap-northeast-2
                   no_check_bucket = true
+                  storage_class = INTELLIGENT_TIERING
                   CONF
 
                   # Sync only 내 라이브러리 + 녹음 libraries to S3
                   # ionice idle class: Seafile과 동일 디스크(Seagate 1TB) 경합 방지
                   ionice -c 3 rclone sync /seafile-data s3:seafile-backup-json-server/media/ \
-                    --filter "+ seafile/seafile-data/storage/*/26ff9347-bbca-4c73-af00-015e862a377f/**" \
-                    --filter "+ seafile/seafile-data/storage/*/c6c9f519-1e30-42e0-b3c7-a05ab0428cc9/**" \
+                    --filter "+ seafile/seafile-data/storage/*/66a1e14f-8c91-45c8-ace8-b3c7f03ac63e/**" \
+                    --filter "+ seafile/seafile-data/storage/*/32e4bb08-fc91-4ddd-992e-a6da1bb814fd/**" \
                     --filter "- **" \
                     --s3-no-check-bucket \
                     --fast-list \


### PR DESCRIPTION
## Summary

- S3 스토리지 클래스를 **Glacier IR → Intelligent-Tiering**으로 변경
- Seafile 라이브러리 재생성으로 **히스토리 오브젝트 88% 감소** (494K → 60K)
- Immich에 `--s3-no-head` 추가하여 기존 GIR 오브젝트 HEAD 비용 방지

## Changes

| 파일 | 변경 |
|------|------|
| `aws/s3.tf` | `media-to-glacier-ir` lifecycle rule 제거 (IT가 자동 관리) |
| `k8s/immich/manifests/media-backup-cronjob.yaml` | `storage_class = INTELLIGENT_TIERING` + `--s3-no-head` |
| `k8s/seafile/manifests/media-backup-cronjob.yaml` | `storage_class = INTELLIGENT_TIERING` + 새 라이브러리 UUID |

## Background

3월 S3 비용 $113 폭탄 원인: rclone sync가 Glacier IR 오브젝트에 HEAD 요청 ($0.01/1K).

해결 전략:
1. **Intelligent-Tiering**: HEAD 요청이 Standard 요금 ($0.005/1K), 90일 후 저장 비용 GIR과 동일
2. **Immich `--s3-no-head`**: 기존 GIR 402GB에 HEAD 요청 자체를 제거
3. **라이브러리 재생성**: Seafile 히스토리 49만 오브젝트 → 6만으로 감소
4. **6월 24일 후**: Immich GIR → IT 일괄 COPY 전환 ($0.42)

## Cost

| | Before | After |
|---|---|---|
| 월간 | $113/월 | ~$2.50/월 |

## Test plan

- [ ] `terraform apply` (lifecycle rule 제거)
- [ ] S3 seafile 고아 데이터 삭제 완료 확인
- [ ] CronJob suspend 해제
- [ ] 다음 날 sync 로그 확인 — IT 클래스로 업로드 되는지
- [ ] seaf-gc 실행 (삭제된 라이브러리 블록 정리)

## Related

- Supersedes #89 (merged, strategy changed from lifecycle to IT)
- Closes #83

🤖 Generated with [Claude Code](https://claude.ai/code)