### PR TITLE
fix(minecraft): correct PVC size key (size→Size) + pin storageClass

### DIFF
--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -21,9 +21,14 @@ nodeSelector:
   kubernetes.io/hostname: json-server-2
 
 persistence:
+  # 클러스터 default StorageClass가 2개(longhorn, longhorn-ssd) → 무명시 시 비결정적.
+  # 마크 월드는 stateful → longhorn-ssd 명시 핀 (복제·노드 비종속, CLAUDE.md 스토리지 규칙).
+  storageClass: longhorn-ssd
   dataDir:
     enabled: true
-    size: 5Gi
+    # itzg 차트 키는 대문자 Size — 소문자 size는 무시되어 차트 기본값 1Gi로 떨어짐 (#229까지 1Gi였던 원인).
+    # longhorn-ssd는 allowVolumeExpansion=true → 기존 PVC가 1Gi→5Gi 온라인 확장됨.
+    Size: 5Gi
 
 minecraftServer:
   eula: "TRUE"


### PR DESCRIPTION
## 배경

[#229](https://github.com/manamana32321/homelab/pull/229) json-server-2 이전 작업 중, 새로 생성된 PVC가 values.yaml의 `size: 5Gi` 설정에도 불구하고 1Gi로 생성되는 것을 발견했습니다.

## 원인

itzg minecraft-server 차트 5.0.0은 PVC 크기 키로 `persistence.dataDir.Size`(**대문자 S**)를 사용합니다. values.yaml의 `size`(소문자)는 Helm이 unknown key로 조용히 무시 → 차트 기본값 `Size: 1Gi`로 생성됐습니다. 이 버그는 최초 배포 시점부터 잠복해 있었습니다(이전 local-path PVC도 1Gi였음).

## 변경

- `persistence.dataDir.size` → `Size` (대문자). PVC 요청 크기 1Gi → 5Gi.
- `persistence.storageClass: longhorn-ssd` 명시 핀. 클러스터에 default StorageClass가 2개(`longhorn`, `longhorn-ssd`)라 무명시 시 비결정적 — `CLAUDE.md` 스토리지 규칙(stateful 앱 = longhorn-ssd)에 맞춰 고정.

## 영향

`longhorn-ssd`는 `allowVolumeExpansion: true` → 기존 PVC가 **재생성 없이 1Gi→5Gi 온라인 확장**됩니다. `storageClassName`은 #229 이전 후 이미 `longhorn-ssd`라 변경 없음(immutable 필드 충돌 없음).

## 검증 계획

머지 후 `argocd app wait minecraft --sync --health` + `kubectl get pvc minecraft-datadir -n minecraft`로 5Gi 확장 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
