### PR TITLE
fix(argocd): use extraDeploy (not extraObjects) for image-updater RBAC

### DIFF
--- a/k8s/argocd/applications/infra/argocd-image-updater.yaml
+++ b/k8s/argocd/applications/infra/argocd-image-updater.yaml
@@ -31,7 +31,7 @@ spec:
         #
         # Scope: 전체 namespace의 secret get/list — Image Updater가 이미
         # Application 수정 권한을 가지므로 추가 보안 영향 미미.
-        extraObjects:
+        extraDeploy:
           - apiVersion: rbac.authorization.k8s.io/v1
             kind: ClusterRole
             metadata:


### PR DESCRIPTION
PR #136 의 extraObjects는 argocd-image-updater Helm chart 스키마에 없는 필드라 무시됐음. 올바른 키 extraDeploy로 수정.