### PR TITLE
feat(minecraft): Discord 양방향 채팅 다리 — DiscordSRV v1.30.5

### DIFF
--- a/k8s/minecraft/manifests/configmap-discordsrv.yaml
+++ b/k8s/minecraft/manifests/configmap-discordsrv.yaml
@@ -1,0 +1,38 @@
+# DiscordSRV v1.30.5 config 최소 오버라이드.
+# 토큰은 DISCORDSRV_TOKEN env var로 주입 (SealedSecret minecraft-discord-credentials)
+# 플러그인 우선순위: JVM property → env var → .token 파일 → config.yml의 BotToken
+#
+# 미지정 키는 jar 내장 디폴트 자동 적용 (Bukkit copyDefaults 메커니즘).
+# 채널 ID는 알아도 봇 권한 없으면 무해 → ConfigMap 평문으로 보관 가능.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minecraft-discordsrv-config
+  namespace: minecraft
+  labels:
+    app.kubernetes.io/part-of: minecraft
+    app.kubernetes.io/component: discord-bridge
+data:
+  config.yml: |
+    # ConfigVersion: 플러그인 jar 버전과 일치해야 migration 트리거 안 됨
+    ConfigVersion: 1.30.5
+
+    # 채팅 다리 채널 (Discord 채널 ID — 친구 서버 단일 채널)
+    Channels: {"global": "1331975298027229196"}
+
+    # 콘솔 채널 비활성화 — Discord에서 서버 명령 실행은 보안 위험 (계정 탈취 시 서버 장악)
+    DiscordConsoleChannelId: ""
+
+    # 양방향 채팅 — Discord 메시지가 인게임에, 인게임 채팅이 Discord에 모두 전달
+    DiscordChatChannelDiscordToMinecraft: true
+    DiscordChatChannelMinecraftToDiscord: true
+
+    # 봇 상태 표시 — Discord 친구 목록에서 봇 클릭 시 "Playing on mc.json-server.win" 노출
+    DiscordGameStatus: ["playing on mc.json-server.win"]
+    DiscordOnlineStatus: ONLINE
+
+    # 계정 연결 강제 비활성화 — 향후 필요 시 활성화 (`/discord link` 명령 그대로 동작)
+    DiscordInviteLink: ""
+
+    # Presence intent 사용 안 함 (Discord Developer Portal 에서도 비활성화 해뒀음)
+    EnablePresenceInformation: false

--- a/k8s/minecraft/manifests/sealed-secret-discord.yaml
+++ b/k8s/minecraft/manifests/sealed-secret-discord.yaml
@@ -1,0 +1,13 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: minecraft-discord-credentials
+  namespace: minecraft
+spec:
+  encryptedData:
+    DISCORDSRV_TOKEN: AgClvjSXh1rksborJdZMo/ZEs1alkAQuh+PBdLXIPAA5fGBF4pFbhFYzOLy5QiNEdbn+sXM9P1BAJghmDRWOxeudGhVx4a2UGsYE5HAxJDv+CyflFq892Xum8r+lA7hoFOnc7375590bmGezUrKwJ81k5GcgNuxsK43OxrStOLG6lv6uOarWoHrvEcHf9O771p+6DqK6tIxLJXJsz3cszV2TyqiSUvhmx+ux6pH3BdcjYYQwM7lwpN4DVWMtHdU7ypiKt7FK6JK8VVuxABGlsP+1vyjnQDoHpJPZYM4orGKVXNJ6y6UtmvVEB95/q0hC7DCPKijM6IlWG/8rdVUgxyu+NqyNeHxmvvkxo/yb0x/hG8CLkrKBu/nSIlUpjINfECq6fvPt1+NbpbaMm2tipNSoSBKY9aW1KqBpRuWdEEo4aorsCvOKVWyZHsNU2gUowuh4jhdMBZtCkVeuZG/KbrSqnJVE1L1iRS0NwOSRUXoiVfZ03oOQbRGI9A8Klh4ccn0A/UrBpiGzjhzLqlqT3fmiYdZPnzwfTcE1OFoIopOCRUql8BxJ9Qh5k/QGByfrCaF7iZ4xuECOk3GUTgThzbaUXClQ20AntbKUlnt3PJ1aMd4tfG4kIcxLvTXA8K1zK/8c59yZ61/te6gvsABVw8n8LNmPLisFzSdjTD3TuZlwIAGFlb1zikk4sKOOP2GBQb1ukkHsFZB5ShGtokViliQmn9U8aPkdhwbJfSy+WTiSY9y1t3P22EkNAOeETLswc9h20Gx9PSWuCwaZZMAK1uti0d/84gq9MZM=
+  template:
+    metadata:
+      name: minecraft-discord-credentials
+      namespace: minecraft
+    type: Opaque

