### PR TITLE
feat(amang): add Redis ArgoCD ApplicationSet + blackbox probe

### DIFF
--- a/k8s/argocd/applications/apps/amang/redis.yaml
+++ b/k8s/argocd/applications/apps/amang/redis.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: amang-redis
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - env: production
+            branch: main
+          - env: staging
+            branch: main
+  template:
+    metadata:
+      name: redis-{{env}}
+      namespace: amang-redis-{{env}}
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: amang-redis-{{env}}
+      source:
+        path: 'infra/k8s/redis/overlays/{{env}}'
+        repoURL: https://github.com/skku-amang/main
+        targetRevision: '{{branch}}'
+        directory:
+          recurse: false
+      project: default
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - PrunePropagationPolicy=foreground

--- a/k8s/observability/blackbox-exporter/values.yaml
+++ b/k8s/observability/blackbox-exporter/values.yaml
@@ -102,6 +102,12 @@ serviceMonitor:
     - name: amang-api-staging
       url: http://api-server.amang-api-staging.svc.cluster.local:8000/health
       module: http_2xx_no_tls
+    - name: amang-redis
+      url: redis.amang-redis-production.svc.cluster.local:6379
+      module: tcp_connect
+    - name: amang-redis-staging
+      url: redis.amang-redis-staging.svc.cluster.local:6379
+      module: tcp_connect
     - name: loki
       url: http://loki.observability.svc.cluster.local:3100/ready
       module: http_2xx_no_tls


### PR DESCRIPTION
## 요약

[skku-amang/main#473](https://github.com/skku-amang/main/pull/473)의 동반 PR. AMANG repo의 Redis 매니페스트가 머지된 후 homelab 클러스터에 sync되도록 ArgoCD ApplicationSet을 추가하고, 클러스터 내부 blackbox-exporter에 redis TCP probe target을 등록합니다.

## 변경

- `k8s/argocd/applications/apps/amang/redis.yaml` 신규 — `amang-db` ApplicationSet 패턴 그대로. staging + production 두 환경 generator. CreateNamespace=true (`amang-redis-{env}` 신규 ns)
- `k8s/observability/blackbox-exporter/values.yaml` — `amang-redis`, `amang-redis-staging` TCP(6379) probe target 추가 (기존 mosquitto와 동일한 `tcp_connect` 모듈)

## 배포 순서

1. **선행**: [skku-amang/main#473](https://github.com/skku-amang/main/pull/473) 머지
2. 본 PR 머지
3. ArgoCD가 자동으로 amang-redis-staging 먼저 배포 → 검증
4. 1주 안정 후 production

## 검증

- [ ] amang#473 머지 확인 후 본 PR 머지
- [ ] ArgoCD Application `redis-staging` Synced + Healthy
- [ ] `kubectl -n amang-redis-staging get pod -l app=redis` Ready 1/1
- [ ] Grafana에서 `probe_success{instance=~".*amang-redis.*"}` 1 확인
- [ ] amang-api pod에서 `redis-cli -h redis.amang-redis-staging -a $PASS ping` → PONG

## 위험

- **데이터 영속성**: PVC 1Gi 생성됨. 회수 시 명시적 `kubectl delete pvc redis-pvc -n amang-redis-{env}` 필요 (orphan PV 방지)
- **롤백**: 본 PR revert → ArgoCD가 자동 prune. 단 PVC는 위와 같이 수동 정리

cc Use case 미정 상태 (TTL 2주, [skku-amang/main#473](https://github.com/skku-amang/main/pull/473) 본문 참조)