### PR TITLE
fix(gbrain): rename PG_URL → GBRAIN_DATABASE_URL

### DIFF
--- a/k8s/gbrain-mcp/manifests/deployment.yaml
+++ b/k8s/gbrain-mcp/manifests/deployment.yaml
@@ -52,13 +52,14 @@ spec:
           imagePullPolicy: Always
           workingDir: /brain
           env:
-            # POSTGRES_PASSWORD must come before PG_URL so $(VAR) interpolation resolves
+            # POSTGRES_PASSWORD must come before GBRAIN_DATABASE_URL so $(VAR) interpolation resolves
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: gbrain-postgres-secrets
                   key: POSTGRES_PASSWORD
-            - name: PG_URL
+            # gbrain reads GBRAIN_DATABASE_URL (or DATABASE_URL) per core/config.ts loadConfig
+            - name: GBRAIN_DATABASE_URL
               value: postgresql://gbrain:$(POSTGRES_PASSWORD)@gbrain-postgres.gbrain.svc.cluster.local:5432/gbrain
             - name: OPENAI_API_KEY
               valueFrom:

--- a/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
+++ b/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
@@ -33,13 +33,14 @@ spec:
                     secretKeyRef:
                       name: gbrain-github-credentials
                       key: GH_PAT
-                # POSTGRES_PASSWORD must come before PG_URL so $(VAR) interpolation resolves
+                # POSTGRES_PASSWORD must come before GBRAIN_DATABASE_URL so $(VAR) interpolation resolves
                 - name: POSTGRES_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: gbrain-postgres-secrets
                       key: POSTGRES_PASSWORD
-                - name: PG_URL
+                # gbrain reads GBRAIN_DATABASE_URL (or DATABASE_URL) per core/config.ts loadConfig
+                - name: GBRAIN_DATABASE_URL
                   value: postgresql://gbrain:$(POSTGRES_PASSWORD)@gbrain-postgres.gbrain.svc.cluster.local:5432/gbrain
                 - name: OPENAI_API_KEY
                   valueFrom:


### PR DESCRIPTION
## Problem

After PR #162 deploy, gbrain-mcp pod fails with:

\`\`\`
No brain configured. Run: gbrain init
\`\`\`

mcp-proxy then crashes with \`McpError: Connection closed\`.

## Root cause

gbrain reads \`GBRAIN_DATABASE_URL\` or \`DATABASE_URL\` per [core/config.ts loadConfig()](https://github.com/garrytan/gbrain/blob/master/src/core/config.ts). Our env var was named \`PG_URL\` which gbrain ignores → falls back to PGLite mode → no DB configured at /brain → exits.

## Fix

Rename \`PG_URL\` → \`GBRAIN_DATABASE_URL\` in:
- \`k8s/gbrain-mcp/manifests/deployment.yaml\`
- \`k8s/gbrain-mcp/manifests/sync-cronjob.yaml\`

Order preserved (POSTGRES_PASSWORD before the URL var for \`\$(VAR)\` interpolation).

## Test plan

- [ ] Merge → ArgoCD sync → pod Running 3/3
- [ ] curl https://gbrain.json-server.win/healthz → 200
- [ ] First CronJob run → page count > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)