--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -40,19 +40,19 @@ minecraftServer:
     enabled: true
     existingSecret: minecraft-rcon-credentials
     # secretKey 기본값 "rcon-password" 그대로 사용
-  # sladkoff minecraft-prometheus-exporter 플러그인 (#206 모니터링)
-  # 설계: docs/superpowers/specs/2026-05-18-minecraft-monitoring-design.md
-  # Service: k8s/minecraft/manifests/service-metrics.yaml (port 9940)
+  # 플러그인 목록 — itzg가 컨테이너 기동 시 jar 다운로드 후 /data/plugins/ 에 배치.
+  # 각 플러그인의 config는 별도 ConfigMap → extraVolumes subPath 마운트 (아래).
   pluginUrls:
+    # sladkoff minecraft-prometheus-exporter (#206 모니터링) — port 9940 /metrics
     - https://github.com/sladkoff/minecraft-prometheus-exporter/releases/download/v3.1.2/minecraft-prometheus-exporter-3.1.2.jar
+    # DiscordSRV (#209 Discord 양방향 채팅 다리)
+    - https://github.com/DiscordSRV/DiscordSRV/releases/download/v1.30.5/DiscordSRV-Build-1.30.5.jar
 
 strategyType: Recreate
 
-# sladkoff exporter v3.1.2 config.yml 강제 주입.
-# 이 버전은 env var override 미지원 (소스 확인: master HEAD에만 추가됨, README가 master 기준이라 잘못 안내).
-# ConfigMap minecraft-prometheus-exporter-config 의 config.yml 을 플러그인 디렉토리에 subPath로 마운트.
-# Bukkit 의 saveDefaultConfig() 는 파일이 이미 존재하면 덮어쓰지 않으므로 우리 값이 살아남음.
+# 플러그인 config.yml 강제 주입 — Bukkit copyDefaults 가 mounted file 을 우선 사용.
 extraVolumes:
+  # sladkoff exporter v3.1.2 — env var override 미지원 (소스 확인, master HEAD 만 지원). config.yml 마운트로 host=0.0.0.0 강제.
   - volumeMounts:
       - name: prometheus-exporter-config
         mountPath: /data/plugins/PrometheusExporter/config.yml
@@ -61,6 +61,21 @@ extraVolumes:
       - name: prometheus-exporter-config
         configMap:
           name: minecraft-prometheus-exporter-config
+  # DiscordSRV v1.30.5 — 토큰은 env(DISCORDSRV_TOKEN)로, 채널/봇설정은 config.yml 로
+  - volumeMounts:
+      - name: discordsrv-config
+        mountPath: /data/plugins/DiscordSRV/config.yml
+        subPath: config.yml
+    volumes:
+      - name: discordsrv-config
+        configMap:
+          name: minecraft-discordsrv-config
+
+# DiscordSRV 가 DISCORDSRV_TOKEN env var 를 1순위로 읽음 (소스 확인: v1.30.5 DiscordSRV.java).
+# 토큰은 SealedSecret minecraft-discord-credentials 에 봉인되어 있고 envFrom 으로 메인 컨테이너에 주입.
+envFrom:
+  - secretRef:
+      name: minecraft-discord-credentials
 
 livenessProbe:
   initialDelaySeconds: 120


### PR DESCRIPTION
## 배경

