### PR TITLE
fix(minecraft): DiscordSRV initContainer로 plugin dir 사전 생성

### DIFF
--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -61,15 +61,41 @@ extraVolumes:
       - name: prometheus-exporter-config
         configMap:
           name: minecraft-prometheus-exporter-config
-  # DiscordSRV v1.30.5 — 토큰은 env(DISCORDSRV_TOKEN)로, 채널/봇설정은 config.yml 로
+  # DiscordSRV v1.30.5 config —
+  # subPath 마운트는 부모 dir 을 root 소유로 만들어 plugin 이 messages.yml/linking.yml 등 다른 파일 작성 시 EACCES
+  # → ConfigMap 은 staging 경로(/etc/configmap/discordsrv)에 read-only directory mount,
+  #   initContainer 가 PVC 의 /data/plugins/DiscordSRV/config.yml 로 복사 (아래 initContainers).
   - volumeMounts:
-      - name: discordsrv-config
-        mountPath: /data/plugins/DiscordSRV/config.yml
-        subPath: config.yml
+      - name: discordsrv-config-staging
+        mountPath: /etc/configmap/discordsrv
+        readOnly: true
     volumes:
-      - name: discordsrv-config
+      - name: discordsrv-config-staging
         configMap:
           name: minecraft-discordsrv-config
+
+# DiscordSRV 가 자기 디렉토리에 messages.yml/linking.yml 등 여러 파일 작성하는데
+# subPath 마운트는 부모 dir 을 root 소유로 잠금 → 권한 거부.
+# initContainer 가 uid 1000 (itzg 기본 사용자) 으로 plugin dir 을 미리 만들고 config.yml 복사 → 메인 컨테이너가 평범한 dir로 인식.
+initContainers:
+  - name: discordsrv-config-seed
+    image: busybox:1.36
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 2000
+    command:
+      - sh
+      - -c
+      - |
+        set -eux
+        mkdir -p /data/plugins/DiscordSRV
+        cp /etc/configmap/discordsrv/config.yml /data/plugins/DiscordSRV/config.yml
+    volumeMounts:
+      - name: datadir
+        mountPath: /data
+      - name: discordsrv-config-staging
+        mountPath: /etc/configmap/discordsrv
+        readOnly: true
 
 # DiscordSRV 가 DISCORDSRV_TOKEN env var 를 1순위로 읽음 (소스 확인: v1.30.5 DiscordSRV.java).
 # 토큰은 SealedSecret minecraft-discord-credentials 에 봉인되어 있고 envFrom 으로 메인 컨테이너에 주입.


### PR DESCRIPTION
## 문제

[PR #217](https://github.com/manamana32321/homelab/pull/217) 머지 후 검증에서 DiscordSRV 플러그인 **로드 자체가 실패**:

```
ERROR: Could not load plugin 'DiscordSRV-Build-1.30.5.jar' in folder 'plugins/.paper-remapped'
Caused by: java.io.FileNotFoundException: 
  /data/plugins/DiscordSRV/messages.yml (Permission denied)
```

## 원인 — K8s ConfigMap subPath 마운트의 알려진 함정

- subPath 단일 파일 마운트가 부모 디렉토리(`/data/plugins/DiscordSRV/`)를 **root 소유**로 생성
- DiscordSRV는 `saveAllDefaults()`로 `messages.yml`, `linking.yml`, `voice.yml`, `alerts.yml`, `synchronization.yml` 등 **여러 파일을 자기 plugin dir에 작성**
- 메인 컨테이너 uid 1000이 root 소유 디렉토리에 쓰기 시도 → EACCES → plugin init fatal exception
- sladkoff는 자기 config.yml 하나만 다뤄서 무사 (그조차 saveDefault 시도하다 실패하지만 plugin은 동작 — error 처리 차이)

## 수정

`k8s/minecraft/values.yaml`만 변경 (manifests/ 그대로):

### Before — subPath 마운트 (실패 원인)
```yaml
extraVolumes:
  - volumeMounts:
      - mountPath: /data/plugins/DiscordSRV/config.yml
        subPath: config.yml
    volumes:
      - configMap: { name: minecraft-discordsrv-config }
```

### After — staging mount + initContainer 복사
```yaml
extraVolumes:
  # staging directory mount (메인 컨테이너 무관)
  - volumeMounts:
      - mountPath: /etc/configmap/discordsrv
        readOnly: true
    volumes:
      - configMap: { name: minecraft-discordsrv-config }

initContainers:
  - name: discordsrv-config-seed
    image: busybox:1.36
    securityContext:
      runAsUser: 1000
      runAsGroup: 2000
    command: [sh, -c, 'mkdir -p /data/plugins/DiscordSRV && cp /etc/configmap/discordsrv/config.yml /data/plugins/DiscordSRV/config.yml']
    volumeMounts:
      - { name: datadir, mountPath: /data }
      - { name: discordsrv-config-staging, mountPath: /etc/configmap/discordsrv, readOnly: true }
```

핵심: initContainer가 **uid 1000으로** PVC에 plugin dir과 config.yml을 미리 생성 → 메인 컨테이너의 plugin은 평범한 owned-directory로 인식 → `messages.yml` 등 다른 파일 자유 작성.

## 사전 검증 (helm template)

- initContainer 렌더링: busybox:1.36, runAsUser=1000, datadir + staging configmap 마운트 정상
- 메인 컨테이너에 DiscordSRV subPath 제거 (PVC가 자기 manage)
- 2개 컨테이너 유지 (`minecraft` + `minecraft-mc-backup` sidecar regression 없음)
- `PLUGINS` env + `envFrom: minecraft-discord-credentials` 그대로

## 머지 후 검증 계획

K8s rules verification checklist:
1. `kubectl patch app minecraft -n argocd ... refresh=hard`
2. ArgoCD Synced + Healthy, initContainer 새 리소스 트리 확인
3. Pod READY 2/2 (initContainer는 init phase에서 Complete)
4. 컨테이너 로그에 `Loaded plugin DiscordSRV v1.30.5` + bot ready 메시지 (이번엔 정상)
5. **Discord 측 확인** (장수님이):
   - 봇이 채널 온라인
   - 게임↔Discord 양방향 메시지 교환
6. mc-backup 사이드카 + sladkoff exporter regression 없음

## 관련

- Issue [#209](https://github.com/manamana32321/homelab/issues/209)
- 직전 PR [#217](https://github.com/manamana32321/homelab/pull/217) (subPath 방식, 실패)