### PR TITLE
feat(basic-memory): gbrain 대체 PoC — MCP 매니페스트 + ArgoCD App

### DIFF
--- a/cloudflare/dns.tf
+++ b/cloudflare/dns.tf
@@ -331,6 +331,16 @@ resource "cloudflare_record" "gbrain" {
   comment = "gbrain HTTP MCP — Bearer auth (caddy sidecar), Cloudflare proxied"
 }
 
+# Basic Memory MCP — PoC alternative to gbrain. Runs in parallel until validated.
+resource "cloudflare_record" "basic_memory" {
+  zone_id = cloudflare_zone.main.id
+  name    = "bm"
+  type    = "A"
+  content = var.default_ip
+  proxied = true
+  comment = "Basic Memory MCP (PoC) — Bearer auth (caddy sidecar), Cloudflare proxied"
+}
+
 # LearningX MCP 마케팅 landing. Cloudflare Pages 정적 사이트에서 essentia-web
 # ingress로 이전 (essentia-edu/essentia#83). apps/web의 (marketing)/learningx
 # route를 host-based rewrite로 서빙 — essentia-web ingress가 이 host를 받는다.

--- a/k8s/argocd/applications/apps/basic-memory.yaml
+++ b/k8s/argocd/applications/apps/basic-memory.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: basic-memory
+  namespace: argocd
+  annotations:
+    # Pin to digest via Image Updater (public image from basicmachines-co — no auth needed).
+    # PoC: track latest tag and roll forward. Stabilize → switch to `semver` strategy with allow-tags pattern.
+    argocd-image-updater.argoproj.io/image-list: app=ghcr.io/basicmachines-co/basic-memory:latest
+    argocd-image-updater.argoproj.io/app.update-strategy: digest
+    argocd-image-updater.argoproj.io/app.force-update: "true"
+    argocd-image-updater.argoproj.io/write-back-method: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/manamana32321/homelab
+    targetRevision: main
+    path: k8s/basic-memory/manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: basic-memory
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/basic-memory/manifests/caddy-configmap.yaml
+++ b/k8s/basic-memory/manifests/caddy-configmap.yaml
@@ -1,0 +1,36 @@
+---
+# Bearer auth gate in front of Basic Memory MCP SSE endpoint.
+# Mirrors gbrain-mcp pattern — keep behavior consistent so client config is interchangeable.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: basic-memory-caddy
+  labels:
+    app.kubernetes.io/name: basic-memory
+    app.kubernetes.io/part-of: brain
+data:
+  Caddyfile: |
+    {
+      auto_https off
+      admin off
+    }
+
+    :80 {
+      handle /healthz {
+        respond "ok" 200
+      }
+
+      @authorized header Authorization "Bearer {env.MCP_AUTH_TOKEN}"
+      handle @authorized {
+        reverse_proxy localhost:8000 {
+          flush_interval -1
+          transport http {
+            read_timeout 24h
+          }
+        }
+      }
+
+      handle {
+        respond "unauthorized" 401
+      }
+    }

