### PR TITLE
chore(mcp): Grafana MCP 추가 (mcp-grafana)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,3 +7,6 @@ export AWS_PROFILE="homelab"
 source_env_if_exists .envrc.local
 
 export KUBECONFIG=~/.kube/config-json
+
+# Go bin (mcp-grafana 등 `go install` 바이너리용)
+PATH_add ~/go/bin

--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -20,3 +20,9 @@ export AWS_REGION="ap-northeast-2"
 
 # GitHub MCP (gh CLI 토큰 재활용, gh auth login 필요)
 export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token)"
+
+# Grafana MCP (https://grafana.json-server.win → Administration → Service accounts → Add service account token)
+# 설치: go install github.com/grafana/mcp-grafana/cmd/mcp-grafana@latest
+# TODO: 추후 MCP 전용 Service Account 분리 (현재는 개인 토큰 사용)
+export GRAFANA_URL="https://grafana.json-server.win"
+export GRAFANA_SERVICE_ACCOUNT_TOKEN=""

--- a/.mcp.json
+++ b/.mcp.json
@@ -29,6 +29,13 @@
         "AWS_PROFILE": "${AWS_PROFILE}",
         "AWS_REGION": "${AWS_REGION}"
       }
+    },
+    "grafana": {
+      "command": "mcp-grafana",
+      "env": {
+        "GRAFANA_URL": "${GRAFANA_URL}",
+        "GRAFANA_SERVICE_ACCOUNT_TOKEN": "${GRAFANA_SERVICE_ACCOUNT_TOKEN}"
+      }
     }
   }
 }


### PR DESCRIPTION
## 🚀 작업 내용

Claude Code에서 홈랩 Grafana를 조회할 수 있도록 `grafana` MCP 서버 연결. Loki 로그, Prometheus 메트릭, 대시보드, 알림을 자연어로 조회 가능.

### 변경 요약

- **`.mcp.json`**: `grafana` 엔트리 추가 (stdio transport, `GRAFANA_URL` / `GRAFANA_SERVICE_ACCOUNT_TOKEN`)
- **`.envrc`**: `PATH_add ~/go/bin` — `go install` 바이너리 접근용
- **`.envrc.local.example`**: 토큰 템플릿 + 설치 가이드

### 설치

```bash
go install github.com/grafana/mcp-grafana/cmd/mcp-grafana@latest
cp .envrc.local.example .envrc.local
# GRAFANA_SERVICE_ACCOUNT_TOKEN 채우기
direnv allow
```

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

- 아망 측 대응 PR: [skku-amang/main#459](https://github.com/skku-amang/main/pull/459)
- 공식: [grafana/mcp-grafana](https://github.com/grafana/mcp-grafana)

## 🙏 리뷰어에게

- 현재는 개인 Service Account 토큰 사용. 추후 **Terraform Grafana provider로 MCP 전용 SA 선언적 관리 + SealedSecret 전환** 예정 (별도 작업).

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 관련 PR이 연결되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)