### PR TITLE
chore(k8s): graduate latest-tag from #169 (10/48)

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -19,8 +19,3 @@ checks:
     # 19 violations. Tracked in #169 — many apps need writable mounts for
     # runtime caches (bun, python pip), requires emptyDir tmpfs additions.
     - no-read-only-root-fs
-
-    # 10 violations. Tracked in #169 — most are our own apps using :latest
-    # with ArgoCD Image Updater for digest pinning. Migration to tagged
-    # images requires Image Updater config rework.
-    - latest-tag

--- a/k8s/essentia/kustomization.yaml
+++ b/k8s/essentia/kustomization.yaml
@@ -22,3 +22,5 @@ resources:
 images:
   - name: ghcr.io/essentia-edu/api
     digest: sha256:1c30ed47e532f84b3a791e23a782baa45878b79a9d32d18b6712a9d39518b67a
+  - name: ghcr.io/essentia-edu/web
+    digest: sha256:02433a63a0a7abd9cb1867eebe69c1942dfc4de1a95a2e0814bd879e87d02749

--- a/k8s/gbrain-mcp/manifests/kustomization.yaml
+++ b/k8s/gbrain-mcp/manifests/kustomization.yaml
@@ -11,4 +11,9 @@ resources:
   - sync-cronjob.yaml
 images:
   - name: ghcr.io/manamana32321/gbrain-mcp
-    newTag: latest
+    digest: sha256:a0aa3b400bfa83da4c1106f6aafc68a73aca71a2a988314e1acfb270eb25ae6f
+  # Pinned to current digest. Public alpine/git base image not subject to
+  # ArgoCD Image Updater (only ghcr.io/* in app annotations); update via
+  # Renovate or manual digest bump.
+  - name: alpine/git
+    digest: sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3

--- a/k8s/health-hub/manifests/kustomization.yaml
+++ b/k8s/health-hub/manifests/kustomization.yaml
@@ -11,3 +11,11 @@ resources:
   - service.yaml
   - ingress.yaml
   - backup-cronjob.yaml
+
+# Pinned digests, kept fresh by argocd-image-updater (annotations on the
+# Argo CD Application in k8s/argocd/applications/apps/health-hub.yaml).
+images:
+  - name: ghcr.io/manamana32321/health-hub
+    digest: sha256:c5bc4b017de06a18b1c4d1d24dcacecf9a567723792ad6e0b9915ae9d9ad20b0
+  - name: ghcr.io/manamana32321/health-hub-dashboard
+    digest: sha256:8ca104d22c234606f5fe3367b89ff4f112fa0be640f6b363dbea9c8e96aa27aa

--- a/k8s/loop/kustomization.yaml
+++ b/k8s/loop/kustomization.yaml
@@ -12,3 +12,12 @@ resources:
   - web/deployment.yaml
   - web/ingress.yaml
   - migrate-job.yaml
+
+# Pinned digests, kept fresh by argocd-image-updater (annotations on the
+# Argo CD Application in k8s/argocd/applications/apps/loop.yaml).
+# loop-api digest is shared by the migrate Job (same image).
+images:
+  - name: ghcr.io/manamana32321/loop-api
+    digest: sha256:ae02c9ce6b1a99fb32b4deddb2da88f03bcf40ec990dafce06e93ceeb9557890
+  - name: ghcr.io/manamana32321/loop-web
+    digest: sha256:27c9e3893f8ba2131532c9ba7040e69ce03f513b366d120640a0ac8993b74091


### PR DESCRIPTION
## Summary

First graduation pass on #169. Resolves all **10 `latest-tag` kube-linter violations** by pinning `:latest` image refs to current sha256 digests via Kustomize `images:` blocks. ArgoCD Image Updater (already annotated on each Application) takes over from there — keeps the digests fresh on every pull-metadata cycle.

`.kube-linter.yaml` has `latest-tag` removed from the exclude list — **the check is now strict-enforced**.

## Apps affected

| App | Container | Image | Action |
|---|---|---|---|
| gbrain/gbrain-mcp | git-clone (init) | alpine/git:latest | Inline pin in kustomization (public, no Image Updater) |
| gbrain/gbrain-mcp | gbrain-mcp | ghcr.io/manamana32321/gbrain-mcp | newTag→digest |
| gbrain/gbrain-sync | sync | ghcr.io/manamana32321/gbrain-mcp | (same image, same digest) |
| health-hub/health-hub | health-hub + mcp | ghcr.io/manamana32321/health-hub | New images: entry |
| health-hub/health-hub-dashboard | dashboard | ghcr.io/manamana32321/health-hub-dashboard | New images: entry |
| loop/loop-api | api + migrate (Job) | ghcr.io/manamana32321/loop-api | New images: entry |
| loop/loop-web | web | ghcr.io/manamana32321/loop-web | New images: entry |
| essentia/essentia-web | web | ghcr.io/essentia-edu/web | Add to existing images: block |

## How digests were obtained

Snapshotted from currently-running pod `imageID` fields:

```bash
kubectl -n <ns> get pods -l app=<label> \
  -o jsonpath='{.items[*].status.containerStatuses[*].imageID}'
```

For `alpine/git`, used `crane digest alpine/git:latest`.

## Local verification

```
kube-linter lint --include latest-tag /tmp/rendered/
=> No lint errors found!

kube-linter lint --config=.kube-linter.yaml /tmp/rendered/
=> No lint errors found!
```

## Out of scope (still in #169)

- 19 `run-as-non-root` violations — separate PR
- 19 `no-read-only-root-fs` violations — separate PR

## Why each digest pinning is safe

- All 9 own apps already have ArgoCD Image Updater annotations with `update-strategy: digest` and `write-back-method: argocd`. After this PR's initial commit, Image Updater will continue digest write-back on each pull-metadata cycle.
- The `alpine/git` is a one-off init container; its digest pinning is manual and Renovate-trackable.

## Test plan

- [ ] CI: kube-linter strict passes
- [ ] argocd-diff-preview: shows the digest substitution in rendered Deployments/Jobs
- [ ] After merge: ArgoCD syncs without disruption (digest matches what's already running, so no rolling restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)