### PR TITLE
fix(essentia): image-updater RBAC + pin api digest

### DIFF
--- a/k8s/essentia/api/image-updater-rbac.yaml
+++ b/k8s/essentia/api/image-updater-rbac.yaml
@@ -1,0 +1,34 @@
+---
+# Grants argocd-image-updater (SA in argocd ns) read access to the
+# ghcr-essentia pull secret in this namespace, so it can fetch
+# registry credentials and pick up new digests. Without this, the
+# updater logs "could not fetch secret 'ghcr-essentia'" every cycle
+# and the Application's Image Updater annotations silently don't
+# trigger rolling updates.
+#
+# Scope is the minimum viable: get-only on one named secret.
+# See: https://github.com/manamana32321/homelab/issues/131
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: image-updater-pullsecret
+  namespace: essentia
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["ghcr-essentia"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: image-updater-pullsecret
+  namespace: essentia
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: image-updater-pullsecret
+subjects:
+  - kind: ServiceAccount
+    name: argocd-image-updater
+    namespace: argocd

--- a/k8s/essentia/kustomization.yaml
+++ b/k8s/essentia/kustomization.yaml
@@ -7,8 +7,17 @@ resources:
   - api/ingress.yaml
   - api/sealed-secret.yaml
   - api/service.yaml
+  - api/image-updater-rbac.yaml
   - postgres/postgres.yaml
   - web/deployment.yaml
   - web/ingress.yaml
   - web/service.yaml
   - ghcr-pull-sealed-secret.yaml
+
+# argocd-image-updater writes the resolved digest back here on each
+# successful pull-metadata cycle (post homelab#131 RBAC fix). This way
+# every ArgoCD sync produces the same canonical image ref instead of
+# flapping between :latest and whatever digest kubelet happened to pull.
+images:
+  - name: ghcr.io/essentia-edu/api
+    digest: sha256:e74b091cdfda2e593e41422215930fdbac3c3ff9925f389b64d3d8bf08846e00


### PR DESCRIPTION
Unblocks PR #39 rollout. Also closes [homelab#131](https://github.com/manamana32321/homelab/issues/131) (image-updater can't read pull secret).