### PR TITLE
chore(essentia): bump essentia-api memory limit 1Gi→2Gi for STT workload

### DIFF
--- a/k8s/essentia/api/deployment.yaml
+++ b/k8s/essentia/api/deployment.yaml
@@ -30,8 +30,8 @@ spec:
                 name: essentia-api-config
           resources:
             requests:
-              memory: 384Mi
+              memory: 512Mi
               cpu: 100m
             limits:
-              memory: 1Gi
-              cpu: 500m
+              memory: 2Gi
+              cpu: 1000m


### PR DESCRIPTION
ffmpeg OOMKilled at 1Gi on 400MB video transcode despite streaming download. 2Gi gives headroom for bulk STT.