### PR TITLE
feat(alerts): Image Updater silent CD failure detection

### DIFF
--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -198,3 +198,42 @@ spec:
           annotations:
             summary: "ArgoCD app degraded: {{ $labels.name }} ({{ $labels.health_status }})"
             description: "Application {{ $labels.name }} (ns: {{ $labels.dest_namespace }}) is in {{ $labels.health_status }} state for 10+ minutes. argocd.json-server.win에서 상세 확인."
+
+    # Image Updater silent CD failure 감지.
+    # 정책상 모든 커스텀 앱이 Image Updater에 의존하므로 (k8s/CLAUDE.md 참조),
+    # 이게 silent fail하면 "왜 새 commit이 배포 안 되지?" 디버깅 헛수고로 이어짐.
+    # 메트릭 출처: argocd-image-updater chart 0.12.0+
+    - name: argocd-image-updater
+      rules:
+        # ArgoCD API write 실패 — argocd 모드에서 digest override를 Application CR에
+        # 박지 못함. 새 image 빌드돼도 배포 안 되는 가장 silent한 critical 시나리오.
+        - alert: ImageUpdaterArgoApiErrors
+          expr: increase(argocd_image_updater_k8s_api_errors_total[15m]) >= 3
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Image Updater: ArgoCD API write 실패 누적"
+            description: "15분간 {{ $value | humanize }}건의 ArgoCD API 에러. digest override write-back 실패 가능 → 새 image 빌드돼도 배포 안 됨. ServiceAccount RBAC/token 점검 필요."
+
+        # per-app 처리 에러 sustained — registry pull-secret 만료, annotation 오타,
+        # GHCR 일시 장애 등. application 라벨로 어느 앱이 문제인지 분리해서 알림.
+        - alert: ImageUpdaterImageErrors
+          expr: increase(argocd_image_updater_images_errors_total[30m]) >= 5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Image Updater errors: {{ $labels.application }}"
+            description: "{{ $labels.application }}에서 30분간 {{ $value | humanize }}건의 처리 에러. annotation/pull-secret/GHCR 접근 점검 필요."
+
+        # pod up이지만 폴링 멈춤 — 내부 hang, config 오류, network 문제.
+        # 정상 시 7개 app × 2분 폴링 = ~210 요청/h이므로 15분간 0이면 명백히 stuck.
+        - alert: ImageUpdaterStuck
+          expr: rate(argocd_image_updater_registry_requests_total[15m]) == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Image Updater stuck: registry 폴링 멈춤"
+            description: "{{ $labels.registry }}에 대한 폴링이 15분 이상 0건. pod up이지만 내부 stuck 가능. `kubectl logs -n argocd -l app.kubernetes.io/name=argocd-image-updater` 확인."


### PR DESCRIPTION
## Summary
[PR #196](https://github.com/manamana32321/homelab/pull/196)에서 enable한 Image Updater 메트릭을 기반으로 silent CD failure 감지 알림 3개 추가.

## Why
[k8s/CLAUDE.md Image Updater 정책](k8s/CLAUDE.md#image-updater)에 따라 모든 커스텀 앱이 Image Updater에 의존 (latest 태그 + 수동 재시작 금지). 이 도구가 silent fail하면 "왜 새 commit이 배포 안 되지?" 디버깅 헛수고로 이어짐.

community-vetted 룰이 어디에도 없음 (chart 내장 X, awesome-prometheus-alerts에도 X) → 정책상 직접 정의 정당 (k8s/observability/CLAUDE.md 검색 우선순위 4단계).

## Rules

| 룰 | severity | 잡는 시나리오 |
|---|---|---|
| **ImageUpdaterArgoApiErrors** | critical | argocd 모드에서 ArgoCD API write 실패 → digest override 못 박음 → 새 image 빌드돼도 배포 안 됨 (가장 silent) |
| **ImageUpdaterImageErrors** | warning | per-app 에러 sustained (pull-secret 만료, annotation 오타, GHCR 일시 장애 등) |
| **ImageUpdaterStuck** | warning | pod up이지만 GHCR 폴링 멈춤 (내부 hang/config 오류) |

## Threshold 근거
- ArgoCD API errors: 15분에 3건 이상 (단발 transient 무시, sustained 만 catch)
- Image errors: 30분에 5건 이상 + 5분 sustained (1-2건 일시 hiccup 무시)
- Stuck: 15분간 registry rate == 0 (정상 시 ~210 req/h이므로 15분 0이면 명백)

## Pod down은?
[kube-prometheus-stack TargetDown](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)이 이미 catch — 재발명 회피.

## Test plan
- [ ] ArgoCD `prometheus` app sync 후:
  - [ ] homelab-alerts에 `argocd-image-updater` 그룹 추가 확인
  - [ ] Prometheus runtime에서 3개 룰 모두 healthy
- [ ] 현재 environment에서 미발화 확인 (모든 카운터 정상 범위)
- [ ] 일부러 broken annotation으로 ImageUpdaterImageErrors 발화 테스트는 회귀 위험으로 SKIP — 운영 중 자연 발생 시 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)