### PR TITLE
chore(health-hub): harden Deployments securityContext (2/6 in #169)

### DIFF
--- a/k8s/health-hub/manifests/dashboard-deployment.yaml
+++ b/k8s/health-hub/manifests/dashboard-deployment.yaml
@@ -13,10 +13,22 @@ spec:
       labels:
         app: health-hub-dashboard
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: dashboard
           image: ghcr.io/manamana32321/health-hub-dashboard:latest
           imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
           ports:
             - name: http
               containerPort: 3000

--- a/k8s/health-hub/manifests/deployment.yaml
+++ b/k8s/health-hub/manifests/deployment.yaml
@@ -13,10 +13,22 @@ spec:
       labels:
         app: health-hub
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: health-hub
           image: ghcr.io/manamana32321/health-hub:latest
           imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
           ports:
             - name: http
               containerPort: 8080
@@ -66,6 +78,11 @@ spec:
           image: ghcr.io/manamana32321/health-hub:latest
           command: ["health-hub-mcp"]
           imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
           ports:
             - name: mcp
               containerPort: 8081


### PR DESCRIPTION
## Summary

Hardens `health-hub` and `health-hub-dashboard` Deployments with non-root + read-only-root-fs. **2 of 6 apps in #169.**

## Changes

| File | Change |
|---|---|
| `deployment.yaml` | Pod + per-container `securityContext` for `health-hub` + `mcp` containers |
| `dashboard-deployment.yaml` | Pod + container `securityContext` |

No `/tmp` emptyDir added — Go binaries typically don't write to /tmp. If RO-fs causes runtime failure post-deploy, easy to add later. YAGNI on speculative volumes.

## Out of scope (separate PRs)

- **timescaledb StatefulSet** — postgres needs PGDATA write + careful tmp/socket setup
- **health-hub-db-backup CronJob** — uses `alpine + apk add` inline (needs root + writable). Should swap to a pre-baked image with `pg_dump` + `rclone` already installed

## Local

```
kube-linter --include run-as-non-root --include no-read-only-root-fs
=> 4 errors remaining (all from timescaledb + backup, deferred)
=> 0 errors on the 2 Deployments touched here
```

`.kube-linter.yaml` global exclude unchanged — both rules still tolerated for the rest of the repo.

## Test plan

- [ ] CI: 5 gates pass
- [ ] Post-merge: hard-refresh `health-hub` Argo app, both Deployments roll without `CreateContainerConfigError` or RO-fs panics
- [ ] `health-hub` API, `mcp` (port 8081), `dashboard` (3000) all respond Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)