### PR TITLE
feat(ci): pre-deploy k8s manifest validation + gitleaks (Phase 1)

### DIFF
--- a/.github/workflows/k8s-validate.yaml
+++ b/.github/workflows/k8s-validate.yaml
@@ -1,0 +1,91 @@
+name: k8s validate
+
+on:
+  pull_request:
+    paths:
+      - "k8s/**"
+      - ".github/workflows/k8s-validate.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "k8s/**"
+      - ".github/workflows/k8s-validate.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install kustomize
+        run: |
+          curl -sLo /tmp/kustomize.tar.gz \
+            "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.5.0/kustomize_v5.5.0_linux_amd64.tar.gz"
+          tar -xzf /tmp/kustomize.tar.gz -C /tmp
+          sudo mv /tmp/kustomize /usr/local/bin/
+          kustomize version
+
+      - name: Install kubeconform
+        run: |
+          curl -sL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
+            | tar -xz -C /tmp
+          sudo mv /tmp/kubeconform /usr/local/bin/
+          kubeconform -v
+
+      - name: Render and validate Kustomize roots
+        run: |
+          set -uo pipefail
+          fail=0
+          shopt -s nullglob
+
+          while IFS= read -r kfile; do
+            dir="$(dirname "$kfile")"
+            echo "::group::kustomize build $dir"
+            if ! kustomize build "$dir" 2>/tmp/kust.err \
+                | kubeconform -strict -ignore-missing-schemas \
+                    -schema-location default \
+                    -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+                    -summary -output text; then
+              echo "::error file=$kfile::Kustomize render or schema validation failed for $dir"
+              cat /tmp/kust.err >&2 || true
+              fail=1
+            fi
+            echo "::endgroup::"
+          done < <(find k8s -name 'kustomization.yaml' | sort)
+
+          exit "$fail"
+
+      - name: Validate Argo CD Application / ApplicationSet manifests
+        run: |
+          set -uo pipefail
+          # Argo CD Applications are raw YAML (not behind a kustomization).
+          # Validate them directly so PRs that only touch app definitions still gate.
+          find k8s/argocd -name '*.yaml' -not -name 'values*.yaml' \
+            -not -name 'kustomization.yaml' \
+            -print0 \
+          | xargs -0 kubeconform -strict -ignore-missing-schemas \
+              -schema-location default \
+              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+              -summary -output text
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    # Manual dispatch would do a full-history scan; skip to avoid noise from
+    # known historical findings tracked separately.
+    if: github.event_name != 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: true


### PR DESCRIPTION
## Summary

Argo CD auto-sync today is the only gate — broken manifests fail at sync time, not in CI. Adds a pre-deploy safety net:

1. **`kustomize build` + `kubeconform`** for every Kustomize root (13 roots)
2. **`kubeconform`** directly on Argo CD Application/ApplicationSet manifests (41 files)
3. **gitleaks** on PR diffs (incremental, not full history)

CRD coverage via [datreeio/CRDs-catalog](https://github.com/datreeio/CRDs-catalog) — SealedSecret, Application, ServiceMonitor, PrometheusRule, Certificate, Middleware, Tenant, etc.

## Local smoke test

- 13/13 Kustomize roots render and validate clean
- 41/41 Argo CD Application/ApplicationSet manifests valid (0 skipped)
- `gitleaks protect --staged` against this PR's diff: 0 leaks

## Out of scope (follow-ups)

- **gitleaks historical findings (6 historical, 1 active)**: PR-mode scanning means the workflow only checks new diffs, so these won't break Phase 1. To address separately:
  - **Active (security debt)**: [k8s/traefik/manifests/middleware-crowdsec.yaml#L15](k8s/traefik/manifests/middleware-crowdsec.yaml) — `crowdsecLapiKey` inlined because Traefik plugin CRDs don't accept `secretKeyRef`. Worth investigating External-Secrets templating or a newer Traefik plugin schema.
  - **Historical** (already removed/replaced with `\$VAR`): grafana values, health-hub datasource, seafile regcred — clean now, only in git history.
- **Phase 2-5** (proposed in chat): `argocd-diff-preview` PR comments, kube-linter, trivy, Renovate, terraform plan in CI

## Why kubeconform vs kubeval

[kubeval is archived](https://github.com/instrumenta/kubeval) (deprecated 2022). kubeconform is the maintained drop-in replacement with self-updating schemas.

## Test plan

- [ ] CI: `validate` job passes (13 Kustomize + 41 Apps)
- [ ] CI: `gitleaks` job passes (no new leaks in this diff)
- [ ] After merge: workflow triggers on subsequent PRs that touch `k8s/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)