### PR TITLE
fix(grafana): extraEnvFrom을 envFromSecrets로 교체 (#105, #107 fix)

### DIFF
--- a/k8s/observability/grafana/values.yaml
+++ b/k8s/observability/grafana/values.yaml
@@ -10,11 +10,11 @@ envFromSecret: grafana-github-oauth
 #   - grafana-pg-passwords.PG_HEALTHHUB_PASSWORD (Health Hub TimescaleDB)
 #   - grafana-ro-credentials.GRAFANA_RO_PASSWORD (AMANG Postgres read-only,
 #     reflector로 amang-db-production에서 자동 반영)
-extraEnvFrom:
-  - secretRef:
-      name: grafana-pg-passwords
-  - secretRef:
-      name: grafana-ro-credentials
+# NOTE: Grafana Helm chart 실제 필드는 `envFromSecrets`(배열).
+# `extraEnvFrom`은 Bitnami chart 이름이라 공식 Grafana 차트에선 무시됨.
+envFromSecrets:
+  - name: grafana-pg-passwords
+  - name: grafana-ro-credentials
 
 replicas: 1
 autoscaling:


### PR DESCRIPTION
## 🚀 작업 내용

Grafana 공식 Helm chart의 envFrom 필드 이름은 `envFromSecrets`(복수 배열). `extraEnvFrom`은 Bitnami chart에서 쓰는 이름이라 공식 Grafana 차트에선 **경고 없이 무시**됨.

결과:
- [#105](https://github.com/manamana32321/homelab/pull/105) 이후 HealthHub datasource 비밀번호 인증 실패 상태
- [#107](https://github.com/manamana32321/homelab/pull/107) amang-prod 추가 시에도 같은 오류 반복

### 확인 방법

```bash
TOKEN=...
curl -H "Authorization: Bearer $TOKEN" \
  https://grafana.json-server.win/api/datasources/uid/<UID>/health
# 수정 전: "password authentication failed for user healthhub/grafana_ro"
# 수정 후: "status": "OK"
```

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

- Fixes: [#105](https://github.com/manamana32321/homelab/pull/105), [#107](https://github.com/manamana32321/homelab/pull/107) 부작용

## 🙏 리뷰어에게

- 머지 후 Grafana 파드 롤아웃되고 **양쪽 datasource health 200** 확인 필요
- 이번 이슈가 알려주는 교훈: 머지 체크리스트에 **"Grafana datasource health API 호출"** 넣기 (실제 연결이 아닌 선언만 확인하고 있었음)

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.