### PR TITLE
chore(blackbox): home-assistant target 제거 (replicaCount 0 동안)

### DIFF
--- a/k8s/observability/blackbox-exporter/values.yaml
+++ b/k8s/observability/blackbox-exporter/values.yaml
@@ -87,9 +87,7 @@ serviceMonitor:
     - name: seafile
       url: http://seafile.seafile.svc.cluster.local
       module: http_2xx_no_tls
-    - name: home-assistant
-      url: http://home-assistant.home-assistant.svc.cluster.local:8080
-      module: http_2xx_no_tls
+    # home-assistant: replicaCount 0 (PR #84b4125, 2026-05-23 인시던트 후속) — startupProbe 추가 + 부활 시 복원
     - name: k8s-dashboard
       url: http://headlamp.headlamp.svc.cluster.local
       module: http_2xx_no_tls


### PR DESCRIPTION
## Summary
blackbox-exporter targets에서 \`home-assistant\` 제거.

## Why
2026-05-23 인시던트 후속으로 HA를 \`replicaCount: 0\`로 내림 (commit \`84b4125\`). 그 결과 blackbox probe가 죽은 svc를 찌르며 \`EndpointDown\` critical 알람이 의도와 무관하게 지속 firing. 의도된 down 상태이므로 target에서 일시 제거.

## 미래 복원 트리거
HA에 \`startupProbe\` 추가 + \`replicaCount: 1\` 복구 PR 작업 시 본 PR도 revert. 주석으로 이 트리거 명시함:
\`\`\`yaml
# home-assistant: replicaCount 0 (PR #84b4125, 2026-05-23 인시던트 후속) — startupProbe 추가 + 부활 시 복원
\`\`\`

## Test plan (머지 후)
- [ ] ArgoCD \`prometheus\`(또는 blackbox-exporter app) Synced/Healthy 유지
- [ ] blackbox-exporter ConfigMap에서 home-assistant target 사라짐
- [ ] Alertmanager의 EndpointDown(home-assistant) 알람 resolved
- [ ] 나머지 blackbox targets (argocd/grafana/prometheus 등) probe_success=1 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)