### PR TITLE
feat(minecraft): BlueMap 웹맵 v5.18 도입 (3D web viewer)

### DIFF
--- a/cloudflare/dns.tf
+++ b/cloudflare/dns.tf
@@ -83,6 +83,16 @@ resource "cloudflare_record" "minecraft" {
   proxied = false
 }
 
+# BlueMap 웹 뷰어 — HTTP. proxied=false + cert-manager DNS01 (다른 서비스와 동일 패턴 유지)
+resource "cloudflare_record" "minecraft_map" {
+  zone_id = cloudflare_zone.main.id
+  name    = "mcmap"
+  type    = "A"
+  content = var.default_ip
+  proxied = false
+  comment = "BlueMap 3D web viewer for Minecraft"
+}
+
 resource "cloudflare_record" "k8s" {
   zone_id = cloudflare_zone.main.id
   name    = "k8s"

--- a/k8s/minecraft/manifests/configmap-bluemap.yaml
+++ b/k8s/minecraft/manifests/configmap-bluemap.yaml
@@ -1,0 +1,58 @@
+# BlueMap v5.18 minimal config override.
+# 토큰류 없음 (Mojang 클라이언트 jar 다운로드 동의 + webserver bind 만 필수).
+# 미지정 키는 jar 내장 디폴트 자동 적용 (HOCON 파서가 default fallback).
+# Maps configs (overworld/nether/end) 는 plugin 이 첫 실행 시 자동 생성.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minecraft-bluemap-config
+  namespace: minecraft
+  labels:
+    app.kubernetes.io/part-of: minecraft
+    app.kubernetes.io/component: webmap
+data:
+  core.conf: |
+    # Mojang EULA 동의 + 클라이언트 jar 다운로드 허용 (필수 — false 시 부팅 중단)
+    # 본 jar 는 BlueMap 이 블록 텍스처/모델 추출용으로 사용. 사용자가 마인크래프트 라이센스 보유자여야 함.
+    accept-download: true
+
+    # 데이터 디렉토리 (BlueMap 작업 파일, 렌더 진행상황 등)
+    data: "bluemap"
+
+    # 렌더 스레드 — 메인 컨테이너 리소스(limits.cpu=1000m) 고려해 2로 제한.
+    # 0 또는 음수 = (CPU 코어 수 + 값). 1 코어 환경에서 2 정도가 적정.
+    render-thread-count: 2
+
+    # 메트릭 옵트아웃 (BlueMap 익명 통계)
+    metrics: false
+
+  webserver.conf: |
+    enabled: true
+
+    # 웹 파일들의 루트 — BlueMap 이 html/js/textures 를 여기 생성
+    webroot: "bluemap/web"
+
+    # ip: clusterIP Service 에서 스크레이프 가능하도록 모든 인터페이스 바인드.
+    # source 확인: WebserverConfig.java 의 'ip' 필드.
+    ip: "0.0.0.0"
+
+    # port: chart 의 별도 Service(8100) 와 매칭. default 가 8100 이지만 명시.
+    port: 8100
+
+  plugin.conf: |
+    # 실시간 플레이어 마커 (웹맵에 누가 어디 있는지 헤드 아이콘)
+    live-player-markers: true
+
+    # 스펙테이터 모드는 마커 숨김 (관전 중인 운영자가 위치 노출되지 않도록)
+    hidden-game-modes: ["spectator"]
+
+    # 베니쉬/투명/스니킹 처리 — 기본값 명시
+    hide-vanished: true
+    hide-invisible: true
+    hide-sneaking: false
+
+    # 스킨 다운로드 활성화 (마커에 플레이어 얼굴 표시)
+    skin-download: true
+
+    # 작업 큐 size — 기본값 충분
+    full-update-interval: 1440  # 분 단위 — 1일에 1번 풀 업데이트

--- a/k8s/minecraft/manifests/ingress-bluemap.yaml
+++ b/k8s/minecraft/manifests/ingress-bluemap.yaml
@@ -1,0 +1,29 @@
+# BlueMap 웹맵 Ingress — mcmap.json-server.win
+# proxied=false + cert-manager DNS01 — 다른 홈랩 앱(grafana/immich 등)과 동일 패턴.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minecraft-bluemap
+  namespace: minecraft
+  labels:
+    app.kubernetes.io/part-of: minecraft
+    app.kubernetes.io/component: webmap
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns01
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: mcmap.json-server.win
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minecraft-bluemap
+                port:
+                  number: 8100
+  tls:
+    - secretName: minecraft-bluemap-tls
+      hosts:
+        - mcmap.json-server.win

--- a/k8s/minecraft/manifests/service-bluemap.yaml
+++ b/k8s/minecraft/manifests/service-bluemap.yaml
@@ -1,0 +1,21 @@
+# BlueMap webserver(port 8100)용 별도 Service.
+# 메인 LoadBalancer(25565, TCP Minecraft 프로토콜)에 섞지 않음 — Ingress 라우팅 명료성.
+apiVersion: v1
+kind: Service
+metadata:
+  name: minecraft-bluemap
+  namespace: minecraft
+  labels:
+    app: minecraft-bluemap
+    app.kubernetes.io/part-of: minecraft
+    app.kubernetes.io/component: webmap
+spec:
+  type: ClusterIP
+  selector:
+    # 차트가 생성한 Pod 라벨 (BlueMap plugin 이 같은 Pod 안 메인 컨테이너에서 실행)
+    app: minecraft
+  ports:
+    - name: http
+      port: 8100
+      targetPort: 8100
+      protocol: TCP

--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -47,6 +47,8 @@ minecraftServer:
     - https://github.com/sladkoff/minecraft-prometheus-exporter/releases/download/v3.1.2/minecraft-prometheus-exporter-3.1.2.jar
     # DiscordSRV (#209 Discord 양방향 채팅 다리)
     - https://github.com/DiscordSRV/DiscordSRV/releases/download/v1.30.5/DiscordSRV-Build-1.30.5.jar
+    # BlueMap (#208 웹맵 3D viewer) — v5.18 = 1.21.x 호환 마지막 (v5.19+는 api-version 26.1.1 요구)
+    - https://github.com/BlueMap-Minecraft/BlueMap/releases/download/v5.18/bluemap-5.18-paper.jar
 
 strategyType: Recreate
 
@@ -73,10 +75,19 @@ extraVolumes:
       - name: discordsrv-config-staging
         configMap:
           name: minecraft-discordsrv-config
+  # BlueMap v5.18 config — 동일 staging+initContainer 패턴.
+  # plugin 이 maps/, web/, data/ 등 다중 디렉토리·파일을 plugin dir에 작성하므로 subPath 마운트 불가.
+  - volumeMounts:
+      - name: bluemap-config-staging
+        mountPath: /etc/configmap/bluemap
+        readOnly: true
+    volumes:
+      - name: bluemap-config-staging
+        configMap:
+          name: minecraft-bluemap-config
 
-# DiscordSRV 가 자기 디렉토리에 messages.yml/linking.yml 등 여러 파일 작성하는데
-# subPath 마운트는 부모 dir 을 root 소유로 잠금 → 권한 거부.
-# initContainer 가 uid 1000 (itzg 기본 사용자) 으로 plugin dir 을 미리 만들고 config.yml 복사 → 메인 컨테이너가 평범한 dir로 인식.
+# 멀티파일 plugin 디렉토리는 subPath 마운트가 부모 dir 을 root 소유로 잠금 → EACCES.
+# initContainer 가 uid 1000 (itzg 기본 사용자) 으로 plugin dir 을 미리 만들고 config 복사 → 메인 컨테이너가 평범한 dir로 인식.
 initContainers:
   - name: discordsrv-config-seed
     image: busybox:1.36
@@ -97,6 +108,27 @@ initContainers:
         mountPath: /data
       - name: discordsrv-config-staging
         mountPath: /etc/configmap/discordsrv
+        readOnly: true
+  - name: bluemap-config-seed
+    image: busybox:1.36
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 2000
+    command:
+      - sh
+      - -c
+      - |
+        set -eux
+        mkdir -p /data/plugins/BlueMap
+        # core/webserver/plugin.conf — 우리 override 만 복사. maps/*.conf 는 plugin이 첫 실행 시 월드 dimension 별로 자동 생성.
+        cp /etc/configmap/bluemap/core.conf /data/plugins/BlueMap/core.conf
+        cp /etc/configmap/bluemap/webserver.conf /data/plugins/BlueMap/webserver.conf
+        cp /etc/configmap/bluemap/plugin.conf /data/plugins/BlueMap/plugin.conf
+    volumeMounts:
+      - name: datadir
+        mountPath: /data
+      - name: bluemap-config-staging
+        mountPath: /etc/configmap/bluemap
         readOnly: true
 
 # DiscordSRV 가 DISCORDSRV_TOKEN env var 를 1순위로 읽음 (소스 확인: v1.30.5 DiscordSRV.java).

--- a/k8s/observability/blackbox-exporter/values.yaml
+++ b/k8s/observability/blackbox-exporter/values.yaml
@@ -129,3 +129,6 @@ serviceMonitor:
     - name: minecraft
       url: minecraft.minecraft.svc.cluster.local:25565
       module: tcp_connect
+    - name: minecraft-bluemap
+      url: http://minecraft-bluemap.minecraft.svc.cluster.local:8100
+      module: http_2xx_no_tls


### PR DESCRIPTION
## 배경

[#208](https://github.com/manamana32321/homelab/issues/208) 운영 도구 마지막 카테고리. 인게임 들어가지 않고 브라우저에서 3D 월드 viewer + 실시간 플레이어 위치 마커.

## 도구 버전 선정 — v5.18 (api-version 1.21.6)

| BlueMap | api-version | 호환 |
|---|---|---|
| v5.20 (최신) | 26.1.1 | ❌ 1.21.x 미지원 |
| v5.19 | 26.1.1 | ❌ |
| **v5.18 (채택)** | **1.21.6** | ✅ 1.21.x 호환 |
| v5.17 | 1.21.6 | ✅ |

각 버전 paper jar 직접 다운로드 후 `plugin.yml` 검사로 cutoff 확인. 우리가 1.21.11 핀에 머무는 비용이 또 드러난 케이스 — sladkoff(api 1.16, 광범위 호환)와 정반대로 BlueMap은 최신만 지원.

## 변경 (6 파일)

| 파일 | 변경 |
|---|---|
| `cloudflare/dns.tf` | `mcmap.json-server.win` A record 추가 (proxied=false, cert-manager DNS01) |
| `k8s/minecraft/manifests/configmap-bluemap.yaml` | core.conf (`accept-download:true`, render-thread-count:2) + webserver.conf (`ip:0.0.0.0`, port:8100) + plugin.conf (`live-player-markers:true`) |
| `k8s/minecraft/manifests/service-bluemap.yaml` | ClusterIP Service port 8100 |
| `k8s/minecraft/manifests/ingress-bluemap.yaml` | Ingress traefik + cert-manager DNS01 (다른 앱과 동일 패턴) |
| `k8s/minecraft/values.yaml` | pluginUrls/extraVolumes/initContainer 누적 (5번째 plugin) |
| `k8s/observability/blackbox-exporter/values.yaml` | `minecraft-bluemap` http target 추가 (k8s rule "새 서비스에 Blackbox probe" 준수) |

## 사전 검증

### helm template
- `PLUGINS` env에 3개 jar 콤마구분 (sladkoff + DiscordSRV + BlueMap)
- 2개 initContainer (`discordsrv-config-seed` + `bluemap-config-seed`)
- 3개 ConfigMap volumes (prometheus + discordsrv + bluemap)
- 컨테이너 2개 유지 (sidecar regression 없음)

### terraform plan
```
Plan: 1 to add, 0 to change, 0 to destroy.
+ cloudflare_record.minecraft_map (mcmap A record)
```

### ConfigMap YAML 유효성
- `core.conf` accept-download: true ✓
- `webserver.conf` ip: 0.0.0.0 ✓

## 머지 후 단계 (사용자 액션 필요)

1. **`cd cloudflare && terraform plan` → 확인 → `terraform apply`** — DNS 1개 생성 (수동 승인 필수, cost ~$0)
2. ArgoCD 자동 sync — Pod 재기동, initContainer가 BlueMap config seed, plugin jar 다운로드
3. **첫 풀 청크 렌더** — CPU 부하 (월드 크기에 따라 1~30분). 친구 접속 없을 때 권장
4. cert-manager가 Let's Encrypt 인증서 발급 (DNS01 challenge ~1분)
5. `https://mcmap.json-server.win` 접속 — 3D viewer 표시

## 검증 (post-merge)

K8s rules verification checklist:
1. `kubectl patch app apps -n argocd ... refresh=hard` (Application CR 트리 reconcile)
2. ArgoCD `minecraft` + `blackbox-exporter` Synced + Healthy
3. ConfigMap `minecraft-bluemap-config` 3 키 존재
4. Pod READY 2/2 유지
5. minecraft 컨테이너 로그: `[BlueMap] Loaded plugin BlueMap v5.18` + `Started Webserver`
6. `kubectl get ingress -n minecraft minecraft-bluemap` Address 채워짐
7. cert-manager Certificate Ready (`kubectl get cert -n minecraft minecraft-bluemap-tls`)
8. **Discord/sladkoff regression 체크** — `mc_tps`, `mc_player_online` 정상, DiscordSRV 한국어 메시지 정상
9. Blackbox `probe_success{instance=~".*minecraft-bluemap.*"}` 켜짐

## 리스크

- **첫 렌더 CPU 부하**: render-thread-count: 2 로 제한했으나 부팅 직후 풀 청크 스캔 시 mc_tps 일시 하락 가능. 친구 접속 없을 때 머지 권장
- **plugin v5.18은 1.21.x 호환 마지막**: 향후 BlueMap 업데이트는 26.x 마이그레이션 시점까지 보류

## 관련

- Issue [#208](https://github.com/manamana32321/homelab/issues/208)
- 이전 plugin 패턴: [#212](https://github.com/manamana32321/homelab/pull/212)/[#217](https://github.com/manamana32321/homelab/pull/217)/[#218](https://github.com/manamana32321/homelab/pull/218)/[#220](https://github.com/manamana32321/homelab/pull/220)