### PR TITLE
feat(coral): node-exporter + critical alerting

### DIFF
--- a/coral/monitoring/docker-compose.yml
+++ b/coral/monitoring/docker-compose.yml
@@ -10,6 +10,22 @@ services:
     command:
       - --config.file=/config/blackbox.yml
 
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: node-exporter
+    restart: unless-stopped
+    pid: host
+    network_mode: host
+    command:
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/host/root
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/host/root:ro,rslave
+
   prometheus:
     image: prom/prometheus:v3.4.0
     container_name: prometheus

--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -126,3 +126,33 @@ spec:
           annotations:
             summary: "High memory: {{ $labels.instance }}"
             description: "Memory usage on {{ $labels.instance }} is {{ $value | humanizePercentage }}."
+
+    # Coral Dev Board (K3s 외부, standalone Docker). 외부 관측점이므로 다운 시 critical
+    - name: coral
+      rules:
+        - alert: CoralExternalProbeDown
+          expr: up{job="coral-blackbox-http"} == 0
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "외부 관측점 coral 다운"
+            description: "coral-1 blackbox-exporter 2분 이상 응답 없음. 외부 경로 (DNS/Cloudflare/ingress) 시야 손실. host 점검 필요."
+
+        - alert: CoralHighTemp
+          expr: node_hwmon_temp_celsius{instance="coral-1"} > 75
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Coral CPU 온도 {{ $value }}°C"
+            description: "coral-1 CPU 온도 5분 이상 75°C 초과. i.MX8MQ thermal throttle 임박."
+
+        - alert: CoralLoadHigh
+          expr: node_load5{instance="coral-1"} > 4
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Coral 부하 {{ $value | printf \"%.1f\" }}"
+            description: "coral-1 5분 평균 load가 10분 이상 4 초과 (4-core 포화)."

--- a/k8s/observability/prometheus/values.yaml
+++ b/k8s/observability/prometheus/values.yaml
@@ -85,6 +85,14 @@ prometheus:
           - target_label: __address__
             replacement: 192.168.0.44:9115
 
+      # Coral Dev Board host metrics (CPU/load/temp/memory). K3s 외부 노드라 직접 scrape
+      - job_name: coral-node
+        static_configs:
+          - targets: [192.168.0.44:9100]
+            labels:
+              source: coral
+              instance: coral-1
+
   ingress:
     enabled: true
     hosts:


### PR DESCRIPTION
## Summary
- Coral Dev Board에 `prom/node-exporter:v1.8.2` 추가 (CPU 온도/load/메모리 시계열)
- K8s Prometheus가 `192.168.0.44:9100` 직접 scrape (`coral-node` job, `source=coral`)
- Coral 전용 알림 그룹 신설 — `CoralExternalProbeDown` (critical), `CoralHighTemp` / `CoralLoadHigh` (warning)

## Motivation
2026-04-21 07:11 KST coral-1이 4일 15시간 다운됐던 사건의 사후 대응.

- 알림 측: \`TargetDown\` (warning)만 fire되어 4시간 간격 ~28번 telegram 갔지만 인지 못함 → 인프라 외부 관측점 다운은 **critical로 분리**해 우선순위 높임.
- 분석 측: 다운 직전 호스트 메트릭 부재로 freeze 원인이 power loss / hard freeze / thermal 중 어느 쪽인지 사후 구분 불가능 → node_exporter로 시계열 보존.

## Changes

| 파일 | 변경 |
|---|---|
| [coral/monitoring/docker-compose.yml](coral/monitoring/docker-compose.yml) | \`node-exporter\` 서비스 추가. \`pid: host\`, \`network_mode: host\`, \`/proc\`/\`/sys\`/\`/\` mount. ARM64 multi-arch image. |
| [k8s/observability/prometheus/values.yaml](k8s/observability/prometheus/values.yaml) | \`additionalScrapeConfigs\`에 \`coral-node\` job (\`source=coral\`, \`instance=coral-1\`) 추가. |
| [k8s/observability/prometheus/manifests/alert-rules.yaml](k8s/observability/prometheus/manifests/alert-rules.yaml) | \`coral\` 그룹 신설: \`CoralExternalProbeDown\` (critical, 2m / \`up{job=\"coral-blackbox-http\"}==0\`), \`CoralHighTemp\` (warning, 75°C/5m), \`CoralLoadHigh\` (warning, \`node_load5\`>4/10m). |

## Operational Notes (이 PR 외 추가 적용분)
Coral 자체에 SSH로 별도 적용 완료 (declarative 관리는 추후 ansible/chezmoi 도입과 함께):

- \`/etc/systemd/system.conf\`에 \`RuntimeWatchdogSec=30s\` + \`RebootWatchdogSec=10min\` — i.MX2 hardware watchdog 60s timeout 활성화. 이전엔 \`#RuntimeWatchdogSec=0\` (default = ping 안 함) 상태라 사실상 dead stick이었음. 이제 freeze 시 60s 안에 자동 reboot.
- \`/var/log/journal/\` 디렉토리 생성 → systemd-journald **persistent** 활성화. 다음 freeze 직전 부팅 로그 보존.

## Test Plan
- [ ] PR 머지 후 [coral-deploy.yaml](.github/workflows/coral-deploy.yaml) workflow가 self-hosted runner에서 \`coral/monitoring/\` 재배포 → \`docker ps\`에 \`node-exporter\` 컨테이너 등장 확인 (KST: \`ssh mendel@192.168.0.44 'docker ps --format \"{{.Names}}\"'\`)
- [ ] \`curl -s http://192.168.0.44:9100/metrics | grep node_hwmon_temp\` 응답 확인
- [ ] ArgoCD prometheus app sync 후 Prometheus targets 페이지에서 \`coral-node\` UP 확인
- [ ] Grafana Explore에서 \`node_hwmon_temp_celsius{instance=\"coral-1\"}\` 시계열 노출 확인
- [ ] Prometheus alerts 페이지에서 \`CoralExternalProbeDown\` INACTIVE 확인 (coral 살아있으므로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)