### PR TITLE
chore(essentia): add CANVAS_BASE_URL to ConfigMap

### DIFF
--- a/k8s/essentia/api/configmap.yaml
+++ b/k8s/essentia/api/configmap.yaml
@@ -12,3 +12,4 @@ data:
   MINIO_BUCKET: essentia
   GOOGLE_CALLBACK_URL: https://api.essentia.json-server.win/auth/google/callback
   FRONTEND_URL: https://essentia.json-server.win
+  CANVAS_BASE_URL: https://canvas.skku.edu


### PR DESCRIPTION
## Summary

essentia api 가 6 곳에 하드코딩한 `https://canvas.skku.edu` baseUrl을 ConfigMap SSOT로 통합하기 위한 사전 단계.

## 변경

`k8s/essentia/api/configmap.yaml` 에 `CANVAS_BASE_URL: https://canvas.skku.edu` 한 줄 추가.

## Coordinated 머지 순서

1. **이 PR 먼저** (cluster ConfigMap에 key 추가, 기존 동작 영향 없음 — api 코드는 아직 하드코딩이라 사용 안 함)
2. **essentia-edu/essentia PR** (api 코드 `getOrThrow('CANVAS_BASE_URL')` 사용) 머지 → 새 image rollout 시 ConfigMap에서 값 read

순서 뒤집으면 essentia api 새 pod 가 첫 Canvas 호출 시 NestJS `getOrThrow` throw → 500.

## Test plan

- [x] `kubectl apply --dry-run=client -f k8s/essentia/api/configmap.yaml` ✔
- [ ] 머지 후 ArgoCD sync 확인 (manifest-only 변경, 동기 검증 가능)
- [ ] essentia PR 머지 후 새 api pod 정상 기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
