### PR TITLE
fix(health-hub): convert to Kustomize so Image Updater can write digests

### DIFF
--- a/k8s/health-hub/manifests/deployment.yaml
+++ b/k8s/health-hub/manifests/deployment.yaml
@@ -12,8 +12,6 @@ spec:
     metadata:
       labels:
         app: health-hub
-      annotations:
-        homelab.json-server.win/rollout-trigger: "2026-04-19-exercise-type-mapping"
     spec:
       containers:
         - name: health-hub

--- a/k8s/health-hub/manifests/kustomization.yaml
+++ b/k8s/health-hub/manifests/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - sealed-secret.yaml
+  - sealed-secret-backup.yaml
+  - timescaledb-statefulset.yaml
+  - deployment.yaml
+  - dashboard-deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - backup-cronjob.yaml


### PR DESCRIPTION
Closes [#125](https://github.com/manamana32321/homelab/issues/125).

## Root cause (from #125 analysis)

ArgoCD Image Updater with \`write-back-method: argocd\` writes image overrides to **\`spec.source.kustomize.images\`** (for Kustomize sources) or **\`spec.source.helm.parameters\`** (for Helm). With **raw YAML** there is no such slot — the updater detects a new digest, tries to write, and silently drops it.

Prior health-hub PRs ([#121](https://github.com/manamana32321/homelab/pull/121), [#122](https://github.com/manamana32321/homelab/pull/122)) happened to ride on env-var changes that bumped the pod template hash, masking the bug. Code-only [health-hub#6](https://github.com/manamana32321/health-hub/pull/6) exposed it; hot-patched with a manual annotation in [#124](https://github.com/manamana32321/homelab/pull/124).

## Fix

Match the existing [k8s/saemate/kustomization.yaml](k8s/saemate/kustomization.yaml) convention — the only app in this repo that has working auto-rollout. Add a \`kustomization.yaml\` that declares every current manifest as a resource. ArgoCD auto-detects Kustomize when this file is present (no Application change needed), and Image Updater now has a \`kustomize.images\` slot to write into.

## Also in this PR

- Drops the manual \`rollout-trigger\` annotation from [#124](https://github.com/manamana32321/homelab/pull/124). The next code-only rollout will validate whether the real fix works — [health-hub#7](https://github.com/manamana32321/health-hub/pull/7) (dashboard merge today) is conveniently already queued in the build pipeline, so we'll see a clean test within minutes of merging this PR.

## Not included (tracked separately)

- [sme-tour-engine Application](k8s/argocd/applications/apps/sme-tour-engine.yaml) has \`write-back-method: git\` + raw YAML. Since the sme-tour image hasn't been rebuilt since configuration, the bug hasn't surfaced. I'll leave a note on #125 so the next sme-tour image PR doesn't get surprised.

## Test plan

- [x] \`kubectl kustomize k8s/health-hub/manifests/\` renders the full resource set (436 lines, all expected kinds).
- [ ] After merge + ArgoCD sync: dashboard image rollout triggers naturally (PR #7 built a new digest; Image Updater should detect and write it to \`spec.source.kustomize.images\`). Verify dashboard \`/\` and \`/exercise\` pages show \`walking\` / \`running_treadmill\` labels.
- [ ] Leave the next code-only health-hub PR as the real integration test of auto-rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)