### PR TITLE
fix(coral): use node_thermal_zone_temp for CoralHighTemp alert

### DIFF
--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -140,7 +140,8 @@ spec:
             description: "coral-1 blackbox-exporter 2분 이상 응답 없음. 외부 경로 (DNS/Cloudflare/ingress) 시야 손실. host 점검 필요."
 
         - alert: CoralHighTemp
-          expr: node_hwmon_temp_celsius{instance="coral-1"} > 75
+          # i.MX8MQ는 hwmon 미사용 → thermal_zone 메트릭으로 노출 (type=cpu-thermal)
+          expr: node_thermal_zone_temp{instance="coral-1",type="cpu-thermal"} > 75
           for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary
[#158](https://github.com/manamana32321/homelab/pull/158)에서 추가한 \`CoralHighTemp\` alert이 dead rule이었던 버그 수정.

## Root cause
\`node_hwmon_temp_celsius\`로 작성했으나 coral-1의 i.MX8MQ SoC는 **hwmon 드라이버를 사용하지 않음**. CPU 온도는 \`thermal_zone\` 드라이버로 노출:

\`\`\`
node_thermal_zone_temp{instance="coral-1", type="cpu-thermal", zone="0"} 64
\`\`\`

기존 expr \`node_hwmon_temp_celsius{instance=\"coral-1\"} > 75\`는 매칭되는 시계열이 없어 75°C 초과해도 영원히 fire 안 됨.

## Fix
\`node_thermal_zone_temp{instance=\"coral-1\",type=\"cpu-thermal\"} > 75\`로 변경. \`type\` 라벨 추가는 다른 thermal zone(있다면)과 명확히 구분하기 위함.

## Why this slipped
PR #158 단계에서 메트릭 노출 형식을 사전 검증 안 했음 — server-grade x86은 hwmon이 표준이지만 ARM SoC는 thermal_zone이 일반적. 다음 alert 룰 추가 시엔 \`curl :9100/metrics | grep <metric>\` 1회 검증 단계를 PR 전 체크리스트로.

## Test Plan
- [ ] ArgoCD prometheus app sync 후 Prometheus alerts 페이지에서 \`CoralHighTemp\` INACTIVE 등장 확인 (현재 64°C, threshold 75°C)
- [ ] 임시로 threshold를 60°C로 낮춰서 fire 동작 검증할지 — 별도 임시 작업이라 PR 머지 후 운영 중 자연 검증 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)