### PR TITLE
fix(observability): relax NodeDiskAlmostFull SSD threshold 90% → 95%

### DIFF
--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -50,8 +50,9 @@ spec:
             description: "PVC {{ $labels.persistentvolumeclaim }} in {{ $labels.namespace }} is {{ $value | humanizePercentage }} full."
 
         - alert: NodeDiskAlmostFull
-          # SSD(`/`): 90% — Longhorn replica sparse 누적은 Trim Filesystem으로 회수 가능, 늦게 알려도 무방.
-          expr: (1 - node_filesystem_avail_bytes{fstype=~"ext4|xfs",mountpoint!~"/mnt/hdd-.*"} / node_filesystem_size_bytes{fstype=~"ext4|xfs",mountpoint!~"/mnt/hdd-.*"}) > 0.9
+          # SSD(`/`): 95% — Longhorn replica sparse 누적은 Trim Filesystem으로 회수 가능, 늦게 알려도 무방.
+          # kube-prometheus-stack의 `NodeFilesystemSpaceFillingUp` (predict_linear 4h)이 임박 위험을 별도 catch.
+          expr: (1 - node_filesystem_avail_bytes{fstype=~"ext4|xfs",mountpoint!~"/mnt/hdd-.*"} / node_filesystem_size_bytes{fstype=~"ext4|xfs",mountpoint!~"/mnt/hdd-.*"}) > 0.95
           for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary
- `NodeDiskAlmostFull` SSD 임계치 0.9 → 0.95 완화
- HDD(0.75)·PVC(0.80) 룰은 그대로 유지 — 도메인 특성(미디어 누적·앱 책임) 달라 별도 정책

## Why
- json-server-2 SSD (119GB) 가 일상적으로 ~90% 점유 → 알림 빈번
- 현재 99G/116G 사용. 분해:
  - Longhorn replicas 63G (prometheus 32G + essentia-minio 25G + 기타 6G)
  - K3s `/var/lib/rancher` 18G
  - 시스템 ~20G
- 임박 위험은 kube-prometheus-stack 기본 룰 `NodeFilesystemSpaceFillingUp` (predict_linear 4h)이 별도 catch — actionable warning 손실 없음

## Follow-up (별도 작업)
- Longhorn `Trim Filesystem` 으로 sparse 회수 (예상 5~10G)
- K3s containerd image GC
- Prometheus replica 분포 재검토 (server-1 단일 vs 양 노드)

## Test plan
- [ ] PR 머지 후 ArgoCD `prometheus` app hard-refresh + sync 확인
- [ ] `kubectl exec prometheus-prometheus-kube-prometheus-prometheus-0 -c prometheus -- wget -qO- http://localhost:9090/api/v1/rules`로 `NodeDiskAlmostFull` expr `> 0.95` 반영 확인
- [ ] `ALERTS{alertname="NodeDiskAlmostFull",alertstate="firing"}` 비어있는지 확인 (현재 90.3%인 server-2가 95% 밑이므로 resolve 되어야 함)