### PR TITLE
chore(gbrain-mcp): revert securityContext hardening (#181)

### DIFF
--- a/k8s/gbrain-mcp/manifests/caddy-configmap.yaml
+++ b/k8s/gbrain-mcp/manifests/caddy-configmap.yaml
@@ -11,7 +11,7 @@ data:
       admin off
     }
 
-    :8081 {
+    :80 {
       handle /healthz {
         respond "ok" 200
       }

--- a/k8s/gbrain-mcp/manifests/deployment.yaml
+++ b/k8s/gbrain-mcp/manifests/deployment.yaml
@@ -18,13 +18,6 @@ spec:
       labels:
         app: gbrain-mcp
     spec:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        seccompProfile:
-          type: RuntimeDefault
       initContainers:
         # Clone brain repo (private) into shared volume
         - name: git-clone
@@ -48,19 +41,9 @@ spec:
                 secretKeyRef:
                   name: gbrain-github-credentials
                   key: GH_PAT
-            # alpine/git as UID 1000 has no real $HOME; redirect to writable /tmp.
-            - name: HOME
-              value: /tmp
-          securityContext:
-            readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: [ALL]
           volumeMounts:
             - name: brain
               mountPath: /brain
-            - name: git-tmp
-              mountPath: /tmp
           resources:
             requests:
               cpu: 50m
@@ -90,27 +73,12 @@ spec:
                 secretKeyRef:
                   name: llm-api-keys
                   key: OPENAI_API_KEY
-            # Disable .pyc generation so mcp-proxy doesn't try to write
-            # __pycache__ into the read-only image layer.
-            - name: PYTHONDONTWRITEBYTECODE
-              value: "1"
-            - name: PYTHONUNBUFFERED
-              value: "1"
           ports:
             - containerPort: 8080
               name: sse
-          securityContext:
-            readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: [ALL]
           volumeMounts:
             - name: brain
               mountPath: /brain
-            - name: gbrain-tmp
-              mountPath: /tmp
-            - name: bun-cache
-              mountPath: /home/bun/.bun
           resources:
             requests:
               memory: 256Mi
@@ -119,8 +87,7 @@ spec:
               memory: 1Gi
               cpu: 1000m
 
-        # Sidecar: caddy reverse proxy with Bearer auth (listens on :8080
-        # so it can run as non-root without NET_BIND_SERVICE).
+        # Sidecar: caddy reverse proxy with Bearer auth
         - name: caddy
           image: caddy:2-alpine
           command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]
@@ -130,33 +97,21 @@ spec:
                 secretKeyRef:
                   name: gbrain-postgres-secrets
                   key: MCP_AUTH_TOKEN
-            # Caddy expects writable XDG dirs; redirect into mounted tmpfs.
-            - name: XDG_DATA_HOME
-              value: /tmp/caddy-data
-            - name: XDG_CONFIG_HOME
-              value: /tmp/caddy-config
           ports:
-            - containerPort: 8081
+            - containerPort: 80
               name: http
-          securityContext:
-            readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: [ALL]
           volumeMounts:
             - name: caddy-config
               mountPath: /etc/caddy
-            - name: caddy-tmp
-              mountPath: /tmp
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 8081
+              port: 80
             periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8081
+              port: 80
             periodSeconds: 30
           resources:
             requests:
@@ -172,12 +127,3 @@ spec:
         - name: caddy-config
           configMap:
             name: gbrain-mcp-caddy
-        # Writable tmpfs-style emptyDir per container (RO root fs).
-        - name: git-tmp
-          emptyDir: {}
-        - name: gbrain-tmp
-          emptyDir: {}
-        - name: bun-cache
-          emptyDir: {}
-        - name: caddy-tmp
-          emptyDir: {}

--- a/k8s/gbrain-mcp/manifests/service.yaml
+++ b/k8s/gbrain-mcp/manifests/service.yaml
@@ -9,5 +9,5 @@ spec:
     app: gbrain-mcp
   ports:
     - port: 80
-      targetPort: 8081
+      targetPort: 80
       name: http

--- a/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
+++ b/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
@@ -14,13 +14,6 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
-            fsGroup: 1000
-            seccompProfile:
-              type: RuntimeDefault
           containers:
             - name: sync
               image: ghcr.io/manamana32321/gbrain-mcp:latest
@@ -52,23 +45,6 @@ spec:
                     secretKeyRef:
                       name: llm-api-keys
                       key: OPENAI_API_KEY
-                - name: PYTHONDONTWRITEBYTECODE
-                  value: "1"
-                - name: PYTHONUNBUFFERED
-                  value: "1"
-                # alpine git etc need a writable HOME; redirect into /tmp emptyDir.
-                - name: HOME
-                  value: /tmp
-              securityContext:
-                readOnlyRootFilesystem: true
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop: [ALL]
-              volumeMounts:
-                - name: tmp
-                  mountPath: /tmp
-                - name: bun-cache
-                  mountPath: /home/bun/.bun
               resources:
                 requests:
                   memory: 256Mi
@@ -76,8 +52,3 @@ spec:
                 limits:
                   memory: 512Mi
                   cpu: 500m
-          volumes:
-            - name: tmp
-              emptyDir: {}
-            - name: bun-cache
-              emptyDir: {}


### PR DESCRIPTION
## Summary

Reverts #181 (`e8298f2`). The hardening broke both the `gbrain-mcp` Deployment and `gbrain-sync` CronJob at runtime.

**Pod log symptoms** (via `kubectl logs -n gbrain`):

```
exec /usr/bin/caddy: operation not permitted
PermissionError: [Errno 13] Permission denied: 'gbrain'
```

- Caddy can't bind even the relocated `:8081` once `drop: [ALL]` strips `NET_BIND_SERVICE` (or whichever cap the binary's `setcap` was relying on).
- The gbrain CLI inside the published image is missing the `+x` bit for UID 1000 — the image was built assuming root.

## Impact

- `gbrain-mcp` Deployment: `CrashLoopBackOff` (160 restarts over 6h31m at the time of triage)
- `gbrain-sync` CronJob: failing every 5min since #181 landed
- → brain repo's `git → cluster Postgres` sync has been **dead for 6+ hours**. Any markdown push to `manamana32321/brain` since then has not been indexed in the cluster DB.

Reverting restores the sync loop immediately.

## Follow-up

Hardening should re-land in a fresh PR after image-side fixes:
1. Rebuild `ghcr.io/manamana32321/gbrain-mcp` with:
   - `chmod +x /usr/local/bin/gbrain` (or wherever the binary lives) so UID 1000 can exec it under `runAsNonRoot`.
   - `setcap cap_net_bind_service+ep /usr/bin/caddy` so `drop: [ALL]` doesn't strip the bind capability.
2. Locally verify with `docker run --read-only --user 1000 --cap-drop=ALL ...` before re-applying manifest hardening.
3. Then revert this revert (or cherry-pick #181 forward) on top of the fixed image.

## Test plan
- [ ] Merge → ArgoCD hard-refresh on `gbrain-mcp` Application
- [ ] `kubectl get pods -n gbrain` shows `gbrain-mcp` Running, no restarts
- [ ] Next cron tick (≤5min) shows a `Complete` job, not Failed
- [ ] `mcp__gbrain__query` returns results (read path live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)