### PR TITLE
fix(alerts): disable broken smartctl chart rules, add DiskSmartFailed

### DIFF
--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -104,6 +104,20 @@ spec:
             summary: "CRITICAL: Many reallocated sectors on {{ $labels.device }}"
             description: "{{ $labels.device }} has {{ $value }} reallocated sectors. Replace disk."
 
+        # SMART overall verdict — 벤더 normalized threshold가 깨질 때 발화.
+        # reallocation 외의 실패 모드(spin-up 열화, read error rate, retry count 등)도
+        # 잡아냄. 어떤 attribute가 원인인지는 smartctl -A로 별도 확인 필요.
+        # smartctl-exporter chart의 smartCTLDeviceStatus 룰은 메트릭명 버그로
+        # (smartctl_device_status, 미존재) 작동하지 않아 직접 정의함.
+        - alert: DiskSmartFailed
+          expr: smartctl_device_smart_status != 1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "SMART overall FAILED: {{ $labels.device }} ({{ $labels.instance }})"
+            description: "{{ $labels.device }} SMART overall-health 판정이 FAIL. 즉시 디스크 교체 준비. `smartctl -A /dev/{{ $labels.device }}`로 어떤 attribute가 threshold를 넘었는지 확인."
+
     # CrowdSec IPS 알림
     - name: crowdsec
       rules:

--- a/k8s/observability/smartctl-exporter/values.yaml
+++ b/k8s/observability/smartctl-exporter/values.yaml
@@ -22,14 +22,18 @@ prometheusRules:
   extraLabels:
     release: prometheus
   rules:
+    # NVMe 전용 메트릭 — SATA HDD 환경에선 metric 자체가 없어 발화 불가
     smartCTLDeviceMediaErrors:
-      enabled: true
+      enabled: false
     smartCTLDeviceCriticalWarning:
-      enabled: true
+      enabled: false
     smartCTLDeviceAvailableSpareUnderThreshold:
-      enabled: true
+      enabled: false
+    # chart 버그: expr이 `smartctl_device_status`(미존재) 참조.
+    # 실제 메트릭명은 `smartctl_device_smart_status` →
+    # homelab-alerts의 DiskSmartFailed 룰로 대체
     smartCTLDeviceStatus:
-      enabled: true
+      enabled: false
     smartCTLDInterfaceSlow:
       enabled: false
     smartCTLDDeviceTemperature:


### PR DESCRIPTION
## Summary
- smartctl-exporter chart 룰 5개 중 **4개가 SATA HDD 환경에서 발화 불가**임을 클러스터 실측으로 확인 → 명시적 disable
- chart 버그 우회: 정확한 메트릭명을 쓰는 `DiskSmartFailed` 알림을 homelab-alerts에 추가

## Problem
실측 결과 ([Prometheus 메트릭 조회](https://prometheus.json-server.win/api/v1/label/__name__/values)):

| Chart 룰 | 참조 메트릭 | 문제 |
|---|---|---|
| smartCTLDeviceMediaErrors | smartctl_device_media_errors | NVMe 전용, 미존재 |
| smartCTLDeviceCriticalWarning | smartctl_device_critical_warning | NVMe 전용, 미존재 |
| smartCTLDeviceAvailableSpareUnderThreshold | smartctl_device_available_spare | NVMe 전용, 미존재 |
| **smartCTLDeviceStatus** | **smartctl_device_status** | **chart 버그 — 실제 메트릭은 `smartctl_device_smart_status`** |
| smartCTLDDeviceTemperature | smartctl_device_temperature | ✅ 정상 작동 |

NVMe 전용 메트릭 3개는 SATA 디스크만 있는 현 환경에서 metric 자체가 없어 룰이 평생 발화 불가. DeviceStatus는 chart의 expr이 잘못된 메트릭명을 참조해 SMART overall PASS/FAIL을 못 잡아냄.

## Changes
- [`k8s/observability/smartctl-exporter/values.yaml`](k8s/observability/smartctl-exporter/values.yaml): 4개 룰 `enabled: false`. Temperature만 유지
- [`k8s/observability/prometheus/manifests/alert-rules.yaml`](k8s/observability/prometheus/manifests/alert-rules.yaml): `smart` 그룹에 `DiskSmartFailed` 추가 (`smartctl_device_smart_status != 1`)

## Why DiskSmartFailed (not just delete the broken rule)
SMART 알림 3-stage cascade 완성:

| Stage | 룰 | 잡는 시점 |
|---|---|---|
| 1. 조기 (raw count tick) | DiskPendingSectors / DiskReallocatedSectors | 첫 read error로 sector pending |
| 2. 임계 초과 | DiskReallocatedSectorsCritical (>100) | 다량 reallocation |
| **3. 벤더 verdict** | **DiskSmartFailed** | normalized threshold 깨짐. spin-up 열화, retry count 등 reallocation 외 실패 모드도 catch |

Stage 3은 stage 1·2에선 안 보이는 axis(spin-up time, retry count 등)도 잡아내서 complementary.

## Test plan
- [ ] ArgoCD `smartctl-exporter` app sync 후 `kubectl get prometheusrule -n observability smartctl-exporter-prometheus-smartctl-exporter.rules -o yaml | grep -c '\\- alert:'` → 1 (Temperature only)
- [ ] ArgoCD `prometheus` app sync 후 `kubectl get prometheusrule -n observability homelab-alerts -o jsonpath='{.spec.groups[?(@.name==\"smart\")].rules[*].alert}'` → 4개 (Pending, Reallocated, ReallocatedCritical, **SmartFailed**)
- [ ] Prometheus `/api/v1/rules` 호출, smart 그룹 4개 모두 healthy
- [ ] sdb·sdc 모두 `smartctl_device_smart_status == 1` (PASSED) 상태이므로 DiskSmartFailed 발화 없어야 함
- [ ] 기존 알림 receiver(Telegram) 정상 작동 — Watchdog 발화 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)