### PR TITLE
feat(ci): terraform fmt/validate/tflint gate (Phase 5)

### DIFF
--- a/.github/workflows/terraform-validate.yaml
+++ b/.github/workflows/terraform-validate.yaml
@@ -1,0 +1,54 @@
+name: terraform validate
+
+on:
+  pull_request:
+    paths:
+      - "cloudflare/**"
+      - "aws/**"
+      - ".github/workflows/terraform-validate.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "cloudflare/**"
+      - "aws/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: [cloudflare, aws]
+    defaults:
+      run:
+        working-directory: ${{ matrix.dir }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ~1.10
+          terraform_wrapper: false
+
+      - name: terraform fmt
+        run: terraform fmt -check -diff -recursive
+
+      # -backend=false skips state read so no AWS credentials required.
+      # Plan with real state (which would catch drift) is tracked in #172.
+      - name: terraform init (no backend)
+        run: terraform init -backend=false -input=false
+
+      - name: terraform validate
+        run: terraform validate -no-color
+
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: latest
+
+      - name: tflint
+        run: |
+          tflint --init
+          tflint --recursive --color


### PR DESCRIPTION
## Summary

Lightweight Terraform CI for `cloudflare/` and `aws/` directories — completes the 5-phase CI plan started in #166.

| Phase | What | PR |
|---|---|---|
| 1 | kustomize+kubeconform+gitleaks | #166 |
| 2 | argocd-diff-preview PR comments | #168 |
| 3 | kube-linter strict | #170 |
| 4 | Renovate config | #171 |
| **5** | **terraform fmt+validate+tflint** | **this PR** |

## Steps per dir (matrix: cloudflare, aws)

1. `terraform fmt -check -diff -recursive` — style consistency
2. `terraform init -backend=false` — providers only, no state read, **no AWS creds needed**
3. `terraform validate` — syntax + reference correctness
4. `tflint --init && tflint --recursive` — built-in terraform ruleset

## Out of scope (#172)

`terraform plan` in PR comment requires AWS state read → credentials. Tracked separately because it needs:
- GitHub OIDC → IAM role setup (1-time AWS Console work)
- Sensitive variable handling for plan-time provider calls
- PR comment formatting + truncation (similar to Phase 2)

Issue #172 has the full implementation plan.

## Local smoke test

Both `cloudflare/` and `aws/` pass:
- `terraform fmt -check`: clean
- `terraform validate`: Success
- `tflint`: 0 findings

## Test plan

- [ ] CI: matrix runs both `cloudflare` and `aws` jobs
- [ ] Both pass clean (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)