### PR TITLE
feat(minecraft): json-server-2 이전 + 리소스 증설

### DIFF
--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -5,13 +5,20 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+# json-server-2(i5-8400 6C/6T, 메모리 여유)로 이전하며 리소스 증설.
+# 기존 limit 1코어가 CPU throttle 93.7% 유발 → 청크 로딩 지연. node-2는 한가하고 코어 많아 넉넉히 허용.
 resources:
   requests:
-    memory: 1Gi
-    cpu: "500m"
-  limits:
-    memory: 2Gi
+    memory: 3Gi
     cpu: "1000m"
+  limits:
+    memory: 4Gi
+    cpu: "4000m"
+
+# 월드 PVC(local-path)가 node-1에 묶여있어 nodeSelector + PVC 마이그레이션 필요.
+# node-2: i5-8400 (마크는 싱글스레드 의존적 → 신세대 i5가 i7-3770보다 유리) + 메모리 여유.
+nodeSelector:
+  kubernetes.io/hostname: json-server-2
 
 persistence:
   dataDir:
@@ -22,7 +29,8 @@ minecraftServer:
   eula: "TRUE"
   type: "PAPER"
   version: "1.21.11"
-  memory: "1G"
+  # JVM 힙 — node-2 메모리 여유 활용. Paper 1.21 + 플러그인 8종 + BlueMap에 1G는 GC 압박.
+  memory: "3G"
   difficulty: "normal"
   gameMode: "survival"
   maxPlayers: 20


### PR DESCRIPTION
## 배경

청크 로딩 지연 신고 → [#206](https://github.com/manamana32321/homelab/issues/206) 모니터링으로 진단:

| 메트릭 | 값 |
|---|---|
| minecraft 컨테이너 CPU throttle | **93.7%** (limits.cpu 1코어 한도) |
| node-1 메모리 | **84%** (포화) |
| node-2 메모리 | 41% (여유) |

CPU throttle이 청크 생성을 끊어 로딩 지연. 게다가 node-1은 메모리 포화라 JVM 힙 증설도 불가.

## 변경 (`k8s/minecraft/values.yaml`)

- **nodeSelector**: `json-server-2` — i5-8400 6C/6T (마크는 싱글스레드 의존적 → 신세대 i5 > i7-3770), 메모리 여유, 한가한 노드
- **resources**: cpu limit 1→4코어 / request 500m→1000m, memory limit 2→4Gi / request 1→3Gi
- **minecraftServer.memory** (JVM 힙): 1G → 3G

부수 효과: 과부하된 node-1(Immich/Seafile/Prometheus 동거) 부담 경감.

## ⚠️ 머지 후 PVC 마이그레이션 필요

`minecraft-datadir` PVC가 `local-path` + `selected-node: json-server-1` — 월드 데이터가 node-1 디스크에 물리적으로 묶임. nodeSelector만 바꾸면 pod가 Pending(볼륨 노드 어피니티 충돌). restic 백업 기반 마이그레이션:

1. 최신 restic 백업 (안전망)
2. ArgoCD automated 2-레벨 차단 (apps + minecraft — 롤백 때 배운 selfHeal 레이스 방지)
3. minecraft scale 0 → 기존 PVC/PV 삭제
4. `argocd app sync` → 새 PVC가 node-2에 provision, pod 기동(빈 월드)
5. 임시 restic pod(node-2) → `/data/world` restore + banned-players.json restore
6. 재기동 → 검증

## helm template 검증

- `nodeSelector: kubernetes.io/hostname: json-server-2`
- `resources` limit cpu 4000m / mem 4Gi
- `MEMORY=3G`
- 컨테이너 2개 유지 (mc-backup 사이드카 regression 없음)

## 머지 후 검증

1. Pod가 **json-server-2**에 스케줄 + Ready 2/2
2. CPU throttle 메트릭 0 근처로 하락 확인 (이게 핵심 — 청크 로딩 정상화)
3. 월드 데이터 복원 확인 (region 파일, playerdata)
4. 8개 plugin 전부 로드 (sladkoff/DiscordSRV/BlueMap/CoreProtect/EssentialsX/WorldEdit/WorldGuard)
5. mc-backup 사이드카 정상, BlueMap/Discord regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)