### PR TITLE
fix(loop-web): mount emptyDir at /home/node/.cache for corepack

### DIFF
--- a/k8s/loop/web/deployment.yaml
+++ b/k8s/loop/web/deployment.yaml
@@ -49,6 +49,9 @@ spec:
             limits:
               memory: 512Mi
               cpu: 500m
+          volumeMounts:
+            - name: node-cache
+              mountPath: /home/node/.cache
           readinessProbe:
             httpGet:
               path: /
@@ -61,3 +64,6 @@ spec:
               port: 3000
             initialDelaySeconds: 30
             periodSeconds: 30
+      volumes:
+        - name: node-cache
+          emptyDir: {}


### PR DESCRIPTION
## Summary
- PR #183이 `loop-web`에 `readOnlyRootFilesystem: true`를 적용했으나 Node 22 image가 startup에 corepack을 실행해 `/home/node/.cache/node/corepack/v1`에 mkdir 시도 → `ENOENT` 188회 CrashLoopBackOff (15h간).
- 구 ReplicaSet `loop-web-5f465bff9f` (12d)가 트래픽을 받고 있어 외부 영향은 0이지만, 다음 image push가 막혀 있었음.
- 최소 쓰기 마운트 원칙 (관찰된 실패 경로만 emptyDir): `/home/node/.cache` 한 곳만 추가. `/tmp`, `/.next/cache`는 실패 관찰 시 추가.

## Test plan
- [ ] PR 머지 후 ArgoCD `loop` app hard-refresh
- [ ] 새 ReplicaSet `loop-web-*` 1/1 Ready, `RestartCount: 0`
- [ ] 구 ReplicaSet `loop-web-5f465bff9f` 0/0으로 scale down
- [ ] habits.json-server.win 외부 200 응답 + CSR 정상 (feedback_client_side_verify)
- [ ] kube-linter `no-read-only-root-fs` exclude에 loop-web 여전히 포함 (#169 잔여 sub-task — 이 PR에선 exclude 그대로 유지)

Refs: #169 (kube-linter sub-task), supersedes crash from #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)