### PR TITLE
feat(minecraft): 필수 운영 플러그인 3종 (#207)

### DIFF
--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -52,6 +52,20 @@ minecraftServer:
     - https://github.com/DiscordSRV/DiscordSRV/releases/download/v1.30.5/DiscordSRV-Build-1.30.5.jar
     # BlueMap (#208 웹맵 3D viewer) — v5.18 = 1.21.x 호환 마지막 (v5.19+는 api-version 26.1.1 요구)
     - https://github.com/BlueMap-Minecraft/BlueMap/releases/download/v5.18/bluemap-5.18-paper.jar
+    # EssentialsX (#207 QoL — /tpa /home /sethome /back) — api-version 1.13, 1.21.x 광범위 호환.
+    # Modrinth 메타데이터가 1.21.11 미표기(릴리스가 먼저 나옴)라 GitHub 릴리스 jar 직접 사용.
+    - https://github.com/EssentialsX/Essentials/releases/download/2.21.2/EssentialsX-2.21.2.jar
+  # Modrinth 배포 플러그인 (#207) — slug:version 핀. itzg가 Modrinth API로 해석.
+  modrinth:
+    projects:
+      # CoreProtect (그리핑 블록단위 추적/롤백) — Community Edition free 빌드
+      - coreprotect:23.2
+      # WorldEdit — WorldGuard 하드 의존성 (먼저 명시 핀하여 reproducible, downloadDependencies 미사용)
+      - worldedit:7.4.3
+      # WorldGuard (지역 보호 — 스폰/공동 건축물 2차 방어선)
+      - worldguard:7.0.16
+    # WorldEdit를 명시 핀했으므로 의존성 자동 다운로드 불필요 (기본값 유지)
+    downloadDependencies: none
 
 strategyType: Recreate
 


### PR DESCRIPTION
## 배경

[#207](https://github.com/manamana32321/homelab/issues/207) — 운영 도구 마지막 카테고리. 그리퍼 `MauntainsOfLava` 사건이 직접적 계기 (월드 전체 롤백밖에 답이 없었던 상황).

LuckPerms는 제외 — 친구 5명 전원 OP라 권한 그룹이 무의미. WorldGuard도 LuckPerms를 강제하지 않음.

## 호환성 실측 (전부 1.21.11 OK)

| 플러그인 | 버전 | 확인 방법 |
|---|---|---|
| CoreProtect | 23.2 | Modrinth `game_versions` 1.21.11 포함 — **free 빌드** (GitHub 릴리스 본문이 Patreon 링크라 헷갈렸으나 Modrinth에 정식 무료 배포) |
| EssentialsX | 2.21.2 | jar `plugin.yml` api-version 1.13 (광범위 하위호환) |
| WorldGuard | 7.0.16 | Modrinth 1.21.11 포함 |
| WorldEdit | 7.4.3 | WorldGuard 하드 의존성 — Modrinth 1.21.11 포함 |

## 변경 (`k8s/minecraft/values.yaml`)

```yaml
minecraftServer:
  modrinth:
    projects:
      - coreprotect:23.2      # 그리핑 블록단위 추적/롤백
      - worldedit:7.4.3       # WorldGuard 하드 의존성 (명시 핀)
      - worldguard:7.0.16     # 지역 보호
    downloadDependencies: none  # WorldEdit 명시 핀했으므로 자동 다운로드 불필요
  pluginUrls:
    - ...기존 3개...
    - .../EssentialsX-2.21.2.jar  # Modrinth 메타데이터가 1.21.11 미표기 → GitHub jar
```

- CoreProtect/WorldEdit/WorldGuard → `modrinth.projects` (slug:version 핀, 가독성)
- EssentialsX → `pluginUrls` (Modrinth 메타데이터 lag, GitHub 릴리스가 확실)
- **config 마운트 없음** — 4개 jar 모두 기본 설정으로 동작 (CoreProtect SQLite, 나머지 디폴트). ConfigMap/initContainer 불필요

## 도구별 가치 (친구 서버 기준)

- **CoreProtect**: `/co rollback u:griefer t:8m` — 그리퍼 행동만 정밀 롤백. 백업(#205)의 "월드 전체 롤백"(핵폭탄)과 보완 관계 (메스)
- **EssentialsX**: `/tpa` `/home` `/sethome` `/back` — 바닐라엔 없는 플레이어 텔레포트. "같이 노는" 핵심 QoL
- **WorldGuard**: 스폰/공동건축물 지역 보호 — 화이트리스트 뚫려도 2차 방어선

## 사전 검증 (helm template)

- `MODRINTH_PROJECTS=coreprotect:23.2,worldedit:7.4.3,worldguard:7.0.16`
- `MODRINTH_DOWNLOAD_DEPENDENCIES=none`
- `PLUGINS` 4개 URL (기존 3 + EssentialsX)
- 컨테이너 2개 (`minecraft` + `minecraft-mc-backup`) 유지 — regression 없음

## 머지 후 검증

1. `kubectl patch app minecraft -n argocd ... refresh=hard`
2. ArgoCD Synced + Healthy
3. Pod 재기동 후 로그: `Loaded plugins` 에 CoreProtect/EssentialsX/WorldGuard/WorldEdit 5종(기존+신규) + `Enabled` 정상
4. `/co` `/tpa` `/rg` 명령 동작 (RCON 또는 인게임)
5. CoreProtect SQLite DB 생성 확인 (`/data/plugins/CoreProtect/`)
6. mc-backup 사이드카 + sladkoff/DiscordSRV/BlueMap regression 없음

## 관련

- Issue [#207](https://github.com/manamana32321/homelab/issues/207)
- 계기: 그리퍼 사건 + 월드 롤백 (이 세션)
- 운영 도구 5개 카테고리 完 (#205 백업 / #206 모니터링 / #207 플러그인 / #208 웹맵 / #209 Discord)

🤖 Generated with [Claude Code](https://claude.com/claude-code)