### PR TITLE
feat(grafana): AMANG 프로덕션 DB를 read-only Postgres datasource로 추가

### DIFF
--- a/k8s/observability/grafana/values.yaml
+++ b/k8s/observability/grafana/values.yaml
@@ -6,10 +6,15 @@ plugins:
 
 envFromSecret: grafana-github-oauth
 
-# grafana-pg-passwords SealedSecret에서 PG_HEALTHHUB_PASSWORD 환경변수 주입
+# SealedSecret에서 Postgres datasource 비밀번호 환경변수 주입
+#   - grafana-pg-passwords.PG_HEALTHHUB_PASSWORD (Health Hub TimescaleDB)
+#   - grafana-ro-credentials.GRAFANA_RO_PASSWORD (AMANG Postgres read-only,
+#     reflector로 amang-db-production에서 자동 반영)
 extraEnvFrom:
   - secretRef:
       name: grafana-pg-passwords
+  - secretRef:
+      name: grafana-ro-credentials
 
 replicas: 1
 autoscaling:
@@ -93,6 +98,25 @@ datasources:
           timescaledb: true
         secureJsonData:
           password: $PG_HEALTHHUB_PASSWORD
+        editable: false
+      # AMANG 프로덕션 DB (read-only, grafana_ro 전용 유저)
+      # 권한: public 스키마 SELECT만. UPDATE/DELETE/DDL은 DB 레벨 거부됨
+      - name: amang-prod
+        type: postgres
+        access: proxy
+        url: postgres-svc.amang-db-production.svc.cluster.local:5432
+        user: grafana_ro
+        jsonData:
+          database: amang
+          user: grafana_ro
+          sslmode: disable
+          maxOpenConns: 10
+          maxIdleConns: 2
+          maxIdleConnsAuto: true
+          connMaxLifetime: 14400
+          postgresVersion: 1600
+        secureJsonData:
+          password: $GRAFANA_RO_PASSWORD
         editable: false
 
 # help grafana to detect provisioned dashboards


### PR DESCRIPTION
## 🚀 작업 내용

AMANG 프로덕션 DB를 홈랩 Grafana Postgres datasource로 붙임. 이후 Claude Code에서 Grafana MCP로 AMANG DB를 자연어 질의할 수 있음 (예: "지난 주 가입자 수", "장비 대여 빈도 탑10").

### 변경

- `k8s/observability/grafana/values.yaml`
  - `extraEnvFrom`에 `grafana-ro-credentials` 추가 (AMANG DB read-only 비밀번호 주입)
  - Datasource `amang-prod` 추가 — `grafana_ro` 유저, `$GRAFANA_RO_PASSWORD` env 치환

### 선행 완료

- AMANG: [#461](https://github.com/skku-amang/main/pull/461) `grafana_ro` 역할 + SealedSecret + NetworkPolicy (머지 완료)
  - `observability` ns의 `app.kubernetes.io/name: grafana` 파드는 이미 AMANG Postgres 접근 허용됨
  - `grafana-ro-credentials` SealedSecret은 reflector로 `observability` ns에 자동 반영
- AMANG: [#465](https://github.com/skku-amang/main/pull/465) Init Job 제거 → runbook으로 대체, `grafana_ro` 역할 프로덕션 수동 bootstrap 완료

## 📸 스크린샷(선택)

N/A — 배포 후 Grafana UI에서 datasource 연결 테스트 예정

## 🔗 관련 이슈

- amang 측: [skku-amang/main#454](https://github.com/skku-amang/main/issues/454)

## 🙏 리뷰어에게

- 머지 후 수동 검증 필요:
  1. ArgoCD `grafana` app sync
  2. Grafana UI → Data sources → `amang-prod` → Test 버튼 → "Database Connection OK" 확인
  3. Explore 탭에서 `SELECT count(*) FROM users;` 실행 확인
  4. `UPDATE users SET name='x' WHERE id=0;` 시도 시 권한 거부 확인
- Claude Code `.mcp.json`의 grafana MCP로 자연어 질의 확인: "amang DB에서 가입자 수 알려줘" 등

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 관련 이슈가 연결되었습니다.