### PR TITLE
fix(gbrain-mcp): pass env to gbrain subprocess, fix port flags

### DIFF
--- a/k8s/gbrain-mcp/Dockerfile
+++ b/k8s/gbrain-mcp/Dockerfile
@@ -29,6 +29,10 @@ WORKDIR /brain
 # Default port for mcp-proxy SSE transport
 EXPOSE 8080
 
-# mcp-proxy spawns `gbrain serve` (stdio MCP) and exposes it as SSE on :8080
-# Bearer auth handled by Ingress/sidecar (out of scope here)
-ENTRYPOINT ["mcp-proxy", "--sse-port", "8080", "--sse-host", "0.0.0.0", "--", "gbrain", "serve"]
+# mcp-proxy spawns `gbrain serve` (stdio MCP) and exposes it as SSE on :8080.
+# Bearer auth handled by caddy sidecar (see manifests/caddy-configmap.yaml).
+# --pass-environment: forward GBRAIN_DATABASE_URL etc. to the spawned subprocess
+# (mcp-proxy strips env by default, treating stdio servers as untrusted).
+# --port/--host: deprecated aliases --sse-port/--sse-host bind to port 0 in
+# current mcp-proxy versions; use the canonical flags.
+ENTRYPOINT ["mcp-proxy", "--pass-environment", "--port", "8080", "--host", "0.0.0.0", "--", "gbrain", "serve"]


### PR DESCRIPTION
## Summary

Pod was CrashLooping with `No brain configured. Run: gbrain init` even though `GBRAIN_DATABASE_URL` was correctly set in the container env (verified via `kubectl describe pod`). Manual `gbrain init` with the same secret succeeded; the deployment still failed on restart.

**Root cause**: `mcp-proxy` defaults to `--no-pass-environment` when spawning stdio servers, treating them as untrusted. The `gbrain serve` subprocess therefore got an empty env and fell back to PGLite mode (no DB url found), then failed because no PGLite file exists in the pod.

## Changes

`k8s/gbrain-mcp/Dockerfile` ENTRYPOINT:
- Add `--pass-environment` so the gbrain subprocess inherits `GBRAIN_DATABASE_URL` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`.
- Replace `--sse-port 8080 --sse-host 0.0.0.0` with `--port 8080 --host 0.0.0.0`. The older flags bind to a random port (verified: `Uvicorn running on http://127.0.0.1:43363`) in current mcp-proxy versions; the canonical flags bind correctly.

## Verification (in-cluster)

Reproduced both failure mode and fix with debug pods sharing the same secretKeyRef bindings as the deployment:

| Command | Result |
|---|---|
| `mcp-proxy --sse-port 8080 ... -- gbrain serve` | `No brain configured` → crash |
| `mcp-proxy --pass-environment --sse-port 8080 ...` | gbrain starts but uvicorn binds to random port |
| `mcp-proxy --pass-environment --port 8080 --host 0.0.0.0 ...` | `Uvicorn running on http://0.0.0.0:8080`, `HEAD /sse → 200 OK` |

After merge: `gbrain-mcp build` workflow rebuilds image (paths trigger), Argo CD Image Updater (`update-strategy: digest`) rolls the deployment.

## Test plan

- [ ] CI: `gbrain-mcp build` workflow runs and pushes new `:latest` digest
- [ ] Argo CD Image Updater detects new digest and write-backs
- [ ] `gbrain-mcp` pod becomes Ready (both containers)
- [ ] `gbrain-mcp.gbrain.svc.cluster.local/healthz` returns 200 (caddy)
- [ ] `gbrain-mcp.gbrain.svc.cluster.local/sse` with `Authorization: Bearer ...` opens an SSE stream
- [ ] Blackbox exporter target `gbrain-mcp` flips to up

🤖 Generated with [Claude Code](https://claude.com/claude-code)