### PR TITLE
feat(betterstack): external uptime probe via Better Stack (Coral replacement)

### DIFF
--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -4,6 +4,10 @@ export NOTION_TOKEN=""
 # Cloudflare API Token (for Terraform)
 export TF_VAR_cloudflare_api_token=""
 
+# Better Stack Uptime API Token (for Terraform — external probe monitoring)
+# Issue at https://uptime.betterstack.com/team/api-tokens
+export TF_VAR_betterstack_api_token=""
+
 # Default IP for A records (dynamic IP)
 export TF_VAR_default_ip=""
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,10 @@ homelab/
 │   ├── reflector/               # Secret 복제 설정
 │   ├── dashboard/               # Kubernetes Dashboard
 │   └── observability/           # 모니터링 스택 (OTel, Prometheus, Loki, Tempo)
+├── betterstack/             # Terraform - Better Stack Uptime (외부 probe)
+│   ├── versions.tf
+│   ├── variables.tf
+│   └── monitors.tf              # argocd.json-server.win monitor (Coral 후신)
 ├── .envrc                   # 공개 환경변수 (TF_VAR_*)
 └── .envrc.local             # 민감한 credentials (gitignored)
 ```
@@ -40,6 +44,7 @@ homelab/
 |------|------|--------|
 | `k8s/` | ArgoCD GitOps (자동 sync) | Git push → ArgoCD가 감지 |
 | `cloudflare/` | 수동 `terraform apply` | - |
+| `betterstack/` | 수동 `terraform apply` | - |
 
 ## Cloudflare/Terraform
 

--- a/betterstack/.terraform.lock.hcl
+++ b/betterstack/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/betterstackhq/better-uptime" {
+  version     = "0.20.17"
+  constraints = "~> 0.13"
+  hashes = [
+    "h1:K1FPyc3eOUk3QxC6fTwdI0h+zsIW9RGF6pNeIOz3l/A=",
+    "zh:01535c01a9fc0399bcef38fdb9988136cf4fa815a2da2a551e95976d194218e7",
+    "zh:0b4c8b20a0d41230c518719554e6be1409253bddc05e1d5d837b72aa50f70a27",
+    "zh:15e7d74e45dc14b4552ee5d5e75b31b39fe8da899f03150b133d72b4c10cc2c7",
+    "zh:167597e8181d86bc360601d8a2636ac9f24701024761381bcdbc2512df5784d6",
+    "zh:317d0bc046ef4f3cd68f296bc614f922c41a59553d1a0f6316e0e992382ddaa3",
+    "zh:375f643753c1d06e1b2552b385047c1343e2e3c512707c369d99c8328aa8277d",
+    "zh:37b95def81ae6cc6fa3c36592d3425387e8f23a827d2dfac326f1a99770c73f6",
+    "zh:5fe8e985e5b6b4e6ca638fe8ebdc963eb51d1cb50157bf0384fd2f9e93a93e8a",
+    "zh:8823d94d77794581a07797225165eb06dd4107e9614595fa06bde5daf1787d6d",
+    "zh:9d6da6451117142af0d52c7d09598b47cbca5f8abea248308fc51d68b5e3a4a9",
+    "zh:b6a45f70c165f3ce6d0c07c9e6b662f6d7e54a6385db1d590ff31c5b9b25d43f",
+    "zh:b983a5225198fc8ba79b81d6487508683eb2e628b5ea1b3a4e5528465f233ad5",
+    "zh:d701ee5ead0c78ac9d11a2c884392b54ecc2cb7cd790f2540387b2da3c3537d9",
+  ]
+}

--- a/betterstack/monitors.tf
+++ b/betterstack/monitors.tf
@@ -1,0 +1,50 @@
+###############################################################################
+# External uptime probe for argocd.json-server.win
+#
+# Replaces the Coral Dev Board external blackbox (retired 2026-05-18, PR #219).
+# Argo CD is the canonical external endpoint because it shares DNS, Cloudflare,
+# ingress controller, and TLS cert issuance with every other public service —
+# a fault in those layers will surface here first.
+#
+# Free plan: 10 monitors / 3-min check interval / multi-region default.
+# Notifications routed to Telegram via the Telegram integration registered
+# in the BetterStack UI (default escalation policy fan-outs to every active
+# integration; no policy_id needed).
+###############################################################################
+
+resource "betteruptime_monitor" "argocd" {
+  url                = "https://argocd.json-server.win"
+  monitor_type       = "status"
+  pronounceable_name = "Argo CD (json-server.win)"
+
+  # Free-plan minimum interval. 3 fails over ~9 min before incident opens.
+  check_frequency     = 180
+  request_timeout     = 30
+  recovery_period     = 0
+  confirmation_period = 60
+
+  # 2xx and 3xx are both fine — Argo CD redirects unauthenticated GET / to /login.
+  http_method           = "GET"
+  expected_status_codes = [200, 301, 302]
+  follow_redirects      = true
+  remember_cookies      = false
+
+  # TLS certificate watchdog (cert-manager renews at 30d remaining; alert at 7d as
+  # a fail-safe in case renewal stalls).
+  verify_ssl     = true
+  ssl_expiration = 7
+
+  # Domain registry expiry is managed by Cloudflare auto-renew; 30d is a buffer
+  # in case auto-renew silently fails.
+  domain_expiration = 30
+}
+
+output "argocd_monitor_id" {
+  description = "Better Stack monitor ID for argocd.json-server.win"
+  value       = betteruptime_monitor.argocd.id
+}
+
+output "argocd_monitor_url" {
+  description = "Direct URL to the monitor in Better Stack UI"
+  value       = "https://uptime.betterstack.com/team/monitors/${betteruptime_monitor.argocd.id}"
+}

--- a/betterstack/variables.tf
+++ b/betterstack/variables.tf
@@ -1,0 +1,5 @@
+variable "betterstack_api_token" {
+  description = "Better Stack Uptime API token. Issue at https://uptime.betterstack.com/team/api-tokens"
+  type        = string
+  sensitive   = true
+}

--- a/betterstack/versions.tf
+++ b/betterstack/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    betteruptime = {
+      source  = "BetterStackHQ/better-uptime"
+      version = "~> 0.13"
+    }
+  }
+
+  # S3 backend - credentials via AWS_PROFILE
+  backend "s3" {
+    bucket = "homelab-tfstate-361769566809"
+    key    = "betterstack/terraform.tfstate"
+    region = "ap-northeast-2"
+  }
+}
+
+provider "betteruptime" {
+  api_token = var.betterstack_api_token
+}

--- a/k8s/CLAUDE.md
+++ b/k8s/CLAUDE.md
@@ -256,8 +256,8 @@ livenessProbe:
 - 목적: 서비스 self-health
 
 > 외부 관측(인터넷→ingress→cluster 전체 경로)은 Coral Dev Board에서 운영했으나
-> 2026-05 은퇴. 후속 PR에서 **Cloudflare Health Checks**로 이행 예정 — DNS·Cloudflare·ingress·TLS
-> 전체 경로 검증은 그쪽으로 위임.
+> 2026-05 은퇴. 후속으로 **Better Stack Uptime**(SaaS, multi-region, 3분 interval, Telegram 직통)으로
+> 이행 — `betterstack/` Terraform IaC 참조. DNS·Cloudflare·ingress·TLS 전체 경로 검증은 그쪽으로 위임.
 
 ### 새 서비스 배포 시
 

--- a/k8s/observability/blackbox-exporter/values.yaml
+++ b/k8s/observability/blackbox-exporter/values.yaml
@@ -68,7 +68,7 @@ serviceMonitor:
 
   targets:
     # --- 내부 서비스 헬스체크 (ClusterIP, 서비스 자체 health) ---
-    # 외부 경로 헬스체크는 별도 (Cloudflare Health Checks 도입 예정) — see PR follow-up
+    # 외부 경로 헬스체크는 Better Stack Uptime SaaS가 담당 (`betterstack/` Terraform IaC)
     - name: argocd
       url: http://argocd-server.argocd.svc.cluster.local
       module: http_2xx_no_tls


### PR DESCRIPTION
## Summary
- Coral 외부 blackbox-exporter ([#219](https://github.com/manamana32321/homelab/pull/219)에서 은퇴) 후신
- Better Stack Uptime 무료 plan으로 외부 probe 이행
- `betterstack/` Terraform IaC 디렉토리 신설 (cloudflare/·aws/와 동급)

## Why Better Stack
- **독립 사고 도메인**: 우리 인프라(K3s/Cloudflare/ISP)와 운명 공유 안 함 → 진짜 외부 관측
- **Multi-region 기본**: 무료에서도 Europe·Americas·Asia 동시 체크 → 단일 ISP 장애 자동 제외
- **Telegram 직통**: BetterStack UI에서 1회 등록, escalation policy 자동 fan-out
- **IaC 친화**: `BetterStackHQ/better-uptime` Terraform provider로 monitor 선언적 관리

## Resources
| 파일 | 내용 |
|---|---|
| `betterstack/versions.tf` | provider + S3 backend (key: `betterstack/terraform.tfstate`) |
| `betterstack/variables.tf` | `betterstack_api_token` (sensitive) |
| `betterstack/monitors.tf` | argocd.json-server.win monitor (3분, expected 200/301/302, SSL 7d, domain 30d) |
| `.envrc.local.example` | `TF_VAR_betterstack_api_token=""` 항목 추가 |
| `CLAUDE.md`, `k8s/CLAUDE.md`, `k8s/observability/blackbox-exporter/values.yaml` | 문서/주석 정정 (Cloudflare HC → Better Stack) |

## Pre-merge (user action)
- [ ] BetterStack 무료 계정 가입 (https://betterstack.com)
- [ ] Telegram integration 등록 (BetterStack UI → Integrations → Telegram)
- [ ] API token 발급 → `.envrc.local`에 `TF_VAR_betterstack_api_token=...` 추가

## Apply plan (post-merge)
1. `cd betterstack && terraform plan` → 생성 1개(monitor) 확인
2. `terraform apply` → 사용자 승인 후 apply
3. BetterStack UI에서 monitor status `up` 확인 (3분 내)
4. 의도적으로 argocd ingress down 시뮬레이션 (선택) → Telegram 알림 도착 확인

## 후속 (별도 작업)
- monitor 증설 결정 시 (현재 1개로 시작) → `monitors.tf`에 resource 추가
- BetterStack status page 공개 여부 (현재 미설정)