### PR TITLE
fix(argocd): image-updater secrets RBAC via separate Application

### DIFF
--- a/k8s/argocd-image-updater-rbac/rbac.yaml
+++ b/k8s/argocd-image-updater-rbac/rbac.yaml
@@ -1,0 +1,32 @@
+# argocd-image-updater에 cluster-wide secrets get/list 권한 부여.
+#
+# 왜 Helm chart 바깥인가: argocd-image-updater Helm chart v0.12.0은
+# rendered output에 임의 리소스를 삽입하는 values 필드(extraObjects / extraDeploy)를
+# 지원하지 않음. 따라서 Helm application과 분리된 별도 Application으로 관리.
+#
+# 왜 필요한가: 각 앱(loop·essentia·health-hub 등)이
+# `argocd-image-updater.argoproj.io/<alias>.pull-secret: pullsecret:<ns>/<secret-name>`
+# annotation으로 imagePullSecret 재활용을 요청하는데, 기본 ClusterRole은
+# applications + events만 허용 → secrets get 실패 → private registry digest 질의 실패.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-image-updater-secrets-read
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-image-updater-secrets-read
+subjects:
+  - kind: ServiceAccount
+    name: argocd-image-updater
+    namespace: argocd
+roleRef:
+  kind: ClusterRole
+  name: argocd-image-updater-secrets-read
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/argocd/applications/infra/argocd-image-updater-rbac.yaml
+++ b/k8s/argocd/applications/infra/argocd-image-updater-rbac.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-image-updater-rbac
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/manamana32321/homelab
+    targetRevision: main
+    path: k8s/argocd-image-updater-rbac
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/argocd/applications/infra/argocd-image-updater.yaml
+++ b/k8s/argocd/applications/infra/argocd-image-updater.yaml
@@ -20,38 +20,9 @@ spec:
               prefix: ghcr.io
               api_url: https://ghcr.io
               default: true
-
-        # Image Updater가 각 앱 namespace의 imagePullSecret을 읽어
-        # GHCR private registry 질의 시 credential로 사용할 수 있도록
-        # secrets get/list 권한 부여. Helm chart 기본 ClusterRole은
-        # applications + events만 허용하여 private 이미지 auto-update 실패함.
-        #
-        # 영향 범위: loop, essentia, health-hub, sme-tour-engine 등
-        # imagePullSecret(pullsecret:...) annotation 쓰는 모든 app.
-        #
-        # Scope: 전체 namespace의 secret get/list — Image Updater가 이미
-        # Application 수정 권한을 가지므로 추가 보안 영향 미미.
-        extraDeploy:
-          - apiVersion: rbac.authorization.k8s.io/v1
-            kind: ClusterRole
-            metadata:
-              name: argocd-image-updater-secrets-read
-            rules:
-              - apiGroups: [""]
-                resources: ["secrets"]
-                verbs: ["get", "list"]
-          - apiVersion: rbac.authorization.k8s.io/v1
-            kind: ClusterRoleBinding
-            metadata:
-              name: argocd-image-updater-secrets-read
-            subjects:
-              - kind: ServiceAccount
-                name: argocd-image-updater
-                namespace: argocd
-            roleRef:
-              kind: ClusterRole
-              name: argocd-image-updater-secrets-read
-              apiGroup: rbac.authorization.k8s.io
+        # 추가 ClusterRole/RoleBinding으로 secrets 권한 부여하는 건
+        # 별도 Application argocd-image-updater-rbac (k8s/argocd-image-updater-rbac/)
+        # 에서 관리. 이 chart는 extraObjects/extraDeploy를 지원하지 않음.
   destination:
     namespace: argocd
     server: https://kubernetes.default.svc


### PR DESCRIPTION
argocd-image-updater Helm chart v0.12.0이 extraObjects/extraDeploy values를 지원하지 않아 PR #136·#138의 시도가 rendered output에 포함되지 않았음. raw manifest + 별도 Application으로 분리.