[#209](https://github.com/manamana32321/homelab/issues/209) 운영 도구 마지막 트랙. 인게임 채팅 ↔ Discord 채널 양방향 브릿지로 친구들이 게임 안 들어와도 채팅 참여 가능, 접속/사망 이벤트도 Discord 채널에 표시.

## 도구 — DiscordSRV v1.30.5

- ★1,130, 마지막 릴리스 2026-04-24 (3주 전, 매우 활발)
- `api-version: 1.13` (Paper 1.21.x 하위호환 확실)
- 1.21 open issue 3개 (모두 minor edge case — offline mode, sync timing)
- **`DISCORDSRV_TOKEN` env var 1순위 지원** ([v1.30.5 DiscordSRV.java](https://github.com/DiscordSRV/DiscordSRV/blob/v1.30.5/src/main/java/github/scarsz/discordsrv/DiscordSRV.java) 소스 직접 확인) — sladkoff와 달리 env 친화적

## 변경 (3 파일)

### sealed-secret-discord.yaml (신규)
- `minecraft-discord-credentials` SealedSecret, 키 `DISCORDSRV_TOKEN`
- `scope=strict`, `namespace=minecraft`

### configmap-discordsrv.yaml (신규)
- `minecraft-discordsrv-config` ConfigMap — 최소 오버라이드, 나머지는 jar 디폴트
- 핵심 설정:
  - `Channels: {"global": "1331975298027229196"}` — 친구 서버 단일 채널 다리
  - `DiscordConsoleChannelId: ""` — **콘솔 채널 비활성** (Discord에서 서버 명령 실행은 보안 위험)
  - 양방향 chat ON (`DiscordChatChannelDiscordToMinecraft`/`MinecraftToDiscord: true`)
  - 봇 상태: `"playing on mc.json-server.win"` (친구가 봇 클릭 시 서버 주소 표시)
  - `EnablePresenceInformation: false` (Developer Portal 에서도 비활성)

### values.yaml (수정)
- `minecraftServer.pluginUrls`: DiscordSRV v1.30.5 jar URL 추가 (sladkoff 옆에 누적)
- 최상위 `envFrom`: `minecraft-discord-credentials` SealedSecret 메인 컨테이너에 주입
- `extraVolumes`: DiscordSRV config.yml 마운트 entry 추가

## 사전 검증 (helm template)

PR #213/#214 사고 교훈 따라 머지 전 4점 검증:
1. `PLUGINS` env에 **2개 jar 콤마구분**: sladkoff + DiscordSRV
2. `envFrom: minecraft-discord-credentials` 메인 컨테이너에 정상 주입
3. 두 ConfigMap subPath 마운트 정상 (`/data/plugins/{PrometheusExporter,DiscordSRV}/config.yml`)
4. 2개 컨테이너 유지 (`minecraft` + `minecraft-mc-backup` 사이드카 regression 없음)

## 머지 후 검증 계획

1. `kubectl patch app minecraft -n argocd ... refresh=hard` (즉시 reconcile)
2. ArgoCD Synced + Healthy, resources에 새 SealedSecret + ConfigMap 추가 확인
3. Secret 키 `DISCORDSRV_TOKEN` 비어있지 않음 (~70바이트)
4. Pod READY 2/2 유지
5. 컨테이너 로그에 `Loaded plugin DiscordSRV v1.30.5` + bot ready 메시지
6. **Discord 측 확인** (장수님이):
   - 봇이 채널에 온라인으로 표시
   - 게임 안에서 채팅 → Discord 채널에 메시지 도착
   - Discord에서 메시지 → 게임 채팅에 표시
7. mc-backup 사이드카 regression 없음 (restic 정상)
8. sladkoff 메트릭 정상 (`mc_tps` 등 여전히 노출)

## 보안 메모

봇 토큰이 작업 시작 시점에 chat에 한 번 노출됐음 (채팅 본인 소유로 위험 미미). 100% 안전 원하면 머지 전 Discord Developer Portal → Reset Token 한 번 더 → 새 토큰으로 봉인 재실행. 현 상태 유지도 무방.

## 관련

- Issue [#209](https://github.com/manamana32321/homelab/issues/209)
- 이전 도구 트랙: 백업 [#205](https://github.com/manamana32321/homelab/issues/205), 모니터링 [#206](https://github.com/manamana32321/homelab/issues/206)