### PR TITLE
feat(observability): sustained CPU throttling 경고 룰 추가

### DIFF
--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -153,6 +153,29 @@ spec:
             summary: "High memory: {{ $labels.instance }}"
             description: "Memory usage on {{ $labels.instance }} is {{ $value | humanizePercentage }}."
 
+        # chart 룰 CPUThrottlingHigh(info, 5m window)는 짧은 버스트성 스로틀링까지
+        # 잡아 info noise로 묻힌다. wedge된 컨트롤러(예: minio-operator의
+        # PolicyBinding watch hot-loop)는 CPU limit에 몇 시간씩 연속으로 붙어
+        # ~100% 스로틀된다 — 버스트와 명확히 구분되는 고신뢰 신호이므로
+        # 더 긴 window + warning으로 별도 발화. CPUThrottlingHigh의 컴포넌트별
+        # 재정의가 아니라, sustained 케이스 전용 상위 severity tier.
+        - alert: ContainerCPUThrottlingSustained
+          expr: >-
+            sum by (namespace, pod, container) (
+              rate(container_cpu_cfs_throttled_periods_total{container!="", job="kubelet", metrics_path="/metrics/cadvisor"}[15m])
+            )
+            /
+            sum by (namespace, pod, container) (
+              rate(container_cpu_cfs_periods_total{container!="", job="kubelet", metrics_path="/metrics/cadvisor"}[15m])
+            )
+            > 0.9
+          for: 2h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Sustained CPU throttling: {{ $labels.namespace }}/{{ $labels.pod }}"
+            description: "{{ $labels.container }} ({{ $labels.namespace }}/{{ $labels.pod }})가 2시간+ 동안 {{ $value | humanizePercentage }} CPU 스로틀 중. CPU limit에 붙어 wedge되었거나 limit이 과소 설정됨 — pod 재시작 또는 limit 증설 필요."
+
     # ArgoCD 앱 health — chart의 ArgoAppMissing/ArgoAppNotSynced로는 못 잡는
     # Degraded/Missing/Unknown 상태를 12h 기다리지 않고 catch.
     # Healthy/Progressing/Suspended는 의도적 정상 상태이므로 제외.


### PR DESCRIPTION
## 배경

minio-operator가 약 12일간 wedge 상태였다 — apiserver flap 이후 `PolicyBinding` CRD watch가 hot-loop에 빠져 CPU limit(500m)에 붙어 ~100% 스로틀. pod는 `Running`/`Ready`였고(probe 없음) 컨트롤러 reconcile 루프만 마비.

이 상황을 잡는 chart 룰 `CPUThrottlingHigh`는 **12일 내내 정상 발화**했고 Telegram에도 전달됐다. 문제는 `severity: info` — 짧은 버스트성 스로틀링까지 잡는 룰이라 info noise로 묻혀 12일짜리 stuck-controller 신호가 actionable하게 triage되지 못했다.

→ 관측 누락이 아니라 **severity-triage 문제**.

## 변경

`homelab-alerts`의 `resources` 그룹에 `ContainerCPUThrottlingSustained` 추가:

- CFS 스로틀링 비율 **> 90%가 2시간+ 지속** → `severity: warning`
- 짧은 버스트(deploy/migration 등)와 명확히 구분되는 **wedge 전용 고신뢰 시그널**
- `CPUThrottlingHigh`의 컴포넌트별 재정의가 아니라, sustained 케이스 전용 **상위 severity tier** (observability/CLAUDE.md 알림 룰 정책 준수)

검증 데이터: 지난 12일간 이 조건은 wedge된 minio-operator에만 연속 매칭됐고, minecraft는 1회 순간 발화만 있어 `>0.9` + `for: 2h`에 걸리지 않음 — false positive 없음.

## 검증

- `kubectl apply --dry-run=server` 통과 (prometheus-operator validating webhook이 PromQL 검증)
- 머지 후 ArgoCD sync → `kubectl ... /api/v1/rules`로 룰 health `ok` 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)