### PR TITLE
fix(windmill): bypass Authentik for /api/mcp (MCP client access)

### DIFF
--- a/k8s/windmill/manifests/ingress-mcp.yaml
+++ b/k8s/windmill/manifests/ingress-mcp.yaml
@@ -1,0 +1,32 @@
+# Windmill MCP 엔드포인트용 별도 Ingress.
+# 기존 Windmill Ingress는 Authentik forward auth 적용 (UI 보호).
+# MCP 경로는 token 기반 인증이라 Authentik 우회 필요 — Claude Desktop MCP client가
+# OAuth cookie 없이 Authorization header(or query token)로 접근.
+#
+# 보안: /api/mcp/* 는 Windmill 자체 token 인증 (`?token=...` 또는 Authorization: Bearer).
+# Authentik 이중 방어 → Windmill 단일 방어로 축소되나 token 누출 시 scope 제한.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: windmill-mcp
+  namespace: windmill
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns01
+    traefik.ingress.kubernetes.io/redirect-entry-point: https
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: windmill.json-server.win
+      http:
+        paths:
+          - path: /api/mcp
+            pathType: Prefix
+            backend:
+              service:
+                name: windmill-app
+                port:
+                  number: 8000
+  tls:
+    - secretName: windmill-tls
+      hosts:
+        - windmill.json-server.win


### PR DESCRIPTION
## Summary
Claude Desktop MCP client가 Windmill MCP endpoint 접근 시 Authentik이 막음 (OAuth cookie flow 필요 → MCP token 모델과 불일치). 별도 Ingress로 \`/api/mcp\` 경로만 Authentik 우회.

## 변경
- **신규**: \`k8s/windmill/manifests/ingress-mcp.yaml\`
- Host: \`windmill.json-server.win\`
- Path: \`/api/mcp\` (Prefix)
- middleware annotation 없음 → Authentik 우회
- Traefik이 더 구체적 path 매칭 우선 → 기존 \`/\` Ingress와 공존

## 보안 판단
- \`/api/mcp/*\`는 Windmill 자체 token 인증 필수 (\`?token=\` 또는 Authorization Bearer)
- Authentik 이중 방어 → Windmill 단일 방어로 축소
- 단일 사용자 홈랩 환경 + token scope 제한 가능으로 수용
- 필요 시 후속 PR에서 IP allowlist 추가 고려

## Test plan
- [ ] 머지 후 ArgoCD sync → \`windmill-mcp\` Ingress 생성 확인
- [ ] \`curl https://windmill.json-server.win/api/mcp/w/admins/mcp?token=...\` → 302 redirect 없이 MCP 응답 (SSE 또는 JSON)
- [ ] 기존 \`https://windmill.json-server.win\` (UI) 은 여전히 Authentik 요구

🤖 Generated with [Claude Code](https://claude.com/claude-code)