### PR TITLE
fix(minecraft): drop storageClass pin — chart renders it as immutable PVC annotation

### DIFF
--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -21,9 +21,12 @@ nodeSelector:
   kubernetes.io/hostname: json-server-2
 
 persistence:
-  # 클러스터 default StorageClass가 2개(longhorn, longhorn-ssd) → 무명시 시 비결정적.
-  # 마크 월드는 stateful → longhorn-ssd 명시 핀 (복제·노드 비종속, CLAUDE.md 스토리지 규칙).
-  storageClass: longhorn-ssd
+  # storageClass는 values에 핀하지 않음 — itzg 차트 5.0.0은 storageClass를
+  # 레거시 annotation(volume.beta.kubernetes.io/storage-class)으로 렌더하는데,
+  # 이 annotation은 기존 PVC에서 immutable이라 ArgoCD sync가 통째로 거부됨
+  # (#230에서 핀 시도 → PVC 패치 전체 실패로 Size 확장까지 막힘).
+  # 현 PVC는 이미 longhorn-ssd(spec.storageClassName, immutable) — 핀 불필요.
+  # 향후 PVC 재생성 시 결정성은 클러스터 default SC 단일화로 해결.
   dataDir:
     enabled: true
     # itzg 차트 키는 대문자 Size — 소문자 size는 무시되어 차트 기본값 1Gi로 떨어짐 (#229까지 1Gi였던 원인).


### PR DESCRIPTION
## 문제

[#230](https://github.com/manamana32321/homelab/pull/230)이 추가한 `persistence.storageClass: longhorn-ssd`가 배포 후 ArgoCD sync 실패를 유발했습니다.

```
PersistentVolumeClaim "minecraft-datadir" is invalid:
metadata.annotations.volume.beta.kubernetes.io/storage-class:
Invalid value: "longhorn-ssd": field is immutable
```

## 원인

itzg minecraft-server 차트 5.0.0은 `persistence.storageClass`를 `spec.storageClassName`뿐 아니라 **레거시 annotation** `volume.beta.kubernetes.io/storage-class`로도 렌더합니다. 이 annotation은 Kubernetes가 기존 PVC에서 **immutable**로 취급 → ArgoCD의 PVC 패치가 통째로 거부됩니다. 패치는 원자적이라, 같은 패치에 들어 있던 `Size 1Gi→5Gi` 확장까지 함께 막혔습니다. 결과: minecraft app `OutOfSync` + sync 무한 재시도 실패.

## 변경

`persistence.storageClass` 핀을 제거합니다. PVC는 이미 `spec.storageClassName: longhorn-ssd`(immutable 필드)라 기능상 영향 없음. `Size: 5Gi`만 남으면 PVC가 정상 온라인 확장됩니다.

향후 PVC 재생성 시의 storage class 결정성은, 클러스터 default StorageClass 단일화(`longhorn` / `longhorn-ssd` 중복 default 해소)로 별도 해결하는 것이 옳은 접근입니다.

## 검증 계획

머지 후 `argocd app wait minecraft --sync --health` + `kubectl get pvc minecraft-datadir -n minecraft`로 1Gi→5Gi 확장 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
