### PR TITLE
feat(alerts): ArgoCD app health alerts (chart examples + Degraded)

### DIFF
--- a/k8s/argocd/values.yaml
+++ b/k8s/argocd/values.yaml
@@ -97,6 +97,37 @@ controller:
       enabled: true
       additionalLabels:
         release: prometheus
+    # chart 기본 PrometheusRule (commented examples 그대로 사용).
+    # 추가 도메인 알림은 homelab-alerts.argocd 그룹에서 관리.
+    rules:
+      enabled: true
+      additionalLabels:
+        release: prometheus
+      spec:
+        - alert: ArgoAppMissing
+          expr: |
+            absent(argocd_app_info) == 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "[Argo CD] No reported applications"
+            description: >
+              Argo CD has not reported any applications data for the past 15 minutes which
+              means that it must be down or not functioning properly.  This needs to be
+              resolved for this cloud to continue to maintain state.
+        - alert: ArgoAppNotSynced
+          expr: |
+            argocd_app_info{sync_status!="Synced"} == 1
+          for: 12h
+          labels:
+            severity: warning
+          annotations:
+            summary: "[{{`{{$labels.name}}`}}] Application not synchronized"
+            description: >
+              The application [{{`{{$labels.name}}`}} has not been synchronized for over
+              12 hours which means that the state of this cloud has drifted away from the
+              state inside Git.
 
 ## Dex
 dex:

--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -182,3 +182,19 @@ spec:
           annotations:
             summary: "Coral 부하 {{ $value | printf \"%.1f\" }}"
             description: "coral-1 5분 평균 load가 10분 이상 4 초과 (4-core 포화)."
+
+    # ArgoCD 앱 health — chart의 ArgoAppMissing/ArgoAppNotSynced로는 못 잡는
+    # Degraded/Missing/Unknown 상태를 12h 기다리지 않고 catch.
+    # Healthy/Progressing/Suspended는 의도적 정상 상태이므로 제외.
+    # ArgoAppMissing(controller 침묵), ArgoAppNotSynced(12h drift)는
+    # argo-cd chart values의 controller.metrics.rules에서 관리.
+    - name: argocd
+      rules:
+        - alert: ArgoAppDegraded
+          expr: argocd_app_info{health_status=~"Degraded|Missing|Unknown"} == 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "ArgoCD app degraded: {{ $labels.name }} ({{ $labels.health_status }})"
+            description: "Application {{ $labels.name }} (ns: {{ $labels.dest_namespace }}) is in {{ $labels.health_status }} state for 10+ minutes. argocd.json-server.win에서 상세 확인."


### PR DESCRIPTION
## Summary
새 [알림 룰 정책](k8s/observability/CLAUDE.md#알림-룰-작성-정책)에 따라 **재발명 회피** + **chart 부재 영역만 직접 정의**:

- **chart 기본 룰 활성화** (verbatim): `ArgoAppMissing`, `ArgoAppNotSynced`
  - argo-cd chart 9.0.6의 [commented example](https://github.com/argoproj/argo-helm/blob/argo-cd-9.0.6/charts/argo-cd/values.yaml#L1051-L1075) 그대로
- **homelab-alerts에 추가**: `ArgoAppDegraded`
  - chart에 동등한 룰 부재. Degraded/Missing/Unknown 상태를 10분 후 catch (12h NotSynced보다 빠른 운영 신호)

## Coverage 분석

| 시나리오 | 잡는 룰 | 출처 |
|---|---|---|
| Application controller 침묵 (15m+ 메트릭 무) | ArgoAppMissing | chart |
| Sync drift 12h+ (Image Updater write-back 실패 등) | ArgoAppNotSynced | chart |
| **App health Degraded/Missing/Unknown 10m+** | **ArgoAppDegraded** | **homelab-alerts (신규)** |
| ArgoCD 컨트롤러/repo-server/server pod down | TargetDown | kube-prometheus-stack (이미 작동) |
| Pod CrashLooping | KubePodCrashLooping | kube-prometheus-stack (이미 작동) |

## Why exclude Progressing/Suspended
- `Progressing`: rolling update 정상 과정
- `Suspended`: 의도적 정지 (예: dev 앱 hibernation)
- `Healthy`: 정상

→ `=~"Degraded|Missing|Unknown"`만 알림 대상

## Why not custom SyncFailed/ControllerDown
- **SyncFailed**: 결국 OutOfSync로 manifest되어 12h 후 ArgoAppNotSynced가 catch. 이벤트 기반 룰 추가는 noise 가치 낮음
- **ControllerDown**: kube-prometheus-stack의 `TargetDown`(`up==0` 모든 scrape target)이 이미 작동. 재발명 회피

## Test plan
- [ ] ArgoCD `argocd` app sync 후 새 PrometheusRule 생성 확인:
  ```
  kubectl get prometheusrules -n argocd
  ```
- [ ] homelab-alerts에 argocd 그룹 4번째 추가 확인:
  ```
  kubectl get prometheusrule -n observability homelab-alerts -o jsonpath='{.spec.groups[?(@.name=="argocd")].rules[*].alert}'
  ```
- [ ] Prometheus runtime에서 3개 룰 모두 healthy:
  ```
  kubectl exec ... -- wget -qO- http://localhost:9090/api/v1/rules | jq '.data.groups[] | select(.name | contains("argo"))'
  ```
- [ ] 47개 app 모두 Healthy + Synced 상태이므로 알림 firing 없어야 함

🤖 Generated with [Claude Code](https://claude.com/claude-code)