### PR TITLE
feat(windmill): deploy Windmill workflow platform

### DIFF
--- a/cloudflare/dns.tf
+++ b/cloudflare/dns.tf
@@ -110,13 +110,13 @@ resource "cloudflare_record" "otel" {
 }
 
 
-resource "cloudflare_record" "claw" {
+resource "cloudflare_record" "windmill" {
   zone_id = cloudflare_zone.main.id
-  name    = "claw"
+  name    = "windmill"
   type    = "A"
   content = var.default_ip
   proxied = true
-  comment = "OpenClaw AI Agent"
+  comment = "Windmill workflow platform"
 }
 
 resource "cloudflare_record" "longhorn" {

--- a/k8s/argocd/applications/apps/windmill.yaml
+++ b/k8s/argocd/applications/apps/windmill.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: windmill
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://helm.windmill.dev
+      chart: windmill
+      targetRevision: '4.0.134'
+      helm:
+        valueFiles:
+          - $homelab/k8s/windmill/values.yaml
+    - repoURL: https://github.com/manamana32321/homelab
+      targetRevision: main
+      ref: homelab
+
+    - repoURL: https://github.com/manamana32321/homelab
+      targetRevision: main
+      path: k8s/windmill/manifests
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: windmill
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/k8s/authentik/manifests/blueprint-cloudbeaver.yaml
+++ b/k8s/authentik/manifests/blueprint-cloudbeaver.yaml
@@ -159,6 +159,43 @@ data:
           failure_result: false
           negate: false
 
+      # Windmill
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: windmill-provider
+        attrs:
+          name: windmill-provider
+          mode: forward_single
+          external_host: https://windmill.json-server.win
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: windmill
+        attrs:
+          name: Windmill
+          slug: windmill
+          meta_launch_url: https://windmill.json-server.win
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, windmill-provider]]
+          policy_engine_mode: any
+
+      # Windmill: authentik Admins 그룹만 접근 허용
+      - model: authentik_policies.policybinding
+        state: present
+        identifiers:
+          order: 0
+          target: !Find [authentik_core.application, [slug, windmill]]
+          group: !Find [authentik_core.group, [name, authentik Admins]]
+        attrs:
+          enabled: true
+          order: 0
+          timeout: 30
+          failure_result: false
+          negate: false
+
       # Embedded Outpost (모든 forward auth provider를 포함)
       - model: authentik_outposts.outpost
         state: present
@@ -173,3 +210,4 @@ data:
             - !Find [authentik_providers_proxy.proxyprovider, [name, cloudbeaver-provider]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, longhorn-provider]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, health-hub-provider]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, windmill-provider]]

--- a/k8s/authentik/manifests/blueprint-forward-auth.yaml
+++ b/k8s/authentik/manifests/blueprint-forward-auth.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: blueprint-cloudbeaver
+  name: blueprint-forward-auth
   namespace: authentik
 data:
-  cloudbeaver.yaml: |
+  forward-auth.yaml: |
     version: 1
     metadata:
-      name: "CloudBeaver Forward Auth"
+      name: "Forward Auth Providers"
     entries:
       - model: authentik_providers_proxy.proxyprovider
         state: present

--- a/k8s/authentik/values.yaml
+++ b/k8s/authentik/values.yaml
@@ -72,5 +72,5 @@ postgresql:
 
 blueprints:
   configMaps:
-    - blueprint-cloudbeaver
+    - blueprint-forward-auth
     - blueprint-github-source

--- a/k8s/observability/blackbox-exporter/values.yaml
+++ b/k8s/observability/blackbox-exporter/values.yaml
@@ -117,3 +117,6 @@ serviceMonitor:
     - name: sme-tour-engine
       url: http://sme-tour-engine.sme-tour.svc.cluster.local/healthz
       module: http_2xx_no_tls
+    - name: windmill
+      url: http://windmill-app.windmill.svc.cluster.local:8000/api/version
+      module: http_2xx_no_tls

--- a/k8s/windmill/manifests/ingress.yaml
+++ b/k8s/windmill/manifests/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: windmill
+  namespace: windmill
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns01
+    traefik.ingress.kubernetes.io/redirect-entry-point: https
+    traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: windmill.json-server.win
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: windmill-app
+                port:
+                  number: 8000
+  tls:
+    - secretName: windmill-tls
+      hosts:
+        - windmill.json-server.win

