### PR TITLE
fix(gbrain): sync CronJob amd64 nodeSelector + deadline — raspi-1 ImagePullBackOff cascade 차단

### DIFF
--- a/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
+++ b/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
@@ -9,11 +9,15 @@ spec:
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid         # never overlap
+  startingDeadlineSeconds: 300      # skip schedule if not started within 5m (prevents stuck-job cascade)
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 1800   # kill job after 30m (normal sync finishes in ~17m)
       template:
         spec:
           restartPolicy: OnFailure
+          nodeSelector:
+            kubernetes.io/arch: amd64   # image is amd64-only; raspi-1 (arm64) would ImagePullBackOff
           containers:
             - name: sync
               image: ghcr.io/manamana32321/gbrain-mcp:latest


### PR DESCRIPTION
## Summary
- nodeSelector `kubernetes.io/arch=amd64` 추가 — 이미지가 amd64-only인데 nodeSelector 없어 raspi-1(ARM64)에 떨어지면 영원히 ImagePullBackOff
- `startingDeadlineSeconds: 300` 추가 — 박힌 job이 후속 5분 sync 전부 차단하는 cascade 방지
- `activeDeadlineSeconds: 1800` 추가 — hang 시 자동 kill (정상 sync는 ~17분에 끝남)

## 배경
2026-05-25 13:13 UTC ~ `gbrain-sync-29661190`가 raspi-1에 떨어져 3일 13시간 ImagePullBackOff (22,480회 재시도). `concurrencyPolicy: Forbid` 때문에 후속 5분 sync 전부 차단 → KubeJobNotCompleted Telegram 알림 cascade. 박힌 job 수동 삭제(Phase 1)로 즉시 unblock 완료, 새 sync job은 json-server-1에 정상 배치되어 Running. 이 PR은 재발 방지(Phase 2).

## Test plan
- [ ] PR 머지 후 ArgoCD hard-refresh로 stale state 회피
- [ ] \`argocd app wait gbrain-mcp --sync --health --timeout=600\`
- [ ] 신규 sync job이 amd64 노드(server-1/2)에만 스케줄되는지 확인
- [ ] KubeJobNotCompleted 알림 firing 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)