### PR TITLE
chore(gbrain-mcp): harden securityContext (non-root + RO root-fs)

### DIFF
--- a/k8s/gbrain-mcp/manifests/caddy-configmap.yaml
+++ b/k8s/gbrain-mcp/manifests/caddy-configmap.yaml
@@ -11,7 +11,7 @@ data:
       admin off
     }
 
-    :80 {
+    :8081 {
       handle /healthz {
         respond "ok" 200
       }

--- a/k8s/gbrain-mcp/manifests/deployment.yaml
+++ b/k8s/gbrain-mcp/manifests/deployment.yaml
@@ -18,6 +18,13 @@ spec:
       labels:
         app: gbrain-mcp
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         # Clone brain repo (private) into shared volume
         - name: git-clone
@@ -41,9 +48,19 @@ spec:
                 secretKeyRef:
                   name: gbrain-github-credentials
                   key: GH_PAT
+            # alpine/git as UID 1000 has no real $HOME; redirect to writable /tmp.
+            - name: HOME
+              value: /tmp
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
           volumeMounts:
             - name: brain
               mountPath: /brain
+            - name: git-tmp
+              mountPath: /tmp
           resources:
             requests:
               cpu: 50m
@@ -73,12 +90,27 @@ spec:
                 secretKeyRef:
                   name: llm-api-keys
                   key: OPENAI_API_KEY
+            # Disable .pyc generation so mcp-proxy doesn't try to write
+            # __pycache__ into the read-only image layer.
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+            - name: PYTHONUNBUFFERED
+              value: "1"
           ports:
             - containerPort: 8080
               name: sse
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
           volumeMounts:
             - name: brain
               mountPath: /brain
+            - name: gbrain-tmp
+              mountPath: /tmp
+            - name: bun-cache
+              mountPath: /home/bun/.bun
           resources:
             requests:
               memory: 256Mi
@@ -87,7 +119,8 @@ spec:
               memory: 1Gi
               cpu: 1000m
 
-        # Sidecar: caddy reverse proxy with Bearer auth
+        # Sidecar: caddy reverse proxy with Bearer auth (listens on :8080
+        # so it can run as non-root without NET_BIND_SERVICE).
         - name: caddy
           image: caddy:2-alpine
           command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]
@@ -97,21 +130,33 @@ spec:
                 secretKeyRef:
                   name: gbrain-postgres-secrets
                   key: MCP_AUTH_TOKEN
+            # Caddy expects writable XDG dirs; redirect into mounted tmpfs.
+            - name: XDG_DATA_HOME
+              value: /tmp/caddy-data
+            - name: XDG_CONFIG_HOME
+              value: /tmp/caddy-config
           ports:
-            - containerPort: 80
+            - containerPort: 8081
               name: http
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
           volumeMounts:
             - name: caddy-config
               mountPath: /etc/caddy
+            - name: caddy-tmp
+              mountPath: /tmp
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 80
+              port: 8081
             periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 80
+              port: 8081
             periodSeconds: 30
           resources:
             requests:
@@ -127,3 +172,12 @@ spec:
         - name: caddy-config
           configMap:
             name: gbrain-mcp-caddy
+        # Writable tmpfs-style emptyDir per container (RO root fs).
+        - name: git-tmp
+          emptyDir: {}
+        - name: gbrain-tmp
+          emptyDir: {}
+        - name: bun-cache
+          emptyDir: {}
+        - name: caddy-tmp
+          emptyDir: {}

--- a/k8s/gbrain-mcp/manifests/service.yaml
+++ b/k8s/gbrain-mcp/manifests/service.yaml
@@ -9,5 +9,5 @@ spec:
     app: gbrain-mcp
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8081
       name: http

--- a/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
+++ b/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
@@ -14,6 +14,13 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: sync
               image: ghcr.io/manamana32321/gbrain-mcp:latest
@@ -45,6 +52,23 @@ spec:
                     secretKeyRef:
                       name: llm-api-keys
                       key: OPENAI_API_KEY
+                - name: PYTHONDONTWRITEBYTECODE
+                  value: "1"
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                # alpine git etc need a writable HOME; redirect into /tmp emptyDir.
+                - name: HOME
+                  value: /tmp
+              securityContext:
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: [ALL]
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+                - name: bun-cache
+                  mountPath: /home/bun/.bun
               resources:
                 requests:
                   memory: 256Mi
@@ -52,3 +76,8 @@ spec:
                 limits:
                   memory: 512Mi
                   cpu: 500m
+          volumes:
+            - name: tmp
+              emptyDir: {}
+            - name: bun-cache
+              emptyDir: {}


### PR DESCRIPTION
## Summary

Hardens \`gbrain-mcp\` Deployment + \`gbrain-sync\` CronJob with non-root + read-only-root-fs (defense-in-depth, per #169 plan). 1 of 6 apps.

## Changes

| File | Change |
|---|---|
| \`deployment.yaml\` | Pod-level + per-container \`securityContext\`. Caddy moved to :8081 (non-root can't bind :80). emptyDir mounts for /tmp + Bun cache. \`PYTHONDONTWRITEBYTECODE=1\` for mcp-proxy |
| \`sync-cronjob.yaml\` | Same hardening, single container |
| \`caddy-configmap.yaml\` | Caddy listens on :8081 |
| \`service.yaml\` | targetPort 80 → 8081. External Service port (80) unchanged |

## Why

Per #169 (graduate \`run-as-non-root\` + \`no-read-only-root-fs\` from kube-linter exclude). Two rules don't graduate until all 6 apps comply, but each PR is small + verifiable in isolation. This is gbrain-mcp's slice.

## Threat model addressed

- **Compromise via prompt-injection / Bun supply-chain**: attacker constrained to UID 1000 (can't write \`/etc\`, can't bind :80, can't kernel-exploit easily)
- **Persistent backdoor**: RO root-fs makes any drop ephemeral — pod restart wipes attacker foothold

## Local verification

\`\`\`
kube-linter lint --do-not-auto-add-defaults \
  --include run-as-non-root --include no-read-only-root-fs \
  /tmp/gbrain-rendered.yaml
=> No lint errors found!
\`\`\`

## Sequencing concerns

- Caddy port change is **not zero-downtime** for the Service: when ArgoCD applies, old pod still listens on :80 until rollout completes; Service targetPort changes simultaneously. There's a brief moment where Service forwards to :8081 but old pod doesn't listen there yet. Recreate strategy + readiness probe minimizes the window.
- After merge: hard-refresh \`gbrain-mcp\` Argo app, watch pod start as non-root, verify https://gbrain.json-server.win/healthz returns 200 (Bearer skipped).

## Test plan

- [ ] CI: 5 gates pass (kube-linter still passes per global exclude)
- [ ] Post-merge: Argo app Synced + Healthy
- [ ] Pod runs with \`runAsUser: 1000\`
- [ ] gbrain-sync next CronJob run completes
- [ ] gbrain-mcp HTTP responds via Service (port 80 → targetPort 8081)

🤖 Generated with [Claude Code](https://claude.com/claude-code)