### PR TITLE
feat(vercel): Terraform IaC for sme-tour

### DIFF
--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -4,6 +4,10 @@ export NOTION_TOKEN=""
 # Cloudflare API Token (for Terraform)
 export TF_VAR_cloudflare_api_token=""
 
+# Vercel API Token (for Terraform — vercel/ 디렉토리)
+# https://vercel.com/account/tokens → Create Token → Full Account scope
+export TF_VAR_vercel_api_token=""
+
 # Default IP for A records (dynamic IP)
 export TF_VAR_default_ip=""
 

--- a/vercel/README.md
+++ b/vercel/README.md
@@ -1,0 +1,76 @@
+# Vercel — Terraform IaC
+
+homelab에서 관리하는 Vercel 리소스. `cloudflare/`, `aws/` 패턴 동일.
+
+## 관리 대상
+
+| 리소스 | scope | 비고 |
+|---|---|---|
+| `vercel_project.sme_tour` | Amang team (`test-576d510a`) | 종합설계 한시적, 학기 후 destroy |
+
+## 사전 요구
+
+1. Vercel API token 발급
+   - https://vercel.com/account/tokens → Create Token
+   - Scope: **Full Account** (Amang team 포함 전체)
+   - Expiration: 90일 권장 (과제 기간 충분)
+2. `.envrc.local` 에 추가:
+   ```bash
+   export TF_VAR_vercel_api_token="<token>"
+   ```
+3. `direnv allow`
+
+## 최초 셋업 (import 1회)
+
+```bash
+cd vercel
+terraform init
+
+# 기존 Vercel 리소스를 Terraform state로 편입
+terraform import vercel_project.sme_tour prj_AM3ftVU9rEv1rhdfpENy4T8l9bDq
+terraform import \
+  vercel_project_environment_variable.sme_tour_api_base \
+  prj_AM3ftVU9rEv1rhdfpENy4T8l9bDq/14squVanlmQYCB2V
+
+# 변경 없어야 정상. 변경 뜨면 코드 조정 후 커밋
+terraform plan
+```
+
+Import 후엔 `terraform plan/apply` 정상 사용.
+
+## 일상 운영
+
+```bash
+terraform plan   # drift 체크
+terraform apply  # 변경 적용 (CLAUDE.md 규칙: -auto-approve 금지)
+```
+
+## 변경 예시
+
+### env 값 변경
+
+`variables.tf` 의 `sme_tour_api_base` default 수정 또는 tfvars 사용. `terraform apply`.
+
+### custom domain 추가
+
+`sme-tour.tf` 에 아래 block 추가:
+
+```hcl
+resource "vercel_project_domain" "sme_tour_custom" {
+  project_id = vercel_project.sme_tour.id
+  domain     = "tour.example.com"
+}
+```
+
+### 학기 종료 후 제거
+
+```bash
+terraform destroy
+```
+
+Vercel UI에서 수동 삭제하지 말 것 — state 불일치 방지.
+
+## State
+
+- Backend: S3 (`homelab-tfstate-361769566809/vercel/terraform.tfstate`, ap-northeast-2)
+- Credentials: `AWS_PROFILE=homelab` (상위 `.envrc`에서 export됨)

--- a/vercel/outputs.tf
+++ b/vercel/outputs.tf
@@ -1,0 +1,9 @@
+output "sme_tour_project_id" {
+  description = "Vercel project ID"
+  value       = vercel_project.sme_tour.id
+}
+
+output "sme_tour_default_url" {
+  description = "Vercel 기본 배포 URL"
+  value       = "https://sme-tour.vercel.app"
+}

