### PR TITLE
chore(essentia): bump essentia-api memory limit 512Mi→1Gi

### DIFF
--- a/k8s/essentia/api/deployment.yaml
+++ b/k8s/essentia/api/deployment.yaml
@@ -30,8 +30,8 @@ spec:
                 name: essentia-api-config
           resources:
             requests:
-              memory: 256Mi
+              memory: 384Mi
               cpu: 100m
             limits:
-              memory: 512Mi
+              memory: 1Gi
               cpu: 500m


### PR DESCRIPTION
## Summary

Bump \`k8s/essentia/api/deployment.yaml\` resources:
- requests: memory 256Mi → 384Mi
- limits: memory 512Mi → 1Gi

## Why

Bulk archive of 2주차 (file + 3 videos) OOMKilled the pod mid-upload. Root-cause fix is in [essentia-edu/essentia#30](https://github.com/essentia-edu/essentia/pull/30) (streaming upload via \`lib-storage\`) — this PR is defence in depth for inference / processor bursts.

## Test plan

- [ ] ArgoCD syncs new limit
- [ ] Pod restarts with new spec, steady-state memory still ~65-180Mi

🤖 Generated with [Claude Code](https://claude.com/claude-code)