### PR TITLE
feat(health-hub): set DEFAULT_TIMEZONE=Asia/Seoul on MCP

### DIFF
--- a/k8s/health-hub/manifests/deployment.yaml
+++ b/k8s/health-hub/manifests/deployment.yaml
@@ -83,6 +83,8 @@ spec:
                   key: DB_PASSWORD
             - name: LISTEN_ADDR
               value: ":8081"
+            - name: DEFAULT_TIMEZONE
+              value: Asia/Seoul
             - name: MCP_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- Adds `DEFAULT_TIMEZONE=Asia/Seoul` env to the `mcp` container in the health-hub deployment.
- Pairs with [manamana32321/health-hub#2](https://github.com/manamana32321/health-hub/pull/2), which teaches the MCP server to read this env and use it for `time_bucket` and YYYY-MM-DD parsing.
- **Effect**: MCP tools like `get_steps`, `get_meals`, `get_sleep` now align day boundaries to KST local midnight by default. Callers no longer need to pass `timezone: "Asia/Seoul"` on every tool call.

## Merge order

Either order is safe:
- If this lands first → current image doesn't read `DEFAULT_TIMEZONE`, no-op until image rolls out.
- If the code PR lands first → falls back to UTC until this PR merges.

Likely the code PR merges first (ArgoCD Image Updater picks up the new `:latest`), then this PR flips the default to KST on the pod restart.

## Test plan

- [ ] After both PRs merge + pod reschedule: exec into `health-hub-mcp` pod, verify `printenv DEFAULT_TIMEZONE` shows `Asia/Seoul`.
- [ ] Call `get_steps start_date=2026-04-13 end_date=2026-04-19` without passing `timezone` — expect KST-aligned buckets (today's early-morning data stays in today's bucket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)