### PR TITLE
feat(loop): add migrate Job (ArgoCD PostSync hook) for auto schema + seed

### DIFF
--- a/k8s/loop/README.md
+++ b/k8s/loop/README.md
@@ -14,43 +14,37 @@ k8s/loop/
 └── web/                              # Next.js — Deployment + Service + Ingress(habits.json-server.win + Authentik)
 ```
 
-## 최초 배포 절차 (수동 단계)
+## 자동 초기화 · 마이그레이션
 
-ArgoCD가 리소스를 배포하면 Postgres만 올라오고 스키마·hypertable·seed는 비어 있음.
-API 이미지에 Prisma CLI/tsx가 devDependency라서 자동 초기화 Job은 별도 PR로 분리 예정.
-첫 배포 시 로컬에서 한 번 다음을 실행:
+`migrate-job.yaml` (ArgoCD PostSync hook)이 sync마다 실행:
+
+1. `prisma migrate deploy` — 미적용 migration 전부 apply (hypertable SQL 포함, Loop#8)
+2. `pnpm db:seed` — roles · domains · habits · devices upsert
+
+모든 단계 idempotent. sync 반복 실행 안전.
+
+### 수동 재실행
 
 ```bash
-# 1. 로컬에서 클러스터로 port-forward
-kubectl -n loop port-forward svc/loop-postgres 5433:5432 &
+kubectl -n loop delete job loop-migrate
+kubectl -n argocd patch app loop --type merge -p '{"operation":{"sync":{}}}'
+# 또는 템플릿에서 새 Job 생성
+kubectl -n loop create job --from=job/loop-migrate loop-migrate-$(date +%s)
+```
 
-# 2. Loop 레포 루트에서
-cd ~/loop-worktrees/main
+### Job 로그 확인
 
-# 3. DB URL 지정 (패스워드는 loop-api-secrets SealedSecret에서 조회)
-PG_PASS=$(kubectl -n loop get secret loop-api-secrets -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)
-export DATABASE_URL="postgresql://loop:${PG_PASS}@localhost:5433/loop?schema=public"
-
-# 4. Prisma migration
-pnpm --filter @loop/db exec prisma migrate deploy
-
-# 5. TimescaleDB hypertable
-psql "$DATABASE_URL" -f packages/db/prisma/post-migration/01_timescale_hypertable.sql
-
-# 6. Seed
-pnpm db:seed
-
-# 7. 정리
-kill %1
-unset DATABASE_URL
+```bash
+kubectl -n loop logs job/loop-migrate --all-containers --tail=200
 ```
 
 ## 스키마 변경 시
 
-1. Loop 레포에서 `prisma/schema.prisma` 수정 → `prisma migrate dev --name <desc>` 로 migration 생성·커밋
-2. CI/CD가 api 이미지 재빌드
-3. ArgoCD Image Updater가 새 digest 감지 → 배포
-4. (현재는 수동) 위 port-forward + `prisma migrate deploy` 로 DB 스키마 적용
+1. Loop 레포 워크트리에서 `prisma/schema.prisma` 수정
+2. `pnpm --filter @loop/db exec prisma migrate dev --name <desc>` → migration 생성·커밋·Loop PR 셀프 머지
+3. GitHub Actions build-push → GHCR에 새 이미지
+4. ArgoCD Image Updater가 digest 감지 → Deployment + Job 둘 다 새 이미지
+5. Job 실행 → `prisma migrate deploy` 가 신규 migration 자동 apply
 
 ## TLS / 접근
 

--- a/k8s/loop/kustomization.yaml
+++ b/k8s/loop/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - web/service.yaml
   - web/deployment.yaml
   - web/ingress.yaml
+  - migrate-job.yaml

--- a/k8s/loop/migrate-job.yaml
+++ b/k8s/loop/migrate-job.yaml
@@ -1,0 +1,76 @@
+# Loop 자동 초기화·마이그레이션 Job
+#
+# ArgoCD PostSync hook으로 sync마다 실행.
+# 전부 idempotent — prisma migrate deploy는 적용 안 된 migration만 실행,
+# hypertable SQL은 IF NOT EXISTS, seed는 upsert.
+#
+# 수동 재실행: kubectl -n loop delete job loop-migrate && kubectl -n argocd patch app loop ...
+# 또는: kubectl -n loop create job --from=job/loop-migrate loop-migrate-$(date +%s)
+#
+# Migrate Job은 Image Updater가 spec.source.kustomize.images 에 쓴
+# digest 오버라이드를 받으려면 ArgoCD가 Job 템플릿을 재생성할 때 같이
+# kustomize image transformer를 적용하는 kind여야. Deployment와 동일
+# 이미지 경로(ghcr.io/manamana32321/loop-api)를 쓰므로 kustomize image
+# 치환이 자동 적용됨.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: loop-migrate
+  namespace: loop
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+    app: loop-migrate
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app: loop-migrate
+    spec:
+      restartPolicy: OnFailure
+      imagePullSecrets:
+        - name: ghcr-pull
+      initContainers:
+        - name: wait-for-db
+          image: timescale/timescaledb:2.17.2-pg17
+          command:
+            - sh
+            - -c
+            - |
+              echo "waiting for loop-postgres..."
+              until pg_isready -h loop-postgres -U loop -d loop; do sleep 2; done
+              echo "postgres ready"
+          resources:
+            requests: { cpu: 50m, memory: 32Mi }
+            limits:   { cpu: 200m, memory: 128Mi }
+      containers:
+        - name: migrate
+          image: ghcr.io/manamana32321/loop-api:latest
+          imagePullPolicy: Always
+          workingDir: /app
+          envFrom:
+            - secretRef:
+                name: loop-api-secrets
+          command:
+            - sh
+            - -c
+            - |
+              set -eo pipefail
+
+              echo "--- 1) prisma migrate deploy (schema + hypertable 통합 migration) ---"
+              pnpm --filter @loop/db exec prisma migrate deploy
+
+              echo "--- 2) seed (roles / domains / user habits & devices, upsert) ---"
+              pnpm --filter @loop/db run seed
+
+              echo "--- migrate complete ---"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi


### PR DESCRIPTION
## Summary

Loop 자동 초기화·마이그레이션 Job. Loop#8(hypertable을 Prisma migration으로 통합)과 짝.

### 동작

1. `argocd.argoproj.io/hook: PostSync` — ArgoCD sync 끝날 때마다 실행
2. initContainer로 `loop-postgres` ready 대기
3. main container: `loop-api` 이미지에서 `prisma migrate deploy` + `pnpm db:seed`
4. 24h 뒤 `ttlSecondsAfterFinished`로 자동 정리

### 왜 loop-api 이미지?

Loop#5 (Dockerfile 전체 workspace 복사)로 runtime 이미지에 이미 Prisma CLI(`node_modules/.bin/prisma`)와 `tsx`가 포함됨. 별도 migrate 전용 이미지 불필요.

### Image Updater 연동

Application spec의 `spec.source.kustomize.images`에 Image Updater가 쓰는 digest override가 kustomize image transformer로 **Deployment·Job 모두에** 적용됨 (kustomize 동작 특성). 즉 Job도 항상 최신 digest로 실행.

### Idempotency

- `prisma migrate deploy` — 미적용 migration만 apply
- hypertable SQL — `IF NOT EXISTS` / `if_not_exists => TRUE`
- `seed.ts` — 모든 레코드 upsert

반복 실행 안전. 여러 번 돌아도 DB 상태 변화 없음.

## Test plan

- [ ] PR 머지 후 ArgoCD가 loop Application sync → Job 생성
- [ ] `kubectl -n loop logs job/loop-migrate` 에서:
  - `prisma migrate deploy` 성공 (이미 다 apply됐으면 "No pending migrations")
  - `seed` 성공 (roles 11 · domains 6 · habits 12 · devices 18 · habit_devices 25 upsert)
- [ ] 기존 DB 데이터 변화 없음 (upsert라 무영향)
- [ ] 다음 스키마 변경 PR 머지 시 자동 apply되는지 (별도 향후 PR로 검증)

## 후속 효과

스키마 변경 시 지금까지 필요했던 수동 `kubectl port-forward` + `prisma migrate deploy` 절차 전부 삭제. PR 머지 → 이미지 빌드 → ArgoCD sync → Job 자동 마이그레이션.

🤖 Generated with [Claude Code](https://claude.com/claude-code)