### PR TITLE
fix(amang-minio): storageClassName base를 longhorn-ssd로 통일 — raspi-1 SD카드 회피

### DIFF
--- a/k8s/minio-tenants/base/tenant.yaml
+++ b/k8s/minio-tenants/base/tenant.yaml
@@ -23,7 +23,9 @@ spec:
           resources:
             requests:
               storage: 5Gi
-          storageClassName: local-path
+          # longhorn-ssd: server-1+server-2 SSD에 복제본 2 + 노드 이동성 — raspi-1 SD카드 회피.
+          # Tenant volumeClaimTemplate은 immutable이라 SC 변경 시 PVC 재생성 + 데이터 이관 필요.
+          storageClassName: longhorn-ssd
       resources:
         requests:
           cpu: 50m

--- a/k8s/minio-tenants/overlays/essentia/kustomization.yaml
+++ b/k8s/minio-tenants/overlays/essentia/kustomization.yaml
@@ -6,13 +6,4 @@ resources:
   - sealed-secret.yaml
   - ingress.yaml
   - ingress-console.yaml
-patches:
-  - target:
-      group: minio.min.io
-      version: v2
-      kind: Tenant
-      name: minio
-    patch: |
-      - op: replace
-        path: /spec/pools/0/volumeClaimTemplate/spec/storageClassName
-        value: longhorn-ssd
+# base/tenant.yaml이 longhorn-ssd로 통일되어 patch 제거 (SSOT).


### PR DESCRIPTION
## 무엇

`k8s/minio-tenants/base/tenant.yaml`의 `storageClassName: local-path` → `longhorn-ssd`로 승격하고, 그 결과로 redundant해진 essentia overlay의 patch 제거.

## 왜

- amang **prod/staging MinIO**가 `local-path`를 상속해 raspi-1 SD카드에 고정돼 있음 — 단일 복사본 + 가장 약한 노드. 프로덕션 오브젝트 데이터가 무방비
- **essentia overlay는 이미 longhorn-ssd로 patch** 중 — 세 tenant의 의도가 동일. base 기본값으로 끌어올려 SSOT 회복
- raspi-1을 클러스터에서 정리하려는 후속 정비의 사전 조건

```
diff (요약):
- base/tenant.yaml         : storageClassName local-path → longhorn-ssd
- overlays/essentia        : 중복 patch 블록 제거 (base가 이제 동일 값)
- overlays/production/stag : 변경 없음 (base 상속으로 자동 적용)
```

kustomize render 검증 — 3 tenant 모두 `storageClassName: longhorn-ssd` 확인:
```
production: storageClassName: longhorn-ssd
staging:    storageClassName: longhorn-ssd
essentia:   storageClassName: longhorn-ssd  (변화 없음)
```

## 머지만으로는 데이터 안 옮겨짐 — 후속 필요

MinIO Tenant의 `volumeClaimTemplate.storageClassName`은 StatefulSet 제약상 **immutable**. 이 PR을 머지하면 Tenant CR spec은 `longhorn-ssd`로 바뀌지만 **기존 PVC는 `local-path`인 채 그대로** (operator도 손 못 댐).

머지 후 별도로 진행:
- **prod (54MB)**: `kubectl exec tar`로 `/export` 통째 백업 → Tenant CR + 구 PVC 삭제 → longhorn-ssd 신규 PVC에 helper pod로 복원 → operator가 채택
- **staging (2MB)**: 데이터 비우고 재생성 (사용자 결정)

essentia는 33일 전 이 patch가 적용된 후 자기 ns에서 정상 동작 중 — 동일 절차 검증됨.

## 검증 계획 (머지 후)

1. ArgoCD hard-refresh → `amang-minio-production`, `amang-minio-staging`, `essentia-minio` 셋 다 `Synced + Healthy`
2. 기존 MinIO 파드는 raspi-1 그대로 (PVC immutable) — 정상
3. 데이터 이관 작업 별도 진행, 완료 후 파드가 raspi-1이 아닌 노드로 이동했는지 + 버킷 `amang` 존재 + amang API 파일 IO 확인

Refs skku-amang/main#505

🤖 Generated with [Claude Code](https://claude.com/claude-code)