### PR TITLE
chore(prometheus): disable kubeEtcd rules (K3s embedded)

### DIFF
--- a/k8s/observability/prometheus/values.yaml
+++ b/k8s/observability/prometheus/values.yaml
@@ -1,10 +1,13 @@
-# K3s는 controller-manager, scheduler, proxy가 k3s server에 내장되어
+# K3s는 controller-manager, scheduler, proxy, etcd가 k3s server에 내장되어
 # 별도 metrics endpoint를 노출하지 않음 → 스크랩/rule 비활성화
 kubeControllerManager:
   enabled: false
 kubeScheduler:
   enabled: false
 kubeProxy:
+  enabled: false
+# K3s embedded etcd는 :2381 metrics endpoint 미노출. 룰 15개가 dead weight였음
+kubeEtcd:
   enabled: false
 
 prometheus-node-exporter:


### PR DESCRIPTION
## Summary
- K3s 내장 etcd는 별도 :2381 metrics endpoint를 노출하지 않음 → kube-prometheus-stack의 etcd ServiceMonitor·PrometheusRule 15개가 평생 발화하지 못하는 dead weight였음
- 이미 비활성화한 `kubeControllerManager`/`kubeScheduler`/`kubeProxy`와 동일한 컨벤션으로 `kubeEtcd: enabled: false` 추가

## What changes
- ServiceMonitor `prometheus-kube-prometheus-kube-etcd` 제거
- PrometheusRule `prometheus-kube-prometheus-etcd` 제거 (15 rules: etcdMembersDown, etcdNoLeader, etcdHighFsyncDurations 등)
- Grafana etcd 대시보드 (자동 provisioned 분) 제거

## Why
- 데이터가 들어오지 않는 룰은 alerting noise는 없지만 `kubectl get prometheusrules`·Prometheus UI에서 인지 부담만 추가
- 외부 etcd로 전환할 일이 생기면 `enabled: true` + endpoints 명시로 부활 가능

## Test plan
- [ ] ArgoCD `prometheus` app sync 후 `kubectl get servicemonitor -n observability prometheus-kube-prometheus-kube-etcd` → NotFound
- [ ] `kubectl get prometheusrule -n observability | grep -c etcd` → 0
- [ ] 기존 알림 receiver(Telegram) 정상 작동 — Watchdog 발화 유지 확인
- [ ] Prometheus `/api/v1/rules`에서 etcd 그룹 사라짐, 다른 그룹은 healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)