--- a/k8s/windmill/values.yaml
+++ b/k8s/windmill/values.yaml
@@ -1,0 +1,76 @@
+# Windmill Helm values
+# Chart: windmill-labs/windmill v4.0.134+
+# Docs: https://github.com/windmill-labs/windmill-helm-charts
+
+postgresql:
+  enabled: true
+  resources:
+    limits:
+      memory: "512Mi"
+  auth:
+    postgresUser: postgres
+    # 내부 cluster 통신 전용. 외부 노출 없음 (Service ClusterIP).
+    postgresPassword: "windmill-cluster-internal-2026"
+    database: windmill
+  persistence:
+    enabled: true
+    storageClass: longhorn-ssd
+    accessMode: ReadWriteOnce
+    size: 5Gi
+
+# MinIO 번들 비활성 (필요 시 별도)
+minio:
+  enabled: false
+
+windmill:
+  # Helm이 chart appVersion에서 이미지 tag 자동 선택
+  tag: ""
+  image: ""
+
+  # Replica 최소화 (홈랩 리소스 절약)
+  appReplicas: 1
+  extraReplicas: 0        # LSP/Multiplayer 비활성 — 에디터 부가 기능만, 필수 아님
+
+  databaseUrl: "postgres://postgres:windmill-cluster-internal-2026@windmill-postgresql/windmill?sslmode=disable"
+
+  # 도메인 + 프로토콜
+  baseDomain: "windmill.json-server.win"
+  baseProtocol: "https"
+
+  rustLog: info
+
+  # 기본 worker group 단순화 (3 replicas → 1)
+  workerGroups:
+    - name: "default"
+      controller: "Deployment"
+      replicas: 1
+      terminationGracePeriodSeconds: 300
+      privileged: true
+      podSecurityContext:
+        runAsUser: 0
+        runAsNonRoot: false
+      resources:
+        limits:
+          memory: "1Gi"
+      mode: "worker"
+      extraEnv:
+        - name: HOME
+          value: "/tmp"
+
+    - name: "native"
+      controller: "Deployment"
+      replicas: 1
+      terminationGracePeriodSeconds: 60
+      privileged: false
+      resources:
+        limits:
+          memory: "256Mi"
+      mode: "worker"
+      # native mode: Python/TS inline 실행 (bash 제외) — 가벼운 워크로드
+      extraEnv:
+        - name: HOME
+          value: "/tmp"
+
+# Ingress는 별도 manifest로 관리 (Authentik forward auth 주입 위해)
+ingress:
+  enabled: false


### PR DESCRIPTION
## Summary
OpenClaw 후속 Phase B-2. 학업 자동화(study agent cron jobs)를 Windmill로 이전하기 위한 **인프라 배포**. 스크립트 포팅은 다음 PR.

## 주요 변경
- **신규**: `k8s/windmill/` (values + Ingress), `k8s/argocd/applications/apps/windmill.yaml`
- **Authentik 통합**: blueprint-cloudbeaver.yaml에 Windmill proxy provider 추가, Outpost providers 리스트에 등록. 접근 권한 `authentik Admins` 그룹으로 제한 (longhorn/health-hub와 동일 패턴)
- **Blackbox probe**: windmill target 추가 — `http://windmill-app.windmill.svc.cluster.local:8000/api/version`
- **DNS 정리**: `claw` 레코드 제거 (OpenClaw 폐기), `windmill` 추가

## 구성
| 항목 | 값 |
|---|---|
| Helm chart | `windmill-labs/windmill` v4.0.134 |
| Ingress | `windmill.json-server.win` (proxied=true) |
| PostgreSQL | 번들, Longhorn-SSD 5Gi |
| Worker | default(1) + native(1) |
| 총 RAM | ~2GB |

## 알려진 이슈 (후속 개선)
- **PG password values.yaml 평문** — cluster 내부 전용이고 Service는 ClusterIP라 외부 접근 불가. 하지만 홈랩 repo가 public이라 "Git 노출" 원칙상 바람직하지 않음 → **후속 PR에서 SealedSecret 전환**
- Playwright용 custom worker 이미지 필요 → 스크립트 포팅 PR에서 추가

## Test plan
- [ ] 사용자: `cd cloudflare && terraform plan && terraform apply`
- [ ] ArgoCD `windmill` App Synced + Healthy
- [ ] `kubectl get pods -n windmill` 전부 Running (postgresql, app, worker-default, worker-native)
- [ ] `https://windmill.json-server.win` 접근 → Authentik 로그인 → Windmill UI 로드
- [ ] Blackbox target windmill probe 성공 (prometheus `probe_success{target="windmill"}==1`)
- [ ] 기존 `claw.json-server.win` DNS 응답 없음 (cloudflare apply 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)