### PR TITLE
feat(authentik): GitHub OAuth enrollment 시 user.type=internal 자동 부여

### DIFF
--- a/k8s/authentik/manifests/blueprint-github-source.yaml
+++ b/k8s/authentik/manifests/blueprint-github-source.yaml
@@ -32,3 +32,35 @@ data:
         attrs:
           sources:
             - !Find [authentik_sources_oauth.oauthsource, [slug, github]]
+
+      # Expression Policy: GitHub OAuth source 경유 enrollment 시 user.type=internal 부여.
+      # skku-amang org 검증은 app-level policy(cloudbeaver/longhorn/health-hub/loop)에서
+      # 별도 처리 — 여기서는 type 부여만, 권한 검증은 앱 레이어에서 (Separation of Concerns).
+      - model: authentik_policies_expression.expressionpolicy
+        state: present
+        identifiers:
+          name: github-oauth-enrollment-internal-grant
+        attrs:
+          name: github-oauth-enrollment-internal-grant
+          expression: |
+            source = request.context.get("source")
+            if source is not None and getattr(source, "slug", "") == "github":
+                request.context.setdefault("prompt_data", {})["type"] = "internal"
+                login = request.context.get("oauth_userinfo", {}).get("login", "?")
+                ak_logger.info(f"granted internal type to github oauth user: {login}")
+            return True
+
+      # default-source-enrollment flow에 binding — user_write stage 이전에 평가되어
+      # prompt_data["type"]가 영속화됨.
+      - model: authentik_policies.policybinding
+        state: present
+        identifiers:
+          order: 0
+          target: !Find [authentik_flows.flow, [slug, default-source-enrollment]]
+          policy: !Find [authentik_policies_expression.expressionpolicy, [name, github-oauth-enrollment-internal-grant]]
+        attrs:
+          enabled: true
+          order: 0
+          timeout: 30
+          failure_result: false
+          negate: false


### PR DESCRIPTION
## Summary

- `manamana32321` 같은 GitHub OAuth로 enroll된 사용자가 Authentik 인터페이스에서 "Interface can only be accessed by internal users"로 차단되던 문제 근본 해결
- GitHub OAuth source 경유 enrollment 시 expression policy로 `user.type = internal` 자동 부여
- 권한 검증과 type 분류 분리 — skku-amang org check는 app-level policy([blueprint-forward-auth.yaml](k8s/authentik/manifests/blueprint-forward-auth.yaml))에서 그대로 유지

## 배경

Authentik 2024.6+에서 OAuth/SAML enrollment 사용자는 기본 `external`로 생성됨. `external` user는 `/if/user`, `/if/admin` 등 Authentik 인터페이스 접근이 차단되므로, forward-auth flow 안에서 user interface 단계를 거치는 cloudbeaver 같은 앱이 "권한 거부" 화면을 띄움 (스크린샷의 manamana32321 케이스).

## 설계 결정

| 옵션 | 채택 | 이유 |
|---|---|---|
| `request.user.save()` 직접 mutate | ❌ | 비표준, Authentik docs에 공식 예제 없음 |
| Expression policy → `prompt_data['type']` 주입 → user_write 영속화 | ✅ | docs의 Google OAuth username mapping 예제와 동일 패턴 |
| B1: enrollment 시 GitHub org check + 통과 시 internal | ❌ | enrollment context 변수 location 미명시, 첫 시도 실패 위험 |
| B2: 무조건 internal + app-level org check 유지 | ✅ | SoC, 단순, 보안 회귀 없음 (sensitive app은 이미 별도 policy) |

## 검증 plan (머지 후)

1. ArgoCD hard-refresh + sync wait
2. 기존 external 사용자 1회성 백필 (Tailscale 필요):
   ```bash
   kubectl --context json -n authentik exec deploy/authentik-worker -- \
     ak change_user_type --username manamana32321 --type internal
   ```
3. https://db.json-server.win 접근 → 이전 "권한 거부" 화면 대신 cloudbeaver UI 진입 확인

## Test plan
- [ ] ArgoCD authentik app Synced + Healthy
- [ ] Authentik 로그에서 blueprint import 에러 없음
- [ ] manamana32321 백필 후 user.type == internal (ak shell 또는 admin API)
- [ ] db.json-server.win 접근 → cloudbeaver UI 정상 진입

🤖 Generated with [Claude Code](https://claude.com/claude-code)