### PR TITLE
fix(argocd): grant image-updater secrets:get/list via extraObjects

### DIFF
--- a/k8s/argocd/applications/infra/argocd-image-updater.yaml
+++ b/k8s/argocd/applications/infra/argocd-image-updater.yaml
@@ -20,6 +20,38 @@ spec:
               prefix: ghcr.io
               api_url: https://ghcr.io
               default: true
+
+        # Image Updater가 각 앱 namespace의 imagePullSecret을 읽어
+        # GHCR private registry 질의 시 credential로 사용할 수 있도록
+        # secrets get/list 권한 부여. Helm chart 기본 ClusterRole은
+        # applications + events만 허용하여 private 이미지 auto-update 실패함.
+        #
+        # 영향 범위: loop, essentia, health-hub, sme-tour-engine 등
+        # imagePullSecret(pullsecret:...) annotation 쓰는 모든 app.
+        #
+        # Scope: 전체 namespace의 secret get/list — Image Updater가 이미
+        # Application 수정 권한을 가지므로 추가 보안 영향 미미.
+        extraObjects:
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRole
+            metadata:
+              name: argocd-image-updater-secrets-read
+            rules:
+              - apiGroups: [""]
+                resources: ["secrets"]
+                verbs: ["get", "list"]
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+              name: argocd-image-updater-secrets-read
+            subjects:
+              - kind: ServiceAccount
+                name: argocd-image-updater
+                namespace: argocd
+            roleRef:
+              kind: ClusterRole
+              name: argocd-image-updater-secrets-read
+              apiGroup: rbac.authorization.k8s.io
   destination:
     namespace: argocd
     server: https://kubernetes.default.svc


### PR DESCRIPTION
## Summary

homelab 전체 private GHCR 앱의 Image Updater가 **1년+ auto-update 불가 상태**였음. 오늘 Loop 배포 중 발견.

### 증상

```
level=warning msg="Could not fetch credentials: could not fetch secret
'ghcr-pull' from namespace 'loop' (field: '.dockerconfigjson'): secrets
\"ghcr-pull\" is forbidden: User \"system:serviceaccount:argocd:argocd-image-updater\"
cannot get resource \"secrets\" in API group \"\" in the namespace \"loop\""
```

동일 에러를 **loop · essentia · health-hub 전부**에서 확인. 즉 모든 private 앱 자동 배포는 그동안 수동 rollout에 의존.

### 원인

`argocd-image-updater` Helm chart의 기본 ClusterRole:

```yaml
rules:
  - apiGroups: [""]
    resources: ["events"]
    verbs: ["create"]
  - apiGroups: ["argoproj.io"]
    resources: ["applications"]
    verbs: ["get", "list", "update", "patch"]
```

→ `secrets` 권한 없음. 각 앱 Application이 `pullsecret:<ns>/<name>` annotation으로 imagePullSecret을 재활용하라 지시하지만 실제로 secret을 못 읽음.

### 해결

`extraObjects`로 별도 ClusterRole + ClusterRoleBinding 생성, cluster-wide `secrets: get/list` 부여.

**Scope**: 전체 namespace의 secret get/list.
- Image Updater ServiceAccount는 이미 `applications: update,patch` 권한 보유 (Application spec 변경 가능) → 추가 보안 영향 미미
- 대안 (resourceNames 제한)은 신규 앱 추가마다 rule 갱신 필요 → 유지보수 비용

## 기대 효과

머지·sync 후 Image Updater 로그에서 warning 사라지고 정상 digest 조회 시작. 이후 `:latest` 재push 시 자동 rollout 회복.

현재 영향 받는 앱:
- `loop`
- `essentia`
- `health-hub`
- `sme-tour-engine`
- `argocd-image-updater` app (amang용 ImageUpdater CRD도 포함)

## Test plan

- [ ] PR 머지 후 ArgoCD가 argocd-image-updater app sync
- [ ] `kubectl get clusterrole argocd-image-updater-secrets-read` 존재 확인
- [ ] `kubectl get clusterrolebinding argocd-image-updater-secrets-read` subject/roleRef 확인
- [ ] Image Updater Pod 자동 재기동 후 `kubectl -n argocd logs deploy/argocd-image-updater --tail=50` 에서 warning 사라짐
- [ ] (선택) 테스트 push로 auto-rollout 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)