### PR TITLE
chore(loop): harden api + web Deployments securityContext (3/6 in #169)

### DIFF
--- a/k8s/loop/api/deployment.yaml
+++ b/k8s/loop/api/deployment.yaml
@@ -17,10 +17,22 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-pull
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: api
           image: ghcr.io/manamana32321/loop-api:latest
           imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
           ports:
             - containerPort: 3001
           envFrom:

--- a/k8s/loop/web/deployment.yaml
+++ b/k8s/loop/web/deployment.yaml
@@ -17,10 +17,22 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-pull
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: web
           image: ghcr.io/manamana32321/loop-web:latest
           imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
           ports:
             - containerPort: 3000
           env:


### PR DESCRIPTION
## Summary

Hardens `loop-api` (Go) and `loop-web` (Next.js) Deployments with non-root + read-only-root-fs. **3 of 6 apps in #169.**

## Changes

| File | Change |
|---|---|
| `api/deployment.yaml` | Pod + container `securityContext` |
| `web/deployment.yaml` | Pod + container `securityContext` |

No writable `/tmp` mounts — start minimal; add only if a deploy-time failure points at a specific path (lesson from #182).

## Out of scope (separate PRs)

- **loop-postgres Deployment** — TimescaleDB image needs careful PGDATA + tmpfs for `/var/run/postgresql` socket dir
- **loop-migrate Job** — `wait-for-db` + `migrate` containers, both `timescaledb`-image-based; same plan as postgres

## Local

```
kube-linter --include run-as-non-root --include no-read-only-root-fs
=> 6 errors remaining (all postgres + migrate Job, deferred)
=> 0 errors on api + web touched here
```

## Test plan

- [ ] CI: 5 gates pass
- [ ] Post-merge: hard-refresh `loop` Argo app, both Deployments roll without `CreateContainerConfigError` or RO-fs failure
- [ ] `loop-api` (3001) and `loop-web` (3000) respond Healthy
- [ ] Watch loop-web for Next.js image-optimization failures (if it uses `next/image`); add `/tmp` emptyDir if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)