### PR TITLE
fix(minio-operator): zombie pod 방지 — replicas=2 + CPU limit 상향 + lease stale 알림

### DIFF
--- a/k8s/CLAUDE.md
+++ b/k8s/CLAUDE.md
@@ -297,7 +297,7 @@ resources:
 - **Python + pip install 인라인** (brain-agent 등): `memory: 256Mi-512Mi` 권장
 - **Postgres·TimescaleDB**: `request 256Mi / limit 1Gi+`
 - **Prometheus**: metric 볼륨에 따라 `500Mi+`
-- **minio-operator**: CPU 200m→500m 상향 필요 (PolicyBinding watch CPU 소모)
+- **minio-operator**: CPU `limit: "1"` + `replicaCount: 2` 권장. RSS는 ~25Mi지만 CFS throttle이 60s leader lease 윈도우 안의 renew를 놓치면 leader-lost callback 후 재캠페인 goroutine deadlock → TCP는 살아있지만 reconcile 멈추는 zombie pod 발생. 과거 "PolicyBinding watch CPU 소모"로 잘못 진단된 패턴 — 실제 원인은 leader-election 재캠페인 deadlock. v7.1.1 binary는 HTTP health endpoint 미노출이라 livenessProbe로 자동 감지 불가, 대신 2-replica failover + PrometheusRule `MinIOOperatorLeaseStale`(lease renewTime 5분+ stale)로 대응
 
 ---
 

--- a/k8s/minio-operator/values.yaml
+++ b/k8s/minio-operator/values.yaml
@@ -1,10 +1,38 @@
 operator:
-  replicaCount: 1
+  # 2 replicas로 leader-election failover 확보.
+  # leader pod이 CPU throttling으로 lease 잃은 뒤 재캠페인 deadlock에 빠지는
+  # zombie 패턴 (PR: fix(minio-operator) 참조)이 재발해도 다른 replica가
+  # 60s 내 lease 인수 → tenant 운영 무중단.
+  replicaCount: 2
+
+  # 차트 7.1.1 default antiaffinity는 `name=minio-operator` 라벨을 찾는데
+  # 실제 pod 라벨은 `app.kubernetes.io/name=operator` → 매칭 안 됨 → 두 replica가
+  # 같은 노드에 떨어질 수 있음. selector를 실제 라벨에 맞춰 override.
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - operator
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                  - minio-operator
+          topologyKey: kubernetes.io/hostname
+
   resources:
     requests:
       cpu: 50m
       memory: 128Mi
       ephemeral-storage: 500Mi
     limits:
-      cpu: 500m
+      # CFS throttling이 lease renewal (15s window in 60s lease) timeout을 유발하면
+      # leader-lost callback 후 goroutine deadlock → zombie pod. RSS는 ~25Mi라
+      # CPU 여유만 있으면 trigger 빈도 크게 감소. v7.1.1 binary는 health endpoint를
+      # 노출하지 않아 livenessProbe로 zombie 자동 감지 불가 — replicas=2 failover +
+      # PrometheusRule `MinIOOperatorLeaseStale` 알림으로 대응.
+      cpu: "1"
       memory: 256Mi

--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -230,3 +230,18 @@ spec:
           annotations:
             summary: "Image Updater stuck: registry 폴링 멈춤"
             description: "{{ $labels.registry }}에 대한 폴링이 15분 이상 0건. pod up이지만 내부 stuck 가능. `kubectl logs -n argocd -l app.kubernetes.io/name=argocd-image-updater` 확인."
+
+    # minio-operator zombie 감지 — leader pod이 CPU throttling으로 lease를 잃은 뒤
+    # 재캠페인 goroutine이 deadlock에 빠지면 TCP는 살아있지만 reconcile 멈춤.
+    # v7.1.1 binary는 health endpoint를 노출하지 않아 livenessProbe로 못 잡음.
+    # 대신 kube-state-metrics의 lease renewTime을 watcher로 사용.
+    - name: minio-operator
+      rules:
+        - alert: MinIOOperatorLeaseStale
+          expr: (time() - kube_lease_renew_time{lease="minio-operator-lock"}) > 300
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "minio-operator leader lease 5분+ stale"
+            description: "lease {{ $labels.namespace }}/{{ $labels.lease }}이 {{ $value | humanizeDuration }} 동안 갱신 안 됨. replicas=2 failover가 작동하지 않은 경우. zombie pod 확인 후 `kubectl -n minio-operator rollout restart deploy/minio-operator`."


