### PR TITLE
fix(sme-tour-engine): image-list needs :latest tag + unify write-back to argocd

### DIFF
--- a/k8s/argocd/applications/apps/sme-tour-engine.yaml
+++ b/k8s/argocd/applications/apps/sme-tour-engine.yaml
@@ -4,10 +4,10 @@ metadata:
   name: sme-tour-engine
   namespace: argocd
   annotations:
-    argocd-image-updater.argoproj.io/image-list: engine=ghcr.io/manamana32321/sme-tour-engine
+    argocd-image-updater.argoproj.io/image-list: engine=ghcr.io/manamana32321/sme-tour-engine:latest
     argocd-image-updater.argoproj.io/engine.update-strategy: digest
-    argocd-image-updater.argoproj.io/engine.allow-tags: regexp:^latest$
-    argocd-image-updater.argoproj.io/write-back-method: git
+    argocd-image-updater.argoproj.io/engine.force-update: "true"
+    argocd-image-updater.argoproj.io/write-back-method: argocd
 spec:
   project: default
   source:


### PR DESCRIPTION
홈랩 전체 커스텀 GHCR 앱 Image Updater 설정을 argocd write-back + :latest 태그 패턴으로 통일. 앞으로 새 앱은 이 컨벤션 따름.