### PR TITLE
fix(minecraft): enable RCON to unblock mcbackup sidecar rendering

### DIFF
--- a/k8s/minecraft/manifests/sealed-secret-rcon.yaml
+++ b/k8s/minecraft/manifests/sealed-secret-rcon.yaml
@@ -1,0 +1,13 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: minecraft-rcon-credentials
+  namespace: minecraft
+spec:
+  encryptedData:
+    rcon-password: AgDKdHjj2piod1TyET6oMPWgQNDs6XOMeWMPcFHSGuF0UO5Kp34rf4G2bYufh1QZjy++kgUJuBMwcp9H62v7LfBHR5m3ae4T3asoK1IvYqwNcGqEe2Jji57Q9vp9/0jSjkfe5SAppWeHZpaGpmv8cxu/3HP7WxTh/eZG5k/QRAEM9QoVZSRuaAWQ4VLGfXISPoNeyyU40WKVwJcsQG/qE1NurtWmIqQUmx5oN2hkYX40bFNZn6J+31QTPFrQ7iVZKJOeWcGZm7XdNAEVMfdvvPfu89oxZADZODsoZC3LaJ1UyusFy9xlmRMIF0DpsI6GPD1FWHpTVIpTYkFJ5q2QtSEY7AQJSwCwRVZg+sGdsvrzPotk79bRgDX2iU8MCV2/KuuvrlSo5Tg0zlYP/tBeopWwjxvGGc0EBpKSaAIM1apmqv4Dg8UtA9XT0J1zD3h5uiy9PWZvW9jxmLBIn3EtBl+VYvyEGzIKEu0dwm/nfomPhnBz8H1he3i7THvsgQwnm4ON9f8PEumRQfxKJY6mh5ygEJdmLb6BG+SQ9aQeOPSTArkrVo09v+DetKEQpuky4nmWQiGObVB3GXBs1KERbN5w4La9l5c5/hRbfskddtSHnE/F67+Qmmh8mrUgLRWJ9GGQkJSDnT7ARLkEdqCD2lqC26ObsYnNpVQpEJ3x/dEVPdOPWwfbDq93tguwOyxn6oDDf30gb7yxH5+RtBJeZB/4+gfuWSN/Fd5+Z13lrvh90nd4lGcAVeoC75rFAg==
+  template:
+    metadata:
+      name: minecraft-rcon-credentials
+      namespace: minecraft
+    type: Opaque

--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -32,6 +32,14 @@ minecraftServer:
   # k3s ServiceLB(klipper)가 노드 호스트의 25565를 직접 바인딩 → 공유기 포트포워딩 1:1
   serviceType: LoadBalancer
   servicePort: 25565
+  # RCON — mc-backup 사이드카가 save-off/save-on 명령용으로 필요.
+  # 차트 deployment.yaml의 사이드카 조건이 `mcbackup.enabled AND rcon.enabled`라
+  # rcon이 꺼져 있으면 사이드카가 통째로 렌더링 안 됨.
+  # 서비스는 ClusterIP 기본값 유지 (외부 노출 금지).
+  rcon:
+    enabled: true
+    existingSecret: minecraft-rcon-credentials
+    # secretKey 기본값 "rcon-password" 그대로 사용
 
 strategyType: Recreate
 


### PR DESCRIPTION
## 문제

[PR #212](https://github.com/manamana32321/homelab/pull/212) 머지 후 검증 단계에서 발견 — mcbackup 사이드카가 Deployment에 **렌더링 자체가 안 됨**. ArgoCD는 Synced/Healthy로 보고하나 Pod 컨테이너는 1개(`minecraft`만)에 머무름.

## 원인

itzg/minecraft-server chart 5.0.0의 `templates/deployment.yaml:343`:

```gotemplate
{{- if and .Values.mcbackup.enabled .Values.minecraftServer.rcon.enabled }}
- name: {{ template "minecraft.fullname" . }}-mc-backup
  ...
```

mc-backup 사이드카는 **`mcbackup.enabled` AND `rcon.enabled` 둘 다 true**일 때만 렌더링. mc-backup이 백업 직전 `save-off`, 직후 `save-on`을 RCON으로 호출해야 일관성이 보장되므로 RCON이 필수 의존성. PR #212에서 mcbackup만 켜고 rcon은 차트 기본값(false) 그대로 둬서 사이드카 조건이 안 맞았음.

`helm template`으로 로컬 검증 시에도 mc-backup 컨테이너가 출력되지 않았음 → 차트 의존성을 사전에 잡지 못한 게 원인.

## 변경

### 1. `k8s/minecraft/manifests/sealed-secret-rcon.yaml` (신규)
- `minecraft-rcon-credentials` SealedSecret, 키 `rcon-password`
- `openssl rand -base64 32`로 생성, scope=strict, namespace=minecraft
- 평문은 비밀번호 관리자에 별도 보관 완료

### 2. `k8s/minecraft/values.yaml` — `minecraftServer.rcon` 추가
```yaml
rcon:
  enabled: true
  existingSecret: minecraft-rcon-credentials
  # secretKey 기본값 "rcon-password" 그대로
  # serviceType 기본값 ClusterIP 그대로 (외부 노출 금지)
```

- `existingSecret` 지정 → chart가 자동 생성하던 `minecraft-rcon` Secret은 더 이상 생성 안 됨 (ArgoCD prune이 정리)
- RCON Service는 ClusterIP 그대로 — **외부 인터넷에 RCON 노출 절대 금지**

## 검증 (로컬)

`helm template`으로 rendered Deployment 확인:
- ✅ `minecraft` + `minecraft-mc-backup` 두 컨테이너 렌더링
- ✅ 둘 다 `RCON_PASSWORD` env로 `minecraft-rcon-credentials.rcon-password` 참조
- ✅ `minecraft-rcon` Service는 `type: ClusterIP`

## 머지 후 검증 계획

K8s rules verification checklist:
1. `kubectl patch app minecraft -n argocd ... refresh=hard` (즉시 reconcile)
2. ArgoCD Synced + Healthy, **resources 목록에 `SealedSecret/minecraft-rcon-credentials` 포함** 확인
3. `kubectl get secret minecraft-rcon-credentials -n minecraft -o json | jq '.data | map_values(@base64d | length)'` — `rcon-password` 키 비어있지 않은지 (empty SealedSecret 함정)
4. Pod READY=**2/2** (마크 + mc-backup 사이드카) — 핵심 검증 항목
5. `kubectl logs deploy/minecraft -c minecraft-mc-backup` — 사이드카 정상 부팅 로그
6. 첫 백업 후 `restic snapshots` (또는 `pauseIfNoPlayers`로 보류 시 수동 트리거)
7. **복원 리허설** — 임시 dir에 `restic restore`
8. Service `minecraft-rcon`이 ClusterIP인지, EXTERNAL-IP 없음 재확인 (보안)

## 관련

- Issue [#205](https://github.com/manamana32321/homelab/issues/205)
- 후속 PR [#212](https://github.com/manamana32321/homelab/pull/212) (mcbackup 사이드카 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)