### PR TITLE
fix(minecraft): expose server via LoadBalancer

### DIFF
--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -21,7 +21,7 @@ persistence:
 minecraftServer:
   eula: "TRUE"
   type: "PAPER"
-  version: "1.21.4"
+  version: "26.1.2"
   memory: "1G"
   difficulty: "normal"
   gameMode: "survival"

--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -18,9 +18,6 @@ persistence:
     enabled: true
     size: 5Gi
 
-serviceType: NodePort
-nodePort: 30565
-
 minecraftServer:
   eula: "TRUE"
   type: "PAPER"
@@ -32,6 +29,9 @@ minecraftServer:
   pvp: true
   motd: "JSON Homelab Minecraft Server"
   onlineMode: true
+  # k3s ServiceLB(klipper)가 노드 호스트의 25565를 직접 바인딩 → 공유기 포트포워딩 1:1
+  serviceType: LoadBalancer
+  servicePort: 25565
 
 strategyType: Recreate
 


### PR DESCRIPTION
## 배경

마인크래프트 서버를 실제로 쓰려고 보니 외부에서 접근이 안 됨. 원인 추적:

- 라이브 Service가 `ClusterIP` (25565/TCP) — 클러스터 밖에서 도달 불가
- `k8s/minecraft/values.yaml`는 `serviceType: NodePort` / `nodePort: 30565`로 선언돼 있었음
- **하지만 itzg/minecraft-server 차트 5.0.0의 service 키는 `minecraftServer.*` 블록 안에 위치** — 최상위 `serviceType`/`nodePort`는 차트가 무시 → 기본값 `ClusterIP`로 떨어짐
- ArgoCD는 "Synced"로 보고 (자기가 아는 매니페스트는 다 적용했으므로) — Synced ≠ 의도대로 동작의 사례

## 변경

### 1. Service 외부 노출 (LoadBalancer)
- `serviceType` / `nodePort`를 최상위에서 제거
- `minecraftServer` 블록 안에 `serviceType: LoadBalancer` + `servicePort: 25565` 추가
- k3s 내장 ServiceLB(klipper)가 노드 호스트의 25565를 직접 바인딩 → NodePort 30000번대 우회, 표준 포트 그대로

### 2. 서버 버전 bump (1.21.4 → 26.1.2)
- `1.21.4`(2024-12)는 약 17개월 묵음. 최신 자바에디션은 `26.1.2`(2026-04-09, Mojang 연도 기반 버전 체계로 전환). Paper도 26.1.2 빌드 제공
- 버전 핀이 최신이어야 친구들이 기본 런처로 바로 접속 가능 (구버전 핀이면 런처에서 옛 프로필 수동 선택 필요)
- 월드는 빈 상태라 자동 업그레이드 단방향 리스크 없음

## 머지 후 남은 작업 (PR 범위 외 — 사용자 직접)

1. 공유기 포트포워딩: WAN TCP `25565` → `json-server-1` (192.168.0.27)
2. OS 방화벽: json-server-1에서 `sudo ufw status` 확인 → `active`면 `sudo ufw allow 25565/tcp`
3. `mc.json-server.win` A 레코드는 이미 존재 (`cloudflare/dns.tf`, `proxied = false`) — 추가 작업 불필요
4. 친구는 클라이언트(26.1.2)에 `mc.json-server.win` 입력 (25565 기본 포트라 생략 가능). `onlineMode: true`라 정품 계정 필수

## 검증 계획

- [ ] ArgoCD sync 후 `kubectl get svc -n minecraft` → `TYPE: LoadBalancer`, `EXTERNAL-IP` 채워짐 확인
- [ ] Pod 재기동 후 26.1.2로 뜨는지 로그 확인 (`kubectl logs -n minecraft deploy/minecraft`)
- [ ] 클러스터 내부에서 노드 호스트 25565 TCP 접속 확인
- [ ] (공유기 포워딩 후) 외부에서 `mc.json-server.win:25565` 접속 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)