### PR TITLE
feat(ci): kube-linter strict gate (Phase 3)

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -1,0 +1,52 @@
+name: kube-linter
+
+on:
+  pull_request:
+    paths:
+      - "k8s/**"
+      - ".kube-linter.yaml"
+      - ".github/workflows/kube-linter.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "k8s/**"
+      - ".kube-linter.yaml"
+      - ".github/workflows/kube-linter.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kustomize
+        run: |
+          curl -sLo /tmp/kustomize.tar.gz \
+            "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.5.0/kustomize_v5.5.0_linux_amd64.tar.gz"
+          tar -xzf /tmp/kustomize.tar.gz -C /tmp
+          sudo mv /tmp/kustomize /usr/local/bin/
+
+      - name: Install kube-linter
+        run: |
+          curl -sL https://github.com/stackrox/kube-linter/releases/latest/download/kube-linter-linux.tar.gz \
+            | tar -xz -C /tmp
+          sudo mv /tmp/kube-linter /usr/local/bin/
+          kube-linter version
+
+      - name: Render Kustomize roots
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/rendered
+          while IFS= read -r kfile; do
+            dir="$(dirname "$kfile")"
+            name="$(echo "$dir" | sed 's|k8s/||' | tr '/' '-')"
+            kustomize build "$dir" > "/tmp/rendered/${name}.yaml"
+          done < <(find k8s -name 'kustomization.yaml' | sort)
+          echo "Rendered $(ls /tmp/rendered/ | wc -l) Kustomize roots."
+
+      - name: Run kube-linter (strict)
+        run: |
+          kube-linter lint --config=.kube-linter.yaml /tmp/rendered/

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,26 @@
+---
+# kube-linter configuration for homelab K8s manifests.
+#
+# Strategy: enable all built-in default checks, then explicitly exclude
+# checks we have outstanding tech debt against. Each exclusion is tracked
+# in a GitHub issue — graduating an item out of this list = closing that
+# tracking item.
+#
+# When fixing an excluded check across all violators, remove it from
+# `exclude` here in the same PR.
+
+checks:
+  exclude:
+    # 19 violations across loop/health-hub/gbrain-mcp/essentia/brain-agent.
+    # Tracked in #169 — requires per-app securityContext audit (some
+    # workloads like postgres need specific UIDs).
+    - run-as-non-root
+
+    # 19 violations. Tracked in #169 — many apps need writable mounts for
+    # runtime caches (bun, python pip), requires emptyDir tmpfs additions.
+    - no-read-only-root-fs
+
+    # 10 violations. Tracked in #169 — most are our own apps using :latest
+    # with ArgoCD Image Updater for digest pinning. Migration to tagged
+    # images requires Image Updater config rework.
+    - latest-tag

--- a/k8s/brain-agent/cronjob.yaml
+++ b/k8s/brain-agent/cronjob.yaml
@@ -15,7 +15,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
       backoffLimit: 1
       activeDeadlineSeconds: 600
       template:

--- a/k8s/gbrain-mcp/manifests/deployment.yaml
+++ b/k8s/gbrain-mcp/manifests/deployment.yaml
@@ -44,6 +44,13 @@ spec:
           volumeMounts:
             - name: brain
               mountPath: /brain
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
 
       containers:
         # Main: gbrain stdio MCP wrapped via mcp-proxy → SSE :8080
@@ -109,6 +116,13 @@ spec:
               path: /healthz
               port: 80
             periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
 
       volumes:
         - name: brain

--- a/k8s/health-hub/manifests/backup-cronjob.yaml
+++ b/k8s/health-hub/manifests/backup-cronjob.yaml
@@ -13,7 +13,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
       backoffLimit: 2
       template:
         metadata:


### PR DESCRIPTION
## Summary

Adds [stackrox/kube-linter](https://github.com/stackrox/kube-linter) static security/best-practice linting for K8s manifests. Uses default check set (29 checks) with **three temporarily excluded** in [.kube-linter.yaml](.kube-linter.yaml), tracked in #169 for graduation.

Phase 1 (#166) caught schema errors. Phase 2 (#168) caught rendered drift. Phase 3 catches **best-practice/security misconfigurations** (privileged container, host-network, missing resources, latest-tag, etc.).

## Day-1 fixes (6 violations resolved inline)

| File | Fix |
|---|---|
| `k8s/gbrain-mcp/manifests/deployment.yaml` | Added cpu/memory requests+limits to `git-clone` initContainer and `caddy` sidecar (4 violations) |
| `k8s/brain-agent/cronjob.yaml` | Dropped `ttlSecondsAfterFinished` from jobTemplate (CronJob's history limits already handle cleanup) |
| `k8s/health-hub/manifests/backup-cronjob.yaml` | Same drop |

## Deferred violations (48 across 6 apps) — tracked in #169

- `run-as-non-root` (19) — needs per-app securityContext audit
- `no-read-only-root-fs` (19) — needs writable mount additions
- `latest-tag` (10) — needs Image Updater policy review

Each excluded check has a comment in `.kube-linter.yaml` linking back to #169. Graduating an item out of `exclude` = closing that tracking checkbox.

## Local verification

```
$ kube-linter lint --config=.kube-linter.yaml /tmp/rendered/
KubeLinter 0.8.3
No lint errors found!
```

## Test plan

- [ ] CI: `kube-linter` job passes
- [ ] Confirms PR-only triggering (no run on push to main if no `k8s/**` changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)