### PR TITLE
fix(alerts): relax NodeDiskAlmostFull to 90% SSD-only

### DIFF
--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -50,14 +50,23 @@ spec:
             description: "PVC {{ $labels.persistentvolumeclaim }} in {{ $labels.namespace }} is {{ $value | humanizePercentage }} full."
 
         - alert: NodeDiskAlmostFull
-          # SSD(`/`) 만 알림. HDD(`/mnt/hdd-*`)는 미디어/텔레메트리 의도적 누적이라 제외.
-          # 임계치 90%: Longhorn replica sparse 누적은 Trim Filesystem으로 회수 가능 → 늦게 알려도 무방.
+          # SSD(`/`): 90% — Longhorn replica sparse 누적은 Trim Filesystem으로 회수 가능, 늦게 알려도 무방.
           expr: (1 - node_filesystem_avail_bytes{fstype=~"ext4|xfs",mountpoint!~"/mnt/hdd-.*"} / node_filesystem_size_bytes{fstype=~"ext4|xfs",mountpoint!~"/mnt/hdd-.*"}) > 0.9
           for: 5m
           labels:
             severity: warning
           annotations:
             summary: "Disk almost full: {{ $labels.instance }} {{ $labels.mountpoint }}"
+            description: "{{ $labels.mountpoint }} on {{ $labels.instance }} is {{ $value | humanizePercentage }} full."
+
+        - alert: HDDAlmostFull
+          # HDD(`/mnt/hdd-*`): 75% — 미디어 누적이라 회수 불가, 일찍 경고해 정리/확장 시간 확보.
+          expr: (1 - node_filesystem_avail_bytes{fstype=~"ext4|xfs",mountpoint=~"/mnt/hdd-.*"} / node_filesystem_size_bytes{fstype=~"ext4|xfs",mountpoint=~"/mnt/hdd-.*"}) > 0.75
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "HDD almost full: {{ $labels.instance }} {{ $labels.mountpoint }}"
             description: "{{ $labels.mountpoint }} on {{ $labels.instance }} is {{ $value | humanizePercentage }} full."
 
     # SMART 디스크 건강 알림 (ATA HDD 특화 — NVMe 기본 알림은 smartctl-exporter chart에 내장)

--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -50,7 +50,9 @@ spec:
             description: "PVC {{ $labels.persistentvolumeclaim }} in {{ $labels.namespace }} is {{ $value | humanizePercentage }} full."
 
         - alert: NodeDiskAlmostFull
-          expr: (1 - node_filesystem_avail_bytes{fstype=~"ext4|xfs"} / node_filesystem_size_bytes{fstype=~"ext4|xfs"}) > 0.75
+          # SSD(`/`) 만 알림. HDD(`/mnt/hdd-*`)는 미디어/텔레메트리 의도적 누적이라 제외.
+          # 임계치 90%: Longhorn replica sparse 누적은 Trim Filesystem으로 회수 가능 → 늦게 알려도 무방.
+          expr: (1 - node_filesystem_avail_bytes{fstype=~"ext4|xfs",mountpoint!~"/mnt/hdd-.*"} / node_filesystem_size_bytes{fstype=~"ext4|xfs",mountpoint!~"/mnt/hdd-.*"}) > 0.9
           for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary
- `NodeDiskAlmostFull` 알림 임계치 75% → **90%**
- HDD mountpoint(`/mnt/hdd-*`) 제외 — 미디어/텔레메트리 의도적 누적이라 알림 노이즈
- SSD(`/`)만 대상

## Why
- 2026-04-26 server-2 92% 알림 발생 → Prometheus volume sparse 누적이 원인
- Longhorn Trim Filesystem으로 11.5GiB 즉시 회수 → 81% 복귀
- 75% 임계치는 회수 가능한 Longhorn sparse를 너무 이르게 경고. 90%부터 봐도 운영 여유 충분
- HDD는 미디어 저장 용도라 채워지는 게 정상 — 별도 룰 필요 시 후속

## Test plan
- [ ] ArgoCD sync 후 Prometheus rule 반영 확인 (`prometheus.json-server.win` rules 페이지)
- [ ] 현재 firing 중인 server-1 76.9%, server-2 81% 알림이 모두 해제되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)