### PR TITLE
feat(aws): add homelab-probe IAM user for read-only diagnostics

### DIFF
--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -104,3 +104,19 @@ resource "aws_iam_user_policy_attachment" "health_backup" {
 resource "aws_iam_access_key" "health_backup" {
   user = aws_iam_user.health_backup.name
 }
+
+# Read-only probe user — for ad-hoc cost/usage inspection across services.
+# Uses AWS-managed ReadOnlyAccess so future diagnostics (Lambda, ECS, IAM
+# audits, etc.) work without policy churn.
+resource "aws_iam_user" "probe" {
+  name = "homelab-probe"
+}
+
+resource "aws_iam_user_policy_attachment" "probe_readonly" {
+  user       = aws_iam_user.probe.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_access_key" "probe" {
+  user = aws_iam_user.probe.name
+}

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -47,3 +47,15 @@ output "health_backup_bucket" {
   description = "S3 bucket name for Health Hub backups"
   value       = aws_s3_bucket.health_backup.bucket
 }
+
+# Probe user (read-only diagnostics)
+output "probe_access_key_id" {
+  description = "Access Key ID for homelab-probe IAM user (read-only diagnostics)"
+  value       = aws_iam_access_key.probe.id
+}
+
+output "probe_secret_access_key" {
+  description = "Secret Access Key for homelab-probe IAM user"
+  value       = aws_iam_access_key.probe.secret
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- 새 IAM user `homelab-probe` 추가 (Terraform 선언적 관리)
- `arn:aws:iam::aws:policy/ReadOnlyAccess` (AWS 관리형) attach
- Access Key 출력 추가 (sensitive)

## Why
기존 `homelab-terraform` user는 권한이 좁아 S3 inventory, CloudWatch metrics, Cost Explorer 일부 dimension 조회 불가. 4월 S3 비용 폭증 ($29.30, 99% Glacier IR Tier-2 GET) 진단 중 막혀서, 향후 ad-hoc 진단을 위한 read-only inspector를 SSOT로 추가.

## Apply 결과
```
Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
probe_access_key_id = "AKIAVIOZFQJMT6N6NY65"
```

로컬 `~/.aws/credentials`에 `[homelab-probe]` 프로필 추가 완료, `aws sts get-caller-identity` 검증 OK.

## Security
- ReadOnlyAccess는 `s3:GetObject` 포함 — access key 유출 시 모든 S3 객체 read 가능
- 일회성 진단 끝나면 access key를 `Inactive`로 토글 권장 (Terraform `aws_iam_access_key.probe`의 `status` 속성)

## Test plan
- [x] `terraform plan` 깨끗 (3 add)
- [x] `terraform apply` 성공
- [x] `AWS_PROFILE=homelab-probe aws sts get-caller-identity` → `user/homelab-probe`
- [x] `AWS_PROFILE=homelab-probe aws s3api list-buckets` → 4 buckets returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)