### PR TITLE
feat(ci): Renovate config (Phase 4)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,51 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":timezone(Asia/Seoul)",
+    "schedule:weekly",
+    "group:allNonMajor",
+  ],
+
+  // Single rolling Dependency Dashboard issue summarizing pending updates.
+  dependencyDashboardTitle: "Dependency Dashboard (Renovate)",
+
+  labels: ["dependencies"],
+  prHourlyLimit: 5,
+  prConcurrentLimit: 10,
+
+  // ArgoCD Application targetRevision (Helm chart versions).
+  argocd: {
+    fileMatch: ["^k8s/argocd/applications/.*\\.ya?ml$"],
+  },
+
+  // Image tags inside raw K8s manifests under k8s/.
+  kubernetes: {
+    fileMatch: ["^k8s/.*\\.ya?ml$"],
+  },
+
+  packageRules: [
+    {
+      // GitHub Actions minor/patch — auto-merge after CI passes.
+      // Major bumps still require manual review.
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["minor", "patch", "digest"],
+      automerge: true,
+      automergeType: "pr",
+      automergeStrategy: "squash",
+    },
+    {
+      // Major bumps surface in dashboard with extra label, never auto-merged.
+      matchUpdateTypes: ["major"],
+      addLabels: ["major"],
+    },
+    {
+      // Argo CD itself is a critical dep — manual review even for minor.
+      matchManagers: ["argocd"],
+      matchPackageNames: ["argo-cd", "argo-helm"],
+      automerge: false,
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

Adds `.github/renovate.json5` so the [Renovate GitHub App](https://github.com/apps/renovate) picks up dependency updates automatically once installed.

Renovate complements Phases 1-3:
- **Phase 1** (#166): blocks broken manifests at PR
- **Phase 2** (#168): shows rendered K8s diff
- **Phase 3** (#170): blocks security/best-practice regressions
- **Phase 4** (this): proposes upgrades that flow through 1-3 for automatic safety check

## What gets watched

| Manager | Path | Example |
|---|---|---|
| `argocd` | `k8s/argocd/applications/**/*.yaml` | Helm chart `targetRevision` bumps |
| `kubernetes` | `k8s/**/*.yaml` | Image tags in raw manifests |
| `github-actions` | `.github/workflows/**/*.yaml` | `actions/checkout@v4` etc |
| `helm-values` (auto) | `**/values.yaml` | Helm `image.tag` |
| `terraform` (auto) | `cloudflare/*.tf` | Provider versions |
| `dockerfile` (auto) | `Dockerfile` files | `FROM` versions |

## Behavior

- **Schedule**: weekly, KST timezone (no constant churn)
- **Auto-merge**: minor/patch GitHub Actions only; everything else needs manual approval
- **Major bumps**: labeled `major`, surfaced in Dependency Dashboard, never auto-merged
- **Argo CD itself**: never auto-merged even on minor (critical dep)
- **Grouping**: non-major updates batched to reduce PR noise

## Validation

`renovate-config-validator` passes locally:
```
INFO: Config validated successfully
```

## Required follow-up after merge

Install the Renovate App on this repo:
- https://github.com/apps/renovate → **Configure** → select `manamana32321/homelab` → **Save**
- mend.io provides the cron infrastructure; no GHA workflow needed
- First PRs typically arrive within 1-24 hours

## Test plan

- [ ] CI: existing checks pass on this PR (no behavior change in CI itself)
- [ ] After Renovate App install: Dependency Dashboard issue created
- [ ] Renovate auto-creates first batch of update PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)