### PR TITLE
chore(observability): remove openclaw blackbox probe target

### DIFF
--- a/k8s/observability/blackbox-exporter/values.yaml
+++ b/k8s/observability/blackbox-exporter/values.yaml
@@ -90,9 +90,6 @@ serviceMonitor:
     - name: home-assistant
       url: http://home-assistant.home-assistant.svc.cluster.local:8080
       module: http_2xx_no_tls
-    - name: openclaw
-      url: http://openclaw.openclaw.svc.cluster.local:18789
-      module: http_2xx_no_tls
     - name: k8s-dashboard
       url: http://headlamp.headlamp.svc.cluster.local
       module: http_2xx_no_tls


### PR DESCRIPTION
## Summary
- PR #111 후속: Blackbox Exporter probe 대상에서 `openclaw` 제거
- 지금 현재도 probe가 돌고 있어서 `probe_success=0` → `EndpointDown` 알림 연속 발사 중

## Change
`k8s/observability/blackbox-exporter/values.yaml` 에서 `- name: openclaw` 엔트리 제거 (3 줄)

## Test plan
- [ ] 머지 후 ArgoCD blackbox-exporter 재배포
- [ ] Prometheus 알림에서 `EndpointDown{target="openclaw"}` 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)