### PR DESCRIPTION
## Summary
- minio-operator v7.1.1이 CPU throttle로 leader lease 잃은 뒤 재캠페인 goroutine deadlock에 빠지는 **zombie pod 패턴** 차단
- `replicaCount: 1→2`(HA failover) + `cpu limit: 500m→1`(trigger 완화) + antiAffinity 셀렉터 버그 수정 + `MinIOOperatorLeaseStale` PrometheusRule

## Root cause (logs로 확인)
- 2026-05-22 20:09 — pod 부팅, leader 획득, 3 tenant reconcile (initial spike)
- 20:10:32 — CFS throttling이 lease renewal PUT을 timeout (`context deadline exceeded`) → leader-lost callback + `Failed to release lock` race
- 20:11 — controller 정지. **goroutine deadlock** (futex_wait_queue 13 threads)
- 20:30 이후 — logs 0건, CPU 500m pegged, HTTP TCP는 살아있지만 `Empty reply from server`. **73시간 zombie**
- lease `leaseTransitions: 7` — 94일간 반복 발생
- 메모(`Memory.md`)는 "PolicyBinding CRD watch retry loop"로 잘못 진단. 실제로는 leader-election 재캠페인 deadlock — `k8s/CLAUDE.md` 메모도 같이 갱신

## Why no livenessProbe?
- v7.1.1 binary는 controller mode에서 HTTP 4221에 `/webhook/v1/update/*` 단일 경로만 등록 (`pkg/controller/webhook.go`)
- `/healthz`·`/metrics`·`/` 모두 404 (확인됨)
- TCP probe는 zombie 감지 못 함 (TCP accept는 정상)
- → 표준 K8s HTTP probe 적용 불가. 2-replica failover + 외부 알림으로 대체

## Changes
- `k8s/minio-operator/values.yaml`
  - `replicaCount: 2`
  - `resources.limits.cpu: "1"` (RSS ~25Mi라 실제 cost 미미)
  - `affinity.podAntiAffinity` 셀렉터를 실제 pod 라벨 (`app.kubernetes.io/name=operator` + `app.kubernetes.io/instance=minio-operator`)에 맞춤 — 차트 7.1.1 default는 `name=minio-operator` 찾는 버그
- `k8s/observability/prometheus/manifests/alert-rules.yaml`
  - 새 그룹 `minio-operator` + `MinIOOperatorLeaseStale` (renewTime 5분+ stale = warning). failover까지 실패한 시나리오 감지용
- `k8s/CLAUDE.md`
  - "PolicyBinding watch CPU 소모" 메모를 실제 원인(leader-election deadlock)으로 정정

## Test plan
- [x] `helm template` 로컬 렌더링 검증 — replicas/cpu/antiAffinity 모두 의도대로 적용
- [x] `alert-rules.yaml` YAML 파싱 검증 (8 groups, `MinIOOperatorLeaseStale` 등록 확인)
- [x] 즉시 회복: `kubectl rollout restart deploy/minio-operator -n minio-operator` 수행됨 (leaseTransitions 7→8)
- [ ] 머지 후 hard refresh + `argocd app wait minio-operator --sync --health --timeout=600`
- [ ] 2 replica가 서로 다른 노드에 스케줄되는지 확인 (`kubectl -n minio-operator get pods -o wide`)
- [ ] 새 lease 발급 후 한 replica가 leader, 다른 replica는 standby인지 확인
- [ ] PrometheusRule 적용 확인 (`kubectl -n observability get prometheusrule homelab-alerts -o yaml | grep -A 2 MinIOOperatorLeaseStale`)
- [ ] Alertmanager가 그룹을 인식하는지 (`alertmanager.json-server.win` 또는 직접 query)

## Future
- 한 replica zombie 시 자동 회복은 다른 replica의 lease 인수로 해결. 그러나 zombie pod 자체는 CPU 1 core 잡아먹은 채 남아있음 → 추후 Kyverno mutation으로 livenessProbe injection 검토 가능 (현재는 가용 endpoint 없어서 의미 없음)
- v8 chart에 health endpoint가 추가되면 livenessProbe 도입

🤖 Generated with [Claude Code](https://claude.com/claude-code)