### PR TITLE
feat(observability): enable Image Updater metrics scrape

### DIFF
--- a/k8s/argocd/applications/infra/argocd-image-updater.yaml
+++ b/k8s/argocd/applications/infra/argocd-image-updater.yaml
@@ -20,6 +20,14 @@ spec:
               prefix: ghcr.io
               api_url: https://ghcr.io
               default: true
+        # silent CD failure 감지를 위한 메트릭 노출 (port 8081).
+        # 알림 룰은 후속 PR에서 추가 예정.
+        metrics:
+          enabled: true
+          serviceMonitor:
+            enabled: true
+            additionalLabels:
+              release: prometheus
         # 추가 ClusterRole/RoleBinding으로 secrets 권한 부여하는 건
         # 별도 Application argocd-image-updater-rbac (k8s/argocd-image-updater-rbac/)
         # 에서 관리. 이 chart는 extraObjects/extraDeploy를 지원하지 않음.


### PR DESCRIPTION
## Summary
argocd-image-updater chart의 메트릭 endpoint(port 8081) 활성화 + Prometheus ServiceMonitor 등록.

## Why
[k8s/CLAUDE.md Image Updater 섹션](k8s/CLAUDE.md#image-updater)에 박힌 정책 — "커스텀 앱 = Image Updater 필수, latest+수동재시작 금지" — 의 신뢰가 Image Updater 자체의 silent failure 가능성에 의존. 현재 클러스터:

- Image Updater pod: ✅ Running
- metrics endpoint: ❌ disabled (chart values 미설정)
- Prometheus scrape: ❌ 데이터 0

→ 새 이미지가 빌드됐는데 배포 안 되는 상황을 **알림으로 catch할 메트릭이 아예 없음**. 우선 scrape부터 활성화.

## Changes
[k8s/argocd/applications/infra/argocd-image-updater.yaml](k8s/argocd/applications/infra/argocd-image-updater.yaml)의 inline values에 추가:

\`\`\`yaml
metrics:
  enabled: true
  serviceMonitor:
    enabled: true
    additionalLabels:
      release: prometheus
\`\`\`

`release: prometheus` 라벨로 kube-prometheus-stack의 ruleSelector·serviceMonitorSelector가 자동 picked up.

## Why split from alert rule PR
실제 노출되는 메트릭명을 cluster에서 직접 확인하고 룰 작성하는 게 더 정확. 가정으로 작성한 룰이 broken-by-typo 되는 경우 ([PR #192의 smartctl 사례](https://github.com/manamana32321/homelab/pull/192)) 방지.

## Test plan
- [ ] ArgoCD `argocd-image-updater` app sync 후:
  - [ ] Service `argocd-image-updater-metrics` 생성 확인
  - [ ] ServiceMonitor `argocd-image-updater` 생성 확인 + label `release: prometheus`
  - [ ] Prometheus targets에서 argocd-image-updater up=1
- [ ] `argocd_image_updater_*` 메트릭 노출 확인:
  ```
  kubectl exec prometheus-... -- wget -qO- 'http://localhost:9090/api/v1/label/__name__/values' | jq '.data[] | select(startswith("argocd_image_updater"))'
  ```
- [ ] 후속 PR에서 알림 룰 작성

🤖 Generated with [Claude Code](https://claude.com/claude-code)