### PR TITLE
fix(crowdsec): CAPI origin 제외하여 블록리스트 동기화 false positive 해결

### DIFF
--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -97,13 +97,14 @@ spec:
     - name: crowdsec
       rules:
         - alert: CrowdSecHighBanRate
-          expr: increase(cs_active_decisions[5m]) > 50
+          # CAPI(커뮤니티 블록리스트) 제외 — 2시간마다 ~15K건 벌크 동기화로 false positive 발생
+          expr: increase(cs_active_decisions{origin!="CAPI"}[5m]) > 50
           for: 2m
           labels:
             severity: warning
           annotations:
-            summary: "CrowdSec: 다수 IP 차단 중"
-            description: "5분간 {{ $value | humanize }}건의 차단 판단 발생."
+            summary: "CrowdSec: 다수 IP 차단 중 (로컬 탐지)"
+            description: "5분간 {{ $value | humanize }}건의 로컬 차단 판단 발생."
 
         - alert: CrowdSecLAPIDown
           expr: up{job=~".*crowdsec-lapi.*"} == 0


### PR DESCRIPTION
## 문제
커뮤니티 블록리스트(CAPI)가 2시간마다 ~15K건 벌크 동기화되면서 `CrowdSecHighBanRate` 알림이 반복적으로 false positive 발생.

## 변경
- `cs_active_decisions` 메트릭에서 `origin!="CAPI"` 필터 추가
- 로컬 탐지(crowdsec origin)만 카운트하도록 변경
- annotation도 '로컬 탐지'로 명확화

## 영향
- 실제 공격 탐지 알림은 그대로 동작
- CAPI 블록리스트 벌크 동기화로 인한 노이즈만 제거