### PR TITLE
fix(crowdsec): correct LAPI service hostname (closes #175)

### DIFF
--- a/k8s/traefik/manifests/middleware-crowdsec.yaml
+++ b/k8s/traefik/manifests/middleware-crowdsec.yaml
@@ -9,7 +9,7 @@ spec:
       enabled: true
       crowdsecMode: stream
       crowdsecLapiScheme: http
-      crowdsecLapiHost: crowdsec-lapi.crowdsec.svc.cluster.local:8080
+      crowdsecLapiHost: crowdsec-service.crowdsec.svc.cluster.local:8080
       # LAPI key read from file — secret mounted by Traefik HelmChartConfig
       # (k8s/traefik/manifests/helmchartconfig.yaml) from the
       # crowdsec-bouncer-key Secret reflected from the crowdsec namespace.


### PR DESCRIPTION
## Summary

One-line fix: `crowdsecLapiHost` in the bouncer Middleware was pointing at a non-existent Service name. The chart actually creates `crowdsec-service` (port 8080 named `lapi`), not `crowdsec-lapi`.

```diff
-      crowdsecLapiHost: crowdsec-lapi.crowdsec.svc.cluster.local:8080
+      crowdsecLapiHost: crowdsec-service.crowdsec.svc.cluster.local:8080
```

## Why this matters

Bouncer's DNS lookup was failing silently for 15+ days. In stream mode, the plugin couldn't fetch the LAPI decision list → empty cache → **no IPs were ever blocked**. Silent fail-open.

Discovered while verifying #174 (the file-mount migration). Pre-existing bug, not caused by either PR.

## Verification

```
$ kubectl -n crowdsec get svc crowdsec-service -o jsonpath='{.spec.ports}'
[{"name":"metrics","port":6060,"protocol":"TCP","targetPort":6060},
 {"name":"lapi","port":8080,"protocol":"TCP","targetPort":8080}]
```

## Test plan (post-merge)

- [ ] ArgoCD syncs Middleware
- [ ] Traefik pod restarts (HelmChartConfig change → helm-controller → rolling)
- [ ] Traefik logs no longer show "no such host" for `crowdsec-lapi.crowdsec.svc.cluster.local`
- [ ] Plugin successfully polls LAPI decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)