### PR TITLE
fix(windmill): correct helm repo URL

### DIFF
--- a/k8s/argocd/applications/apps/windmill.yaml
+++ b/k8s/argocd/applications/apps/windmill.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   sources:
-    - repoURL: https://helm.windmill.dev
+    - repoURL: https://windmill-labs.github.io/windmill-helm-charts/
       chart: windmill
       targetRevision: '4.0.134'
       helm:


### PR DESCRIPTION
## Summary
PR #113에서 Windmill Helm repo URL 환각: \`helm.windmill.dev\`는 존재하지 않는 도메인.
실제 주소는 `https://windmill-labs.github.io/windmill-helm-charts/` (GitHub Pages).

## 증상
ArgoCD sync 시 ComparisonError:
```
failed to fetch chart: ... lookup helm.windmill.dev on 10.43.0.10:53: no such host
```

## Fix
`k8s/argocd/applications/apps/windmill.yaml`의 `repoURL` 교정 (한 줄).

## Test plan
- [ ] 머지 후 ArgoCD windmill App Synced + Healthy
- [ ] `kubectl get pods -n windmill` Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)