### PR TITLE
feat(health-hub): DEFAULT_TIMEZONE=Asia/Seoul on REST server

### DIFF
--- a/k8s/health-hub/manifests/deployment.yaml
+++ b/k8s/health-hub/manifests/deployment.yaml
@@ -41,6 +41,8 @@ spec:
                   key: API_TOKEN
             - name: LISTEN_ADDR
               value: ":8080"
+            - name: DEFAULT_TIMEZONE
+              value: Asia/Seoul
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## Summary

- Adds `DEFAULT_TIMEZONE=Asia/Seoul` to the `server` container (REST API) in the health-hub deployment.
- Pairs with [manamana32321/health-hub#4](https://github.com/manamana32321/health-hub/pull/4), which teaches the REST handlers to read this env for bucket alignment and YYYY-MM-DD parsing.
- Complements [#121](https://github.com/manamana32321/homelab/pull/121) which did the same for the MCP container.

## Effect

The Next.js dashboard (\`/api/v1/metrics\`) now returns KST-midnight-aligned buckets by default, without callers having to pass \`?timezone=Asia/Seoul\` on every request.

## Test plan

- [ ] After both code (#4) and env (this PR) roll out: from the dashboard, \`/steps\` chart's \"4월 13일\" bar should cover KST 00:00 → 24:00, not 09:00 → 09:00.
- [ ] `exec` into `server` container, `printenv DEFAULT_TIMEZONE` → `Asia/Seoul`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)