### PR TITLE
chore(health-hub): force rollout to pick up new MCP image

### DIFF
--- a/k8s/health-hub/manifests/deployment.yaml
+++ b/k8s/health-hub/manifests/deployment.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app: health-hub
+      annotations:
+        homelab.json-server.win/rollout-trigger: "2026-04-19-exercise-type-mapping"
     spec:
       containers:
         - name: health-hub


### PR DESCRIPTION
Quick-fix for the fact that ArgoCD Image Updater isn't writing new digests back into the deployment manifest, so manamana32321/health-hub#6 (exercise type name mapping) hasn't rolled out even though the image is built and sitting on GHCR.

## What this PR does

Adds a trivial pod template annotation. Any change inside \`spec.template\` recomputes the pod template hash, which makes ArgoCD roll the Deployment. The new pod starts with \`pullPolicy: Always\` and picks up the fresh \`:latest\` image.

## Root cause (to track separately)

\`argocd-image-updater.argoproj.io/write-back-method: argocd\` in [k8s/argocd/applications/apps/health-hub.yaml](k8s/argocd/applications/apps/health-hub.yaml) only works when the Application source is Helm or Kustomize — the updater has a place to write parameter overrides. With **raw YAML** under \`path: k8s/health-hub/manifests\`, there's no such place, so Image Updater silently noop's on the write-back step even though it detects the new digest.

Previous code PRs (#2, #4) happened to ride on homelab env-var changes (#121, #122) that coincidentally bumped the pod template, masking this. Code-only PRs like #6 reveal it.

**Proper fix (follow-up issue)**: switch to \`write-back-method: git\` so Image Updater commits the digest pin directly into \`deployment.yaml\`, or refactor the app to Kustomize.

## Test plan

- [ ] After merge + ArgoCD sync + pod restart: call MCP \`get_exercises\` → response contains \`exercise_type_name\` field (e.g. \`\"walking\"\`, \`\"running_treadmill\"\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)