### PR TITLE
feat(ci): argocd-diff-preview PR comments (Phase 2)

### DIFF
--- a/.github/workflows/argocd-diff-preview.yaml
+++ b/.github/workflows/argocd-diff-preview.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: Generate Argo CD diff
         run: |
           mkdir -p output
+          # --diff-ignore: filter Helm checksum/* annotations that re-hash on
+          # every render (sha256sum of secret/configmap content is non-stable
+          # across runs and produces phantom diffs on no-op PRs).
           docker run --rm \
             --network=host \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -37,7 +40,8 @@ jobs:
             -v "$(pwd)/output:/output" \
             -e TARGET_BRANCH="refs/pull/${{ github.event.number }}/merge" \
             -e REPO="${{ github.repository }}" \
-            dagandersen/argocd-diff-preview:v0.2.4
+            dagandersen/argocd-diff-preview:v0.2.4 \
+            --diff-ignore 'checksum/.*: [a-f0-9]+'
 
       - name: Upload raw diff as artifact
         if: always()

--- a/.github/workflows/argocd-diff-preview.yaml
+++ b/.github/workflows/argocd-diff-preview.yaml
@@ -1,0 +1,71 @@
+name: argocd diff preview
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "k8s/**"
+      - ".github/workflows/argocd-diff-preview.yaml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          path: pull-request
+
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main
+
+      - name: Generate Argo CD diff
+        run: |
+          mkdir -p output
+          docker run --rm \
+            --network=host \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$(pwd)/main:/base-branch" \
+            -v "$(pwd)/pull-request:/target-branch" \
+            -v "$(pwd)/output:/output" \
+            -e TARGET_BRANCH="refs/pull/${{ github.event.number }}/merge" \
+            -e REPO="${{ github.repository }}" \
+            dagandersen/argocd-diff-preview:v0.2.4
+
+      - name: Upload raw diff as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: argocd-diff
+          path: output/
+          retention-days: 14
+
+      - name: Post diff as PR comment
+        if: always() && hashFiles('output/diff.md') != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # GitHub PR comment cap is 65,536 chars; truncate gracefully.
+          MAX=60000
+          if [ "$(wc -c < output/diff.md)" -gt "$MAX" ]; then
+            head -c "$MAX" output/diff.md > output/diff.trimmed.md
+            printf '\n\n---\n_Diff truncated at %s chars. Full output in workflow artifacts._\n' "$MAX" >> output/diff.trimmed.md
+            BODY=output/diff.trimmed.md
+          else
+            BODY=output/diff.md
+          fi
+
+          # Edit existing bot comment if present, else create new.
+          gh pr comment "${{ github.event.number }}" \
+            --repo "${{ github.repository }}" \
+            --body-file "$BODY" --edit-last 2>/dev/null \
+          || gh pr comment "${{ github.event.number }}" \
+              --repo "${{ github.repository }}" \
+              --body-file "$BODY"


### PR DESCRIPTION
## Summary

Adds [dag-andersen/argocd-diff-preview](https://github.com/dag-andersen/argocd-diff-preview) as a CI step. Spins an ephemeral Argo CD inside Docker, renders both branches' Applications/ApplicationSets, and posts the diff as a PR comment.

Catches what static validation (Phase 1, #166) can't:
- Helm values changes producing surprising rendered Deployments/Services
- Multi-source app drift (chart version bump + values change interaction)
- ApplicationSet generator expansion changes
- Kustomize transform/patch effects

## Behavior

- Triggers only on PRs that touch `k8s/**` or this workflow file
- Uses `dagandersen/argocd-diff-preview:v0.2.4` (latest, released 2026-04-25)
- Ephemeral cluster + Argo CD spin-up: ~2 min, full render+diff: ~3-5 min total
- Truncates comment if rendered output > 60KB (GitHub PR comment cap is 64KB); full diff always available as workflow artifact for 14 days
- `--edit-last` keeps a single rolling comment per PR (no spam on push)

## Verification

This PR itself only adds the workflow file (no `k8s/**` changes), so the diff comment will show "no changes". That's the expected baseline. Real verification requires merging then pushing a follow-up PR that touches a Helm values.yaml or Kustomize overlay.

## Out of scope

- Private chart repo auth (we only consume public charts; revisit if that changes)
- App-level filtering (runs all apps; revisit if CI time grows past ~10 min)

## Test plan

- [ ] CI: workflow runs without error
- [ ] PR receives a comment from `github-actions[bot]` with diff content
- [ ] Workflow artifact `argocd-diff` uploaded
- [ ] Follow-up PR test: small values.yaml change shows up in the rendered diff comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)