--- a/vercel/sme-tour.tf
+++ b/vercel/sme-tour.tf
@@ -1,0 +1,41 @@
+# SME-Tour Vercel 프로젝트 — 종합설계 팀 프로젝트
+#
+# scope: Amang team (Hobby 제약으로 personal 이동 불가, PR #143 이관)
+# lifecycle: 학기 종료 후 `terraform destroy` 로 제거 예정
+#
+# Import 기존 프로젝트 (최초 `terraform apply` 전 1회만):
+#   terraform import \
+#     -var="vercel_api_token=$TF_VAR_vercel_api_token" \
+#     vercel_project.sme_tour \
+#     prj_AM3ftVU9rEv1rhdfpENy4T8l9bDq
+#
+#   terraform import \
+#     -var="vercel_api_token=$TF_VAR_vercel_api_token" \
+#     vercel_project_environment_variable.sme_tour_api_base \
+#     prj_AM3ftVU9rEv1rhdfpENy4T8l9bDq/14squVanlmQYCB2V
+
+resource "vercel_project" "sme_tour" {
+  name      = "sme-tour"
+  framework = "nextjs"
+
+  git_repository = {
+    type              = "github"
+    repo              = "manamana32321/sme-tour"
+    production_branch = "main"
+  }
+
+  # monorepo-ish 구조: docs/engine/frontend/k8s. Next.js는 frontend/ 에만 존재.
+  root_directory = "frontend"
+  node_version   = "24.x"
+
+  # Framework default 따름 (next build / .next / next dev).
+  # build_command / install_command / dev_command / output_directory 모두 null.
+}
+
+resource "vercel_project_environment_variable" "sme_tour_api_base" {
+  project_id = vercel_project.sme_tour.id
+  key        = "NEXT_PUBLIC_API_BASE"
+  value      = var.sme_tour_api_base
+  target     = ["production", "preview"]
+  comment    = "K8s ingress에 배포된 sme-tour-engine API base URL"
+}

--- a/vercel/variables.tf
+++ b/vercel/variables.tf
@@ -1,0 +1,17 @@
+variable "vercel_api_token" {
+  description = "Vercel API token (https://vercel.com/account/tokens). Set in .envrc.local via TF_VAR_vercel_api_token."
+  type        = string
+  sensitive   = true
+}
+
+variable "amang_team_id" {
+  description = "Amang team slug/id. sme-tour는 Vercel Hobby 정책상 personal 이동 불가라 한시적으로 Amang Pro scope에 기거 중."
+  type        = string
+  default     = "team_aDiKenl6xun665nVWV49POd4"
+}
+
+variable "sme_tour_api_base" {
+  description = "Public API base URL injected into sme-tour Next.js frontend as NEXT_PUBLIC_API_BASE. K8s ingress에 배포된 sme-tour-engine."
+  type        = string
+  default     = "https://api.sme-tour.json-server.win"
+}

--- a/vercel/versions.tf
+++ b/vercel/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 2.0"
+    }
+  }
+
+  # S3 backend — 기존 homelab-tfstate bucket 재사용
+  # credentials: AWS_PROFILE=homelab (.envrc에서 설정)
+  backend "s3" {
+    bucket = "homelab-tfstate-361769566809"
+    key    = "vercel/terraform.tfstate"
+    region = "ap-northeast-2"
+  }
+}
+
+provider "vercel" {
+  api_token = var.vercel_api_token
+  team      = var.amang_team_id
+}


### PR DESCRIPTION
## Summary

homelab 선언적 관리 원칙 적용. Vercel 프로젝트·env·settings 전부 Terraform 관리로 편입. sme-tour (PR manamana32321/sme-tour#22) 관측성 패키지 PR과 한 세트.

## 구조

| 파일 | 역할 |
|---|---|
| `vercel/versions.tf` | `vercel/vercel ~> 2.0` provider + S3 backend |
| `vercel/variables.tf` | API token (sensitive) + team_id + api_base default |
| `vercel/sme-tour.tf` | `vercel_project` + `vercel_project_environment_variable` |
| `vercel/outputs.tf` | project ID · 기본 URL |
| `vercel/README.md` | import 절차 + 일상 운영 + destroy 가이드 |

## 관리 대상

- **vercel_project.sme_tour** — framework=nextjs, root_directory=frontend, node=24.x, git integration
- **vercel_project_environment_variable.sme_tour_api_base** — `NEXT_PUBLIC_API_BASE` for production+preview

## 사용자가 해야 할 것 (머지 후)

1. **Vercel API token** 발급: https://vercel.com/account/tokens → Full Account scope
2. `.envrc.local` 에 `TF_VAR_vercel_api_token` 추가 → `direnv allow`
3. `terraform init` + 기존 리소스 import (README 명령 2줄)
4. `terraform plan` — 변경 없음 확인
5. 이후 변경은 `terraform apply`로

## 설계 노트

- **state key 분리**: `vercel/terraform.tfstate` — cloudflare/aws와 독립 lock
- **단일 env resource** 선택: env 1개라 가독성·refactor 쉬움. 늘어나면 `..._variables` 복수 resource로 migrate
- **scope 한시성**: sme-tour는 Amang team 기거 (Vercel Hobby 제약). 학기 종료 시 `terraform destroy` 예정

## 관련 PR

- manamana32321/sme-tour#22 — `@vercel/analytics` + `@vercel/speed-insights` 추가 (런타임 observability)
- 이 PR — 선언적 관리 (configuration observability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)