### PR TITLE
chore(ci): clarify latest-tag is permanently excluded

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -20,7 +20,15 @@ checks:
     # runtime caches (bun, python pip), requires emptyDir tmpfs additions.
     - no-read-only-root-fs
 
-    # 10 violations. Tracked in #169 — most are our own apps using :latest
-    # with ArgoCD Image Updater for digest pinning. Migration to tagged
-    # images requires Image Updater config rework.
+    # Permanently excluded — not tech debt.
+    #
+    # The check is a static-intent rule: it flags any `image: foo:latest`
+    # in source manifests. Our own GHCR apps deliberately use `:latest`
+    # in source because ArgoCD Image Updater (write-back-method=argocd)
+    # rewrites the Application CR's spec.source.kustomize.images at sync
+    # time, pinning the resolved digest at runtime.
+    #
+    # Source intent ≠ runtime image. The kube-linter premise doesn't fit
+    # this deployment model, so we silence the rule rather than pretend
+    # to "graduate" it.
     - latest-tag


### PR DESCRIPTION
## Summary

Updates `.kube-linter.yaml` comment for `latest-tag` to reflect a permanent exclusion decision (not pending tech debt).

## Why

PR #177 attempted to "graduate" `latest-tag` by adding `images: digest:` blocks to kustomization.yaml. Discussion in that PR surfaced that the rule's premise doesn't fit our deployment model:

- **kube-linter's `latest-tag`** = static-intent rule. Flags any `image: foo:latest` in source manifests.
- **Our deployment model** = source uses `:latest`; ArgoCD Image Updater (write-back-method=argocd) rewrites the Application CR's `spec.source.kustomize.images` at runtime, digest-pinning what actually runs.

Source intent ≠ runtime image. Trying to enforce static digest in source manifests is busywork that fights the Image Updater workflow.

## Changes

`.kube-linter.yaml` only — comment update.

The check stays in the `exclude` list as before. No actual lint behavior change.

## Updated #169

Subtask "graduate latest-tag" will be removed from #169 — it's not a violation we plan to fix. Remaining work in #169:
- 19 `run-as-non-root` violations
- 19 `no-read-only-root-fs` violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)