### PR TITLE
feat(cloudflare): learningx-mcp landing page (Cloudflare Pages)

### DIFF
--- a/cloudflare/outputs.tf
+++ b/cloudflare/outputs.tf
@@ -2,3 +2,13 @@ output "zone_id" {
   description = "Cloudflare Zone ID"
   value       = cloudflare_zone.main.id
 }
+
+output "learningx_landing_subdomain" {
+  description = "Cloudflare Pages default subdomain (e.g. essentia-learningx.pages.dev)"
+  value       = cloudflare_pages_project.learningx_landing.subdomain
+}
+
+output "learningx_landing_url" {
+  description = "Production URL for the LearningX MCP landing page"
+  value       = "https://learningx.${var.zone_name}"
+}

--- a/cloudflare/pages.tf
+++ b/cloudflare/pages.tf
@@ -1,0 +1,75 @@
+# Cloudflare Pages — @essentia-edu/learningx-mcp 마케팅 landing.
+#
+# 정적 export (Next.js `output: "export"`)된 산출물을 Cloudflare 엣지에서 서빙.
+# 서버 인프라 0대, build/bandwidth 무료 한도(500 builds/월, unlimited bandwidth)
+# 내에서 처리. PR마다 preview deploy 자동 발급.
+#
+# Prerequisite (한 번만 콘솔에서):
+# Cloudflare 대시보드 → Workers & Pages → Connect to GitHub → essentia-edu org
+# install. cloudflare provider는 OAuth 자체를 만들지 못하므로 첫 연결만 수동.
+# 한 번 연결되면 이후 project 추가는 본 terraform이 선언적으로 관리.
+
+resource "cloudflare_pages_project" "learningx_landing" {
+  account_id        = var.cloudflare_account_id
+  name              = "essentia-learningx"
+  production_branch = "main"
+
+  source {
+    type = "github"
+    config {
+      owner                         = "essentia-edu"
+      repo_name                     = "essentia"
+      production_branch             = "main"
+      pr_comments_enabled           = true
+      deployments_enabled           = true
+      production_deployment_enabled = true
+      preview_deployment_setting    = "all"
+      preview_branch_includes       = ["*"]
+      preview_branch_excludes       = []
+    }
+  }
+
+  build_config {
+    # 모노레포 root에서 install + landing app만 build. 빌드 시간 단축을 위해
+    # apps/api, apps/web은 빌드하지 않음.
+    build_command   = "pnpm install --frozen-lockfile && pnpm --filter @essentia/landing build"
+    destination_dir = "apps/landing/out"
+    root_dir        = ""
+  }
+
+  deployment_configs {
+    production {
+      environment_variables = {
+        NODE_VERSION = "22"
+      }
+      compatibility_date  = "2025-11-01"
+      compatibility_flags = ["nodejs_compat"]
+    }
+    preview {
+      environment_variables = {
+        NODE_VERSION = "22"
+      }
+      compatibility_date  = "2025-11-01"
+      compatibility_flags = ["nodejs_compat"]
+    }
+  }
+}
+
+resource "cloudflare_pages_domain" "learningx_landing" {
+  account_id   = var.cloudflare_account_id
+  project_name = cloudflare_pages_project.learningx_landing.name
+  domain       = "learningx.${var.zone_name}"
+}
+
+# DNS CNAME → Cloudflare Pages project subdomain.
+# proxied = true: Cloudflare가 SSL/CDN 자동 처리 (Universal SSL이 single-level
+# subdomain은 커버). multi-level (예: a.b.json-server.win)이었으면
+# proxied=false + cert-manager DNS01 였을 것.
+resource "cloudflare_record" "learningx_landing" {
+  zone_id = cloudflare_zone.main.id
+  name    = "learningx"
+  type    = "CNAME"
+  content = cloudflare_pages_project.learningx_landing.subdomain
+  proxied = true
+  comment = "@essentia-edu/learningx landing (Cloudflare Pages)"
+}


### PR DESCRIPTION
## Summary

`@essentia-edu/learningx-mcp` 마케팅 landing page를 Cloudflare Pages 정적 호스팅에 선언적으로 배포. 서버 인프라 0대, 무료 한도 내 운영. PR마다 preview deploy 자동 발급.

## Changes

- `cloudflare/pages.tf` (신규):
  - `cloudflare_pages_project.learningx_landing` — essentia repo `main` 브랜치 build, 모노레포 빌드 명령 `pnpm --filter @essentia/landing build`, output `apps/landing/out`
  - `cloudflare_pages_domain` — `learningx.json-server.win` custom domain 연결
  - `cloudflare_record.learningx_landing` — CNAME → pages.dev subdomain (Universal SSL, proxied)
- `cloudflare/outputs.tf` — `learningx_landing_subdomain`, `learningx_landing_url` 추가

## Prerequisite (사용자 콘솔 작업)

apply 전에 한 번만 Cloudflare 대시보드 → Workers & Pages → **Connect to GitHub** → `essentia-edu` org install. cloudflare provider는 OAuth 자체를 만들지 못함. (이미 완료)

## Plan 결과

```
Plan: 3 to add, 0 to change, 0 to destroy.
```

**추가 (3):**
- `cloudflare_pages_project.learningx_landing` (essentia-learningx project)
- `cloudflare_pages_domain.learningx_landing` (learningx.json-server.win)
- `cloudflare_record.learningx_landing` (CNAME)

## Resolved during review

초기 plan에 `cloudflare_record.minecraft_map`(mcmap.json-server.win, BlueMap)이 destroy로 잡혔으나 — local main이 origin/main 대비 12 commits behind였던 stale base 문제. [PR #222](https://github.com/manamana32321/homelab/pull/222) 머지된 minecraft_map 코드가 워크트리 base에 없었음. origin/main으로 rebase 후 재 plan: drift 해소, mcmap reconcile 처리.

## Apply 순서

1. [essentia-edu/essentia#82](https://github.com/essentia-edu/essentia/pull/82) (apps/landing skeleton) 머지 ✅ (완료)
2. Cloudflare 대시보드 → essentia-edu GitHub OAuth 연결 ✅ (완료)
3. 이 PR 머지
4. main 워크트리 pull (`git pull --rebase`로 origin/main 동기화) — apply 전 필수
5. `cd cloudflare && terraform init && terraform plan && terraform apply`
6. https://learningx.json-server.win 도달 확인 + SSL 검증

## Test plan

- [x] `terraform fmt` 통과
- [x] `terraform init` 통과 (provider v4.52.7)
- [x] `terraform plan` 통과 (3 add, 0 destroy 확인, mcmap drift 해소 후 재 검증)
- [x] CI: cloudflare/aws/betterstack validate + GitGuardian 모두 SUCCESS
- [ ] `terraform apply` (사용자 수동)
- [ ] learningx.json-server.win 도달 + Universal SSL 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)