### PR TITLE
fix(backup): add --size-only to media-backup rclone sync (~80% S3 savings)

### DIFF
--- a/k8s/immich/manifests/media-backup-cronjob.yaml
+++ b/k8s/immich/manifests/media-backup-cronjob.yaml
@@ -49,7 +49,11 @@ spec:
 
                   # Sync library to S3
                   # ionice idle class: Seafile과 동일 디스크(Seagate 1TB) 경합 방지
+                  # --size-only: 객체별 HEAD(mtime metadata read) 생략. 사진/영상은
+                  # immutable이라 size 일치 = 동일 파일. 빠진 경우 GIR-tier HEAD가
+                  # 객체수 × sync 횟수만큼 청구되어 월 $23 수준 폭발 (cf. PR #185 조사)
                   ionice -c 3 rclone sync /library s3:immich-backup-json-server/media/ \
+                    --size-only \
                     --s3-no-head \
                     --s3-no-check-bucket \
                     --fast-list \

--- a/k8s/seafile/manifests/media-backup-cronjob.yaml
+++ b/k8s/seafile/manifests/media-backup-cronjob.yaml
@@ -49,12 +49,16 @@ spec:
                   CONF
 
                   # Sync only 내 라이브러리 + 녹음 libraries to S3
-                  # --s3-no-head 불필요: S3 기존 데이터 삭제 후 전부 IT 오브젝트 (HEAD $0.005/1K)
+                  # --size-only: 객체별 HEAD(mtime read) 생략. Seafile fs object는
+                  # content-addressed(SHA1)라 한 번 쓰이면 immutable → size 일치 =
+                  # 동일 파일. 매일 sync × 객체수만큼 GIR HEAD 청구되는 패턴 차단
+                  # (cf. immich-backup PR #185 조사)
                   # ionice idle class: Seafile과 동일 디스크(Seagate 1TB) 경합 방지
                   ionice -c 3 rclone sync /seafile-data s3:seafile-backup-json-server/media/ \
                     --filter "+ seafile/seafile-data/storage/*/66a1e14f-8c91-45c8-ace8-b3c7f03ac63e/**" \
                     --filter "+ seafile/seafile-data/storage/*/32e4bb08-fc91-4ddd-992e-a6da1bb814fd/**" \
                     --filter "- **" \
+                    --size-only \
                     --s3-no-check-bucket \
                     --fast-list \
                     --transfers 2 \


### PR DESCRIPTION
## Summary
`immich-media-backup` + `seafile-media-backup` CronJob의 `rclone sync`에 `--size-only` 추가. 매일 객체별 HEAD 발생 → GIR Tier-2 요청 비용 폭발 차단.

## Root cause (4월 청구 진단)
- **4월 S3 청구**: $29.30 / 99% ap-northeast-2
- **80%가 Glacier IR Tier-2 GET = $23.70 (234만 건)**
- 객체 수 immich-backup 85,251 × 30일 ≈ 256만 → 측정값과 일치
- `rclone sync` default 비교 모드는 mtime + size. mtime은 LIST에 없고 객체 user metadata(`X-Amz-Meta-Mtime`)에 있어 **객체별 HEAD 1회씩** 호출
- HEAD는 S3 빌링상 GET과 동일 (Tier-2). INT의 Archive Instant Access tier(90일+)로 떨어진 객체는 GIR 단가 $0.01/1000 적용

## Fix
```diff
+ --size-only \
```
한 줄 추가. mtime 무시, 사이즈만 비교 → HEAD 0건.

## Why safe
- **immich media**: 사진/영상은 immutable (한 번 import 후 in-place 수정 안 함)
- **seafile media**: Seafile fs object는 content-addressed (SHA1 기반 chunking) → 내용이 바뀌면 다른 path에 새 object로 저장. 기존 object는 immutable

## Trade-offs (수용)
- EXIF in-place 편집은 백업에 미반영 (immich UI에서 EXIF 편집 기능 도입 시 재검토 필요)
- silent corruption 자동 감지 불가 (별도 verify cron으로 보완 가능, 향후 작업)
- mtime metadata는 PUT 시점 → restore 시 OS file mtime 정확하지 않음 (immich는 EXIF DateTimeOriginal 사용해서 영향 없음)

## Predicted billing impact
| 항목 | 현재 | After |
|---|---:|---:|
| GIR Tier-2 GET | $23.70 | ~$0 |
| 기타 (storage/INT monitoring/EarlyDelete/LIST) | $5.60 | $5.60 |
| **S3 합계** | **$29.30** | **~$5.60** |
| Tax | $2.94 | $0.56 |
| **월 총** | **$32.33** | **~$6.20** (81% 감소) |

추가로 seafile-backup은 현재 INT-FA(51GB)에 머물러 있지만 90일 후 GIR로 떨어지면 동일 폭탄 → 선제 차단.

## Test plan
- [x] Diff 확인 (manifest-only 변경)
- [ ] 머지 후 ArgoCD `immich`/`seafile` app sync 검증 (manifest-only라 즉시 반영, 다음 schedule 실행 시 적용)
- [ ] 다음 sync 실행 후 `kubectl logs -n immich job/immich-media-backup-...`로 transferred bytes 확인 (size-only 첫 실행에선 일부 false-negative로 재업로드 가능 — 모니터링)
- [ ] 5월 첫 주 [Cost Explorer](https://us-east-1.console.aws.amazon.com/costmanagement/home#/cost-explorer)에서 GIR Tier-2 비용 0 수렴 확인

## 관련
- IAM probe user: #185
- 4월 청구 분석 conversation context

🤖 Generated with [Claude Code](https://claude.com/claude-code)