### PR TITLE
feat(minecraft): 화이트리스트 선언화 (values.yaml SSOT)

### DIFF
--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -29,6 +29,9 @@ minecraftServer:
   pvp: true
   motd: "JSON Homelab Minecraft Server"
   onlineMode: true
+  # 화이트리스트 — 등록된 친구만 접속 (그리퍼 차단). WHITELIST env → whitelist.json 동기화.
+  # 친구 추가 시 이 줄에 쉼표로 닉네임 추가 후 PR. git이 SSOT.
+  whitelist: "EddieDawn,Dinudi,JinuStar0"
   # k3s ServiceLB(klipper)가 노드 호스트의 25565를 직접 바인딩 → 공유기 포트포워딩 1:1
   serviceType: LoadBalancer
   servicePort: 25565
@@ -51,6 +54,14 @@ minecraftServer:
     - https://github.com/BlueMap-Minecraft/BlueMap/releases/download/v5.18/bluemap-5.18-paper.jar
 
 strategyType: Recreate
+
+# 화이트리스트 enforcement 명시 — 차트는 minecraftServer.whitelist(목록)만 노출하므로
+# server.properties 플래그는 extraEnv 로 직접 선언. itzg 가 Pod 재기동 시 재생성해도 보장.
+#   ENABLE_WHITELIST  → white-list=true
+#   ENFORCE_WHITELIST → enforce-whitelist=true (비화이트리스트 접속자 즉시 강퇴)
+extraEnv:
+  ENABLE_WHITELIST: "true"
+  ENFORCE_WHITELIST: "true"
 
 # 플러그인 config.yml 강제 주입 — Bukkit copyDefaults 가 mounted file 을 우선 사용.
 extraVolumes:


### PR DESCRIPTION
## 배경

그리퍼 `MauntainsOfLava` 사건([#209](https://github.com/manamana32321/homelab/issues/209) 후속) 대응으로 RCON으로 화이트리스트를 긴급 적용했으나, **RCON-only는 선언적이지 않음**:
- `whitelist.json` / `banned-players.json`은 PVC에 남지만
- `server.properties`의 `white-list=true` 플래그는 itzg 이미지가 Pod 재기동 시 env 기준으로 재생성 → **다음 재기동 때 enforcement가 풀릴 위험**

이 PR이 화이트리스트를 git SSOT로 전환.

## 변경 (`k8s/minecraft/values.yaml`)

```yaml
minecraftServer:
  whitelist: "EddieDawn,Dinudi,JinuStar0"   # → WHITELIST env → whitelist.json 동기화

extraEnv:                                   # 차트가 enforcement 플래그 미노출 → 직접 선언
  ENABLE_WHITELIST: "true"                  # server.properties white-list=true
  ENFORCE_WHITELIST: "true"                 # enforce-whitelist=true (비화이트리스트 즉시 강퇴)
```

itzg 차트는 `minecraftServer.whitelist`(목록)만 노출하고 enforcement 플래그는 없어서, `extraEnv`로 `ENABLE_WHITELIST`/`ENFORCE_WHITELIST`를 명시. 이제 Pod 재기동·PVC 재생성에도 화이트리스트가 보장됨.

## 범위 결정

- **밴은 별도 선언화 안 함**: itzg에 declarative ban env가 없음. `banned-players.json`은 PVC 영구 보존되고, 화이트리스트 enforcement로 이미 이중 차단 (밴 안 돼있어도 화이트리스트에 없으면 못 들어옴). 굳이 복잡도 추가 안 함.
- **친구 추가 방법**: `whitelist` 줄에 닉네임 쉼표 추가 후 PR. git이 SSOT.

## 사전 검증 (helm template)

```
- name: WHITELIST
  value: "EddieDawn,Dinudi,JinuStar0"
- name: ENABLE_WHITELIST
  value: "true"
- name: ENFORCE_WHITELIST
  value: "true"
```
컨테이너 2개(`minecraft` + `minecraft-mc-backup`) 유지 — regression 없음.

## 머지 후 검증

1. `kubectl patch app minecraft -n argocd ... refresh=hard`
2. ArgoCD Synced + Healthy
3. Pod 재기동 후 컨테이너 env에 3종 whitelist env 존재
4. `rcon-cli whitelist list` → 3명 유지
5. **핵심**: server.properties `white-list=true` + `enforce-whitelist=true` 확인 (이게 RCON-only 대비 개선점)
6. mc-backup 사이드카 + 플러그인 regression 없음

## 관련

- 그리퍼 사건 + 월드 롤백 (이 세션에서 처리)
- 후속 권장: [#207](https://github.com/manamana32321/homelab/issues/207) CoreProtect — 다음 그리퍼는 블록 단위 추적/롤백

🤖 Generated with [Claude Code](https://claude.com/claude-code)