### PR TITLE
fix(grafana): Health Hub Postgres 비밀번호를 SealedSecret + env 주입으로 전환

### DIFF
--- a/k8s/observability/grafana/kustomization.yaml
+++ b/k8s/observability/grafana/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - health-hub-dashboard.yaml
   - factorio-dashboard.yaml
   - crowdsec-dashboard.yaml
+  - sealed-secret-pg-passwords.yaml

--- a/k8s/observability/grafana/sealed-secret-pg-passwords.yaml
+++ b/k8s/observability/grafana/sealed-secret-pg-passwords.yaml
@@ -1,0 +1,23 @@
+---
+# Health Hub TimescaleDB 접속 비밀번호를 SealedSecret으로 관리
+# 생성 방법 (비번 로테이션 시):
+#   echo -n "<새비밀번호>" | kubeseal \
+#     --raw \
+#     --from-file=/dev/stdin \
+#     --namespace observability \
+#     --name grafana-pg-passwords \
+#     --cert <(kubeseal --fetch-cert --controller-namespace kube-system) \
+#     --scope strict
+# 위 명령 출력값을 아래 encryptedData.PG_HEALTHHUB_PASSWORD에 붙여넣은 뒤 커밋.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: grafana-pg-passwords
+  namespace: observability
+spec:
+  encryptedData:
+    PG_HEALTHHUB_PASSWORD: AgANRL4HeERxKYidbLgLDIs9yZ1P9LjY+2721Z3T+maNHytTNF0jiEqeWPnQAE/Z+8mefoGu9C3k+R+Z9ysxNQC8BogduyVjQ0apfRs69U3HUcLGnMuTY0goXx7fSSBsUKEDQsvnciO33Qh39NpJVz59KzpVrCheiUL1cXptEQelTHGceBwiMWShxzDaeKfXcuSLQRmzzlNn7sOfLeyzDUCNyuz1O7PfoBXWzb2uuaDTKCvyJA3jav6VQ8cMUIQfdyj3IAvLoRnipfgYhVzEz8nkbbuh7yxEn1DcLRwYvtqt1772c+sP6e7OV3BV+u+SoI9g52VOdDeRPYGoJVZxoz2uwoYJRmLQbemGnBJ0KuJXoXbD8+cG3f8Bz2OzYL64cCWY9JDwJ5qvL8SVBXwRnu4iKaDBDVrNlAa/C8DbbYInj4WHYcyuUHFDLtfWS5RVSBDUV5gRSUH8pwcXwGZPv2HQmNRYVU72aoOW/9wYXwiALeH1naYUsfA9qSWyqyCAvSVsmNVDy5mRvjPouMfXoJhw7rQ6SwMlrz41ZaFNUSV4dsQZZbaI5Wq5NlhCeSZlj4PK4zzk95QbrcTsXFBOqXbOFwGwHXqH6LNjHZDl9KOKkncoN2V3/nk1DzyxCWBwgPA/37GROJI+YAFiZXfQ6ZsRXjH/FDXjwxCzzEYAA2b9Fgvk0Y+gl6Y9e688htCRgUebizXt5baGSd3/4JPaCBJ4q7TmB6k0AwruzSTx3kqMig==
+  template:
+    metadata:
+      name: grafana-pg-passwords
+      namespace: observability

--- a/k8s/observability/grafana/values.yaml
+++ b/k8s/observability/grafana/values.yaml
@@ -6,6 +6,11 @@ plugins:
 
 envFromSecret: grafana-github-oauth
 
+# grafana-pg-passwords SealedSecret에서 PG_HEALTHHUB_PASSWORD 환경변수 주입
+extraEnvFrom:
+  - secretRef:
+      name: grafana-pg-passwords
+
 replicas: 1
 autoscaling:
   enabled: false
@@ -87,7 +92,7 @@ datasources:
           postgresVersion: 1700
           timescaledb: true
         secureJsonData:
-          password: "kBXFGF9NNiLHedI5Mk27BpHP6O5QvJBH"
+          password: $PG_HEALTHHUB_PASSWORD
         editable: false
 
 # help grafana to detect provisioned dashboards


### PR DESCRIPTION
## 🚀 작업 내용

[이슈 #104](https://github.com/manamana32321/homelab/issues/104): `k8s/observability/grafana/values.yaml`에 평문으로 커밋된 Health Hub TimescaleDB `healthhub` 유저 비밀번호를 SealedSecret 구조로 전환합니다.

| 파일 | 변경 |
|------|------|
| `k8s/observability/grafana/values.yaml` | `secureJsonData.password` 평문 제거 → `$PG_HEALTHHUB_PASSWORD` env 참조, `extraEnvFrom` 추가 |
| `k8s/observability/grafana/sealed-secret-pg-passwords.yaml` | 신규 SealedSecret (`grafana-pg-passwords`, namespace: `observability`) |
| `k8s/observability/grafana/kustomization.yaml` | `sealed-secret-pg-passwords.yaml` 리소스 추가 |

**동작 원리:**
```
SealedSecret (grafana-pg-passwords)
  → Secret (PG_HEALTHHUB_PASSWORD)
    → Grafana 파드 env (extraEnvFrom.secretRef)
      → datasource provisioning ($PG_HEALTHHUB_PASSWORD 치환)
```

Grafana는 datasource provisioning 시 `$ENV_VAR` 형식의 환경변수 치환을 지원합니다.
([Grafana docs — Environment variable interpolation](https://grafana.com/docs/grafana/latest/administration/provisioning/#using-environment-variables))

**비밀번호 재봉인 방법 (로테이션 시):**
```bash
echo -n "<새비밀번호>" | kubeseal \
  --raw --from-file=/dev/stdin \
  --namespace observability \
  --name grafana-pg-passwords \
  --cert <(kubeseal --fetch-cert --controller-namespace kube-system) \
  --scope strict
```

## 📸 스크린샷(선택)

해당 없음 (인프라 변경)

## 🔗 관련 이슈

Closes #104

## 🙏 리뷰어에게

- 현재 PR은 기존 평문 비밀번호를 SealedSecret으로 옮긴 것이며, Git 히스토리에 평문이 남아 있습니다. **머지 후 즉시 비밀번호 로테이션**이 필요합니다.
- Grafana Helm chart `10.5.8`의 `extraEnvFrom` 필드가 실제 배포 시 정상 적용되는지 확인 부탁드립니다 (로컬 테스트 불가 환경).
- `$PG_HEALTHHUB_PASSWORD` 치환이 Grafana provisioning에서 올바르게 동작하는지 datasource 테스트 필요합니다.

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.
- [ ] **머지 후**: TimescaleDB `ALTER USER healthhub PASSWORD '<새비밀번호>';` 실행
- [ ] **머지 후**: 새 비밀번호로 SealedSecret 재봉인 후 커밋
- [ ] **머지 후**: ArgoCD `grafana` Application sync 정상 완료 확인
- [ ] **머지 후**: Grafana → HealthHub datasource 연결 테스트

---

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>