### PR TITLE
fix(longhorn): orphan-auto-deletion 활성화

### DIFF
--- a/k8s/storage/longhorn/values.yaml
+++ b/k8s/storage/longhorn/values.yaml
@@ -8,6 +8,8 @@ defaultSettings:
   storageReservedPercentageForDefaultDisk: 0
   # raspi-1은 Longhorn 스토리지에서 제외
   taintToleration: ""
+  # 고아 복제본 자동 삭제 — rebuild 시 남는 잔여 디렉토리 누적 방지 (chart default: false)
+  orphanAutoDeletion: true
 
 # 차트 기본 longhorn SC를 default에서 내림 — longhorn-ssd(manifests/storage-class.yaml)만 단독 default 유지
 persistence:


### PR DESCRIPTION
## 무엇

Longhorn `defaultSettings.orphanAutoDeletion`을 `true`로 활성화.

## 왜

`orphan-auto-deletion`이 chart 기본값 `false`라, 복제본이 rebuild될 때마다(노드 재부팅·네트워크 blip·리밸런싱) 남는 고아(orphan) 복제본 디렉토리가 **영구 누적**됩니다. 3월 Longhorn 마이그레이션 이후 누적된 고아가 json-server-2 SSD를 90%까지 채워 만성 DiskPressure 상태였고, 2026-05-23 새벽 인시던트에서 그 노드의 CSI 플러그인이 축출돼 장애를 증폭시킨 숨은 요인이었습니다.

`true`로 전환하면 Longhorn이 감지한 고아 복제본을 자동 정리합니다.

## 조치

- 기존 누적 고아 18개는 수동 정리 완료(`kubectl delete orphan`) → json-server-2 `/` 90%→19%, ~78G 회수
- 이 PR로 재발 방지를 선언적으로 고정

## 검증

머지 → ArgoCD sync 후 `kubectl get settings.longhorn.io orphan-auto-deletion -n longhorn-system` 값이 `true`인지 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)