### PR TITLE
fix(minecraft): pin game version to 1.21.11 (last stable 1.x)

### DIFF
--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -21,7 +21,7 @@ persistence:
 minecraftServer:
   eula: "TRUE"
   type: "PAPER"
-  version: "26.1.2"
+  version: "1.21.11"
   memory: "1G"
   difficulty: "normal"
   gameMode: "survival"


### PR DESCRIPTION
## 배경

[PR #203](https://github.com/manamana32321/homelab/pull/203)에서 게임 버전을 최신 `26.1.2`로 올렸으나, 운영 도구 조사(tech-scout) 과정에서 **26.1.x 플러그인 생태계가 깨진 상태**임이 확인됨.

## 26.1.x 문제

- **Paper 26.1이 서버 jar 난독화/remapper를 제거** → 기존 플러그인 ABI 단절 ([PaperMC 26.1 공지](https://papermc.io/news/26-1/))
- **CoreProtect**(그리핑 롤백 — 사실상 독점 표준) 정식 26.1+ 빌드 미비, Patreon dev-build만 존재 ([CoreProtect #901](https://github.com/PlayPro/CoreProtect/issues/901))
- Paper `1.21.11` → `26.1.1` 월드 마이그레이션 실패 이슈 다수 ([Paper #13740](https://github.com/PaperMC/Paper/issues/13740))

## 변경

`minecraftServer.version`: `26.1.2` → `1.21.11`

| 버전 | 출시일 | 상태 |
|---|---|---|
| `1.21.11` | 2025-12-09 | 마지막 1.x 안정 버전, 플러그인 생태계 정상 |
| `26.1.2` | 2026-04-09 | 난독화 제거 분기점 이후, 플러그인 깨짐 |

두 버전은 **달력상 4개월 차이**에 불과 — 버전 *번호* 점프(1.21→26.1)는 Mojang의 연도 기반 체계 전환에 따른 착시. "구버전 후퇴"가 아니라 "ABI 단절선 한 칸 앞에 머무르기".

생태계(CoreProtect·UnifiedMetrics 등)가 26.x 정식 빌드를 내면 itzg 차트는 `version` 한 줄로 롤포워드 가능.

## 검증 계획

- [ ] ArgoCD sync 후 Pod이 `1.21.11`로 기동되는지 로그 확인 (`kubectl logs -n minecraft deploy/minecraft`)
- [ ] LoadBalancer Service (#203) 정상 유지 확인
- [ ] 월드 데이터: 빈 상태라 26.1.2 자동 업그레이드가 일어났더라도 영향 없음 — 1.21.11 기동 시 fresh 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)