--- a/k8s/basic-memory/manifests/deployment.yaml
+++ b/k8s/basic-memory/manifests/deployment.yaml
@@ -1,0 +1,181 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: basic-memory
+  labels:
+    app.kubernetes.io/name: basic-memory
+    app.kubernetes.io/part-of: brain
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: basic-memory
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: basic-memory
+        app.kubernetes.io/part-of: brain
+    spec:
+      initContainers:
+        # Initial clone of brain repo into emptyDir.
+        # Subsequent updates handled by the git-pull sidecar below.
+        - name: git-clone
+          image: alpine/git:latest
+          command:
+            - sh
+            - -c
+            - |
+              set -eo pipefail
+              if [ -d /brain/.git ]; then
+                cd /brain && git pull --ff-only
+              else
+                rm -rf /brain/* /brain/.[!.]* 2>/dev/null || true
+                git clone --depth 1 \
+                  "https://x-access-token:${GH_PAT}@github.com/manamana32321/brain.git" \
+                  /brain
+              fi
+          env:
+            - name: GH_PAT
+              valueFrom:
+                secretKeyRef:
+                  name: basic-memory-github
+                  key: GH_PAT
+          volumeMounts:
+            - name: brain
+              mountPath: /brain
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+      containers:
+        # Background git pull every 5 minutes (PAT embedded in remote URL by init clone).
+        # Basic Memory's WatchService detects file changes and re-indexes incrementally.
+        - name: git-pull
+          image: alpine/git:latest
+          command:
+            - sh
+            - -c
+            - |
+              set -eo pipefail
+              while true; do
+                sleep 300
+                cd /brain && git pull --ff-only 2>&1 \
+                  || echo "[git-pull] pull failed at $(date -Iseconds), retrying next cycle"
+              done
+          volumeMounts:
+            - name: brain
+              mountPath: /brain
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+        # Main: Basic Memory MCP server (SSE on :8000)
+        # Image is public (ghcr.io/basicmachines-co/basic-memory) — no Image Updater needed.
+        # Pin a digest in PoC follow-up once verified.
+        - name: basic-memory
+          image: ghcr.io/basicmachines-co/basic-memory:latest
+          imagePullPolicy: Always
+          env:
+            - name: BASIC_MEMORY_DEFAULT_PROJECT
+              value: brain
+            - name: BASIC_MEMORY_SYNC_CHANGES
+              value: "true"
+            - name: BASIC_MEMORY_SYNC_DELAY
+              value: "2000"
+            - name: BASIC_MEMORY_LOG_LEVEL
+              value: INFO
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              # Wait for /brain to be populated by init container
+              until [ -d /brain/.git ]; do
+                echo "[basic-memory] Waiting for /brain to be populated..."
+                sleep 2
+              done
+              # Idempotent project registration → SSOT path
+              basic-memory project add brain /brain 2>/dev/null || true
+              basic-memory project default brain
+              # Initial index sync (no-op if already current)
+              basic-memory sync --project brain || true
+              # Start MCP SSE server
+              exec basic-memory mcp --transport sse --host 0.0.0.0 --port 8000
+          ports:
+            - containerPort: 8000
+              name: sse
+          volumeMounts:
+            - name: brain
+              mountPath: /brain
+            - name: data
+              mountPath: /home/appuser/.basic-memory
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 90
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: 200m
+            limits:
+              memory: 1Gi
+              cpu: 1000m
+        # Sidecar: caddy reverse proxy with Bearer auth (mirrors gbrain-mcp pattern)
+        - name: caddy
+          image: caddy:2-alpine
+          command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]
+          env:
+            - name: MCP_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: basic-memory-auth
+                  key: MCP_AUTH_TOKEN
+          ports:
+            - containerPort: 80
+              name: http
+          volumeMounts:
+            - name: caddy-config
+              mountPath: /etc/caddy
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      volumes:
+        - name: brain
+          emptyDir: {}
+        - name: data
+          persistentVolumeClaim:
+            claimName: basic-memory-data
+        - name: caddy-config
+          configMap:
+            name: basic-memory-caddy

--- a/k8s/basic-memory/manifests/ingress.yaml
+++ b/k8s/basic-memory/manifests/ingress.yaml
@@ -1,0 +1,30 @@
+---
+# Bearer auth handled by caddy sidecar (Authorization: Bearer <MCP_AUTH_TOKEN>)
+# TLS via cert-manager DNS01 (Cloudflare API).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: basic-memory
+  labels:
+    app.kubernetes.io/name: basic-memory
+    app.kubernetes.io/part-of: brain
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns01
+    traefik.ingress.kubernetes.io/redirect-entry-point: https
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: bm.json-server.win
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: basic-memory
+                port:
+                  number: 80
+  tls:
+    - secretName: basic-memory-tls
+      hosts:
+        - bm.json-server.win

--- a/k8s/basic-memory/manifests/kustomization.yaml
+++ b/k8s/basic-memory/manifests/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Note: no `namespace:` field — ArgoCD `destination.namespace` is the SSOT.
+# SealedSecret manifests embed `metadata.namespace` (sealing cert is scoped) — keep consistent with ArgoCD destination.
+resources:
+  - caddy-configmap.yaml
+  - deployment.yaml
+  - ingress.yaml
+  - pvc.yaml
+  - sealed-secret-auth.yaml
+  - sealed-secret-github.yaml
+  - service.yaml

--- a/k8s/basic-memory/manifests/pvc.yaml
+++ b/k8s/basic-memory/manifests/pvc.yaml
@@ -1,0 +1,17 @@
+---
+# Persistent storage for Basic Memory SQLite index + .basic-memory/config.json
+# Sized for ~1000 markdown notes; FastEmbed embedding cache adds ~200MB.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: basic-memory-data
+  labels:
+    app.kubernetes.io/name: basic-memory
+    app.kubernetes.io/part-of: brain
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-ssd
+  resources:
+    requests:
+      storage: 5Gi

--- a/k8s/basic-memory/manifests/sealed-secret-auth.yaml
+++ b/k8s/basic-memory/manifests/sealed-secret-auth.yaml
@@ -1,0 +1,24 @@
+---
+# PLACEHOLDER — generate a Bearer token (any high-entropy random string) for caddy
+# auth gate in front of MCP SSE endpoint, then seal it:
+#
+#   openssl rand -hex 32 | tr -d '\n' | KUBECONFIG=~/.kube/config-json kubeseal --raw \
+#     --cert k8s/sealed-secrets/cert.pem \
+#     --name basic-memory-auth \
+#     --namespace basic-memory \
+#     --scope strict
+#
+# Store the plaintext token in ~/.claude.json under the basic-memory MCP entry
+# so Claude Code can authenticate. Replace the placeholder below with the resulting ciphertext.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: basic-memory-auth
+  namespace: basic-memory
+spec:
+  encryptedData:
+    MCP_AUTH_TOKEN: PLACEHOLDER_RESEAL_BEFORE_FIRST_SYNC
+  template:
+    metadata:
+      name: basic-memory-auth
+      namespace: basic-memory

--- a/k8s/basic-memory/manifests/sealed-secret-github.yaml
+++ b/k8s/basic-memory/manifests/sealed-secret-github.yaml
@@ -1,0 +1,24 @@
+---
+# PLACEHOLDER — user must generate a fine-grained GitHub PAT for manamana32321/brain
+# (read-only on contents) and seal it with kubeseal targeting the json cluster cert:
+#
+#   echo -n "ghp_..." | KUBECONFIG=~/.kube/config-json kubeseal --raw \
+#     --cert k8s/sealed-secrets/cert.pem \
+#     --name basic-memory-github \
+#     --namespace basic-memory \
+#     --scope strict
+#
+# Replace the placeholder below with the resulting ciphertext.
+# Reuse the gbrain GH_PAT? Strict scope binds ciphertext to namespace, so re-seal — do not copy ciphertext.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: basic-memory-github
+  namespace: basic-memory
+spec:
+  encryptedData:
+    GH_PAT: PLACEHOLDER_RESEAL_BEFORE_FIRST_SYNC
+  template:
+    metadata:
+      name: basic-memory-github
+      namespace: basic-memory

--- a/k8s/basic-memory/manifests/service.yaml
+++ b/k8s/basic-memory/manifests/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: basic-memory
+  labels:
+    app.kubernetes.io/name: basic-memory
+    app.kubernetes.io/part-of: brain
+spec:
+  selector:
+    app.kubernetes.io/name: basic-memory
+  ports:
+    - port: 80
+      targetPort: http
+      name: http

--- a/k8s/observability/blackbox-exporter/values.yaml
+++ b/k8s/observability/blackbox-exporter/values.yaml
@@ -126,6 +126,9 @@ serviceMonitor:
     - name: gbrain-mcp
       url: http://gbrain-mcp.gbrain.svc.cluster.local/healthz
       module: http_2xx_no_tls
+    - name: basic-memory
+      url: http://basic-memory.basic-memory.svc.cluster.local/healthz
+      module: http_2xx_no_tls
     - name: minecraft
       url: minecraft.minecraft.svc.cluster.local:25565
       module: tcp_connect


### PR DESCRIPTION
## Summary

- gbrain 미성숙 신호(PGLite WASM 버그, write 도구 봉인, transport 화석)에 대응해 [Basic Memory](https://github.com/basicmachines-co/basic-memory) PoC 도입
- `bm.json-server.win` 신규 ingress로 gbrain과 1주 병행 운영 → read 검증 후 cutover 판단
- markdown SSOT (`manamana32321/brain`) 그대로 유지 — 데이터 마이그레이션 0 line

## Tech Scout 보고서 요약

| 평가축 | gbrain | Basic Memory |
|---|---|---|
| LLM/MCP 통합 | ★★★ (PGLite 결함) | ★★★★★ (MCP-first 설계) |
| 검색 깊이 | ★★★ 임베딩 | ★★★★★ FTS + FastEmbed/OpenAI hybrid |
| Self-host 운영성 | ★★★ | ★★ (Helm 없음, manifest 직접 작성) |
| Data SSOT | ★★★★★ | ★★★★★ (markdown 동일) |
| 마이그레이션 비용 | - | 0 line (vault 그대로) |

상세 보고서는 대화 컨텍스트 참조.

## 변경 사항

### 신규
- [k8s/basic-memory/manifests/deployment.yaml](k8s/basic-memory/manifests/deployment.yaml) — init git-clone + git-pull sidecar(5분) + basic-memory(MCP SSE :8000) + caddy(Bearer auth :80)
- [k8s/basic-memory/manifests/pvc.yaml](k8s/basic-memory/manifests/pvc.yaml) — 5Gi `longhorn-ssd` (SQLite 인덱스 + .basic-memory config)
- [k8s/basic-memory/manifests/caddy-configmap.yaml](k8s/basic-memory/manifests/caddy-configmap.yaml) — Bearer 게이트 (gbrain 패턴)
- [k8s/basic-memory/manifests/service.yaml](k8s/basic-memory/manifests/service.yaml) / [ingress.yaml](k8s/basic-memory/manifests/ingress.yaml) — `bm.json-server.win` + cert-manager DNS01
- [k8s/basic-memory/manifests/sealed-secret-github.yaml](k8s/basic-memory/manifests/sealed-secret-github.yaml) / [sealed-secret-auth.yaml](k8s/basic-memory/manifests/sealed-secret-auth.yaml) — **placeholder, 머지 전 교체 필수**
- [k8s/argocd/applications/apps/basic-memory.yaml](k8s/argocd/applications/apps/basic-memory.yaml) — ArgoCD App + Image Updater digest pin

### 수정
- [cloudflare/dns.tf](cloudflare/dns.tf) — `bm.json-server.win` A 레코드 (proxied=true, gbrain 패턴)
- [k8s/observability/blackbox-exporter/values.yaml](k8s/observability/blackbox-exporter/values.yaml) — 내부 헬스 probe 타겟 추가

## 머지 전 체크리스트

1. [ ] **GitHub PAT 발급** — fine-grained, repo `manamana32321/brain`, contents:read
2. [ ] **Bearer 토큰 생성** — `openssl rand -hex 32`
3. [ ] **두 SealedSecret sealing** (글로벌 룰: `KUBECONFIG=~/.kube/config-json kubeseal --raw` prefix 명시):
   ```bash
   echo -n "$GH_PAT" | KUBECONFIG=~/.kube/config-json kubeseal --raw \
     --cert k8s/sealed-secrets/cert.pem \
     --name basic-memory-github --namespace basic-memory --scope strict

   echo -n "$MCP_TOKEN" | KUBECONFIG=~/.kube/config-json kubeseal --raw \
     --cert k8s/sealed-secrets/cert.pem \
     --name basic-memory-auth --namespace basic-memory --scope strict
   ```
4. [ ] `sealed-secret-{github,auth}.yaml`의 `PLACEHOLDER_RESEAL_BEFORE_FIRST_SYNC` 교체
5. [ ] `cd cloudflare && terraform plan` — `bm.json-server.win` A 레코드 1건만 보여야 함
6. [ ] `terraform apply` — 사용자 승인

## 머지 후 검증 (manifest-only 변경 → 동기)

```bash
kubectl -n argocd patch app basic-memory --type=merge \
  -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
argocd app wait basic-memory --sync --health --timeout=600

# 검증 항목 (homelab CLAUDE.md 우선순위 순)
kubectl get pods -n basic-memory                     # Pod Ready
argocd app get basic-memory                          # Synced + Healthy
kubectl get secret basic-memory-github basic-memory-auth -n basic-memory -o json \
  | jq '.items[].data | map_values(@base64d | length)'  # empty SealedSecret 함정 확인
kubectl get endpoints basic-memory -n basic-memory   # Service Endpoints
curl -fsS -H "Authorization: Bearer $MCP_TOKEN" https://bm.json-server.win/healthz
```

## MCP 클라이언트 등록 (검증 통과 후)

`~/.claude.json`의 `mcpServers`:
```json
"basic-memory": {
  "type": "sse",
  "url": "https://bm.json-server.win/sse",
  "headers": { "Authorization": "Bearer <MCP_TOKEN>" }
}
```

`mcp__gbrain__*` 호출은 그대로 두고, 1주 병행하며 `mcp__basic-memory__*` read 도구 직접 비교 → cutover 판단.

## Cutover 시 (검증 통과 후 별도 PR)

- gbrain ArgoCD App `replicas: 0` (즉시 회수 가능하게 유지)
- `~/.claude.json`에서 `gbrain` MCP entry 제거
- gbrain DNS 보존 (실수 swap 대비)
- 1개월 후 archive

## Test plan

- [ ] sealing 후 `argocd app sync basic-memory` 성공
- [ ] Pod 3 컨테이너(git-pull, basic-memory, caddy) 전부 Ready
- [ ] `kubectl logs -c basic-memory` 에서 `basic-memory project default brain` 성공 라인 확인
- [ ] curl Bearer auth 200 OK
- [ ] Claude Code에서 `mcp__basic-memory__search_notes` 호출 결과가 `mcp__gbrain__search`와 일치
- [ ] git push 후 5분 내 git-pull sidecar가 변경 감지 + Basic Memory가 인덱스 업데이트 (`tail -f` 로그 확인)
- [ ] 1주 운영하며 RestartCount 0 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)