### PR TITLE
fix(grafana): amang-prod datasource database를 amang_db로 수정

### DIFF
--- a/k8s/observability/grafana/values.yaml
+++ b/k8s/observability/grafana/values.yaml
@@ -107,7 +107,7 @@ datasources:
         url: postgres-svc.amang-db-production.svc.cluster.local:5432
         user: grafana_ro
         jsonData:
-          database: amang
+          database: amang_db
           user: grafana_ro
           sslmode: disable
           maxOpenConns: 10


### PR DESCRIPTION
## 🚀 작업 내용

[#107](https://github.com/manamana32321/homelab/pull/107)에서 amang-prod datasource의 `database` 필드를 `amang`으로 적었으나, 실제 프로덕션 DB명은 `amang_db` ([apps/api/docker-compose.yml의 POSTGRES_DB 기본값](https://github.com/skku-amang/main/blob/main/apps/api/docker-compose.yml) 및 SealedSecret `POSTGRES_DB` 키와 동일).

[#108](https://github.com/manamana32321/homelab/pull/108)로 env 주입 문제 해결 후 health API 확인 결과:

```
amang-prod: ERROR | Database error: ... database "amang" does not exist
HealthHub: OK
```

## 📸 스크린샷(선택)

N/A

## 🔗 관련 이슈

- Fixes: [#107](https://github.com/manamana32321/homelab/pull/107)

## 🙏 리뷰어에게

머지 후 health API로 확인:
```bash
curl -H "Authorization: Bearer $T" \
  "https://grafana.json-server.win/api/datasources/uid/<UID>/health"
# → {"status":"OK","message":"Database Connection OK"}
```

## ✅ 체크리스트

- [x] conventional commits 형식을 따르는 title을 작성했습니다.
- [x] 적절한 label을 1개 이상 추가했습니다.
- [x] 관련 이슈가 연결되었습니다.