### PR TITLE
fix(essentia): pin numeric UID for telegram-relay

### DIFF
--- a/k8s/essentia/telegram-relay/deployment.yaml
+++ b/k8s/essentia/telegram-relay/deployment.yaml
@@ -50,5 +50,10 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            # node:22-alpine declares `USER node` (named). kubelet cannot
+            # verify runAsNonRoot against a named user — must pin numeric.
+            # node user is UID 1000 in the alpine image.
+            runAsUser: 1000
+            runAsGroup: 1000
             capabilities:
               drop: ["ALL"]


### PR DESCRIPTION
## Summary

PR-3 (#200) 의 telegram-relay Pod 가 머지 후 `CreateContainerConfigError` 로 2일 동안 실패 중:

\`\`\`
Error: container has runAsNonRoot and image has non-numeric user (node), 
cannot verify user is non-root
\`\`\`

## 원인

- `Dockerfile` 의 `USER node` (named user) — kubelet 이 runAsNonRoot 검증 불가
- `securityContext.runAsNonRoot: true` 만 있고 `runAsUser` 명시 안 함

## 변경

`deployment.yaml` 에 `runAsUser: 1000`, `runAsGroup: 1000` 추가 (node:22-alpine 의 node user UID).

## Test plan

- [x] kubectl kustomize render OK
- [ ] 머지 후 relay Pod Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)