### PR TITLE
feat(sme-tour-engine): move k8s manifests to homelab (SSOT)

### DIFF
--- a/k8s/argocd/applications/apps/sme-tour-engine.yaml
+++ b/k8s/argocd/applications/apps/sme-tour-engine.yaml
@@ -11,9 +11,9 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/manamana32321/sme-tour
+    repoURL: https://github.com/manamana32321/homelab
     targetRevision: main
-    path: k8s
+    path: k8s/sme-tour-engine
   destination:
     server: https://kubernetes.default.svc
     namespace: sme-tour

--- a/k8s/sme-tour-engine/deployment.yaml
+++ b/k8s/sme-tour-engine/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sme-tour-engine
+  namespace: sme-tour
+  labels:
+    app: sme-tour-engine
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sme-tour-engine
+  template:
+    metadata:
+      labels:
+        app: sme-tour-engine
+    spec:
+      containers:
+        - name: engine
+          image: ghcr.io/manamana32321/sme-tour-engine:latest
+          ports:
+            - containerPort: 8000
+          env:
+            - name: CORS_ALLOWED_ORIGINS
+              value: "https://sme-tour.json-server.win,https://*.vercel.app,http://localhost:3000"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi

--- a/k8s/sme-tour-engine/ingress.yaml
+++ b/k8s/sme-tour-engine/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sme-tour-engine
+  namespace: sme-tour
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns01
+    traefik.ingress.kubernetes.io/redirect-entry-point: https
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - api.sme-tour.json-server.win
+      secretName: sme-tour-engine-tls
+  rules:
+    - host: api.sme-tour.json-server.win
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sme-tour-engine
+                port:
+                  number: 80

--- a/k8s/sme-tour-engine/kustomization.yaml
+++ b/k8s/sme-tour-engine/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/k8s/sme-tour-engine/namespace.yaml
+++ b/k8s/sme-tour-engine/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sme-tour

--- a/k8s/sme-tour-engine/service.yaml
+++ b/k8s/sme-tour-engine/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sme-tour-engine
+  namespace: sme-tour
+spec:
+  selector:
+    app: sme-tour-engine
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP


### PR DESCRIPTION
sme-tour 레포의 k8s/ 매니페스트를 homelab/k8s/sme-tour-engine/ 으로 이전. Application source 변경. Follow-up으로 sme-tour 레포 k8s/ 제거 별도 PR.