### PR TITLE
fix(longhorn): disable chart default StorageClass (longhorn-ssd만 단독 default)

### DIFF
--- a/k8s/storage/longhorn/values.yaml
+++ b/k8s/storage/longhorn/values.yaml
@@ -9,6 +9,10 @@ defaultSettings:
   # raspi-1은 Longhorn 스토리지에서 제외
   taintToleration: ""
 
+# 차트 기본 longhorn SC를 default에서 내림 — longhorn-ssd(manifests/storage-class.yaml)만 단독 default 유지
+persistence:
+  defaultClass: false
+
 # ingress는 argocd auth proxy 뒤에 두거나 비활성화
 longhornUI:
   replicas: 1


### PR DESCRIPTION
## 배경

클러스터에 default StorageClass가 2개 떠 있었음: `longhorn`과 `longhorn-ssd`.

- `longhorn-ssd`는 레포가 **의도적으로** default로 선언한 클래스 — [`k8s/storage/longhorn/manifests/storage-class.yaml`](https://github.com/manamana32321/homelab/blob/main/k8s/storage/longhorn/manifests/storage-class.yaml)의 `storageclass.kubernetes.io/is-default-class: "true"`, 주석에도 "default SC" 명시.
- `longhorn`은 Longhorn Helm 차트 기본값(`persistence.defaultClass: true`)이 꺼지지 않아 생긴 **의도치 않은 default**.
- default가 2개면 `storageClassName` 미지정 PVC가 **비결정적으로** 배치됨 (실제로 minecraft PVC는 `longhorn-ssd`, loki PVC는 `longhorn`으로 제각각 떨어진 사례 있음).

## 변경

[`k8s/storage/longhorn/values.yaml`](https://github.com/manamana32321/homelab/blob/main/k8s/storage/longhorn/values.yaml)에 `persistence.defaultClass: false` 추가. 차트가 만드는 `longhorn` SC를 default에서 내려 `longhorn-ssd` 단독 default로 확정.

```yaml
persistence:
  defaultClass: false
```

## 영향

- **기존 PVC는 영향 없음** — `storageClassName`은 immutable이고 이미 바인딩됨.
- 앞으로 클래스 미지정 PVC는 결정적으로 `longhorn-ssd`로 감.

🤖 Generated with [Claude Code](https://claude.com/claude-code)