### PR TITLE
fix(amang-minio): PVC를 longhorn-ssd로 이관 — Tenant 일시 prune (1/2)

### DIFF
--- a/k8s/minio-tenants/overlays/production/kustomization.yaml
+++ b/k8s/minio-tenants/overlays/production/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: amang-api-production
 resources:
-  - ../../base
+  # ../../base 일시 제거 — PR #236 후속 PVC 마이그레이션 동안 Tenant CR을 GitOps로 비워야 함.
+  # 작업 종료 직후 PR로 복원. 자세한 경위는 PR 본문 참조.
   - sealed-secret.yaml
   - sealed-secret-s3-credentials.yaml
   - ingress.yaml

--- a/k8s/minio-tenants/overlays/staging/kustomization.yaml
+++ b/k8s/minio-tenants/overlays/staging/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: amang-api-staging
 resources:
-  - ../../base
+  # ../../base 일시 제거 — PR #236 후속 PVC 마이그레이션 동안 Tenant CR을 GitOps로 비워야 함.
+  # 작업 종료 직후 PR로 복원. 자세한 경위는 PR 본문 참조.
   - sealed-secret.yaml
   - sealed-secret-s3-credentials.yaml
   - ingress.yaml


### PR DESCRIPTION
## 무엇

amang prod/staging MinIO Tenant CR을 ArgoCD overlay에서 일시 제거한다.
→ ArgoCD prune → minio Tenant/STS/Pod 회수 → outage 시작.

후속 PR(2/2)에서 base 참조 복원 → operator가 새 longhorn-ssd PVC adopt → 종료.

## 왜

[PR #236](https://github.com/manamana32321/homelab/pull/236) (2026-05-23 머지)이 `base/tenant.yaml`의
`storageClassName: local-path → longhorn-ssd`로 끌어올렸지만, Tenant의
`volumeClaimTemplate`은 StatefulSet 제약상 **immutable** — Tenant CR spec만
바뀌고 실제 PVC는 여전히 `local-path` (raspi-1 SD카드)에 묶여 있음.

오늘(2026-05-29 KST 12:22) raspi-1 NotReady — kubelet 사망 + 12:53 자동
재부팅 후 좀비 `k3s.service` (server)가 6444 점유 → `k3s-agent.service`가
317회 재시작 실패. SSH로 들어가 `k3s.service` stop+disable → agent 합류로
임시 해소. 다만 **PVC가 SPOF raspi-1에 남아있는 한 같은 사고 재발**.

## 진행 단계

```
[이 PR]                   ─ overlay에서 ../../base 참조 제거 (Tenant prune)
                            ↓
머지 후 ArgoCD hard-refresh ─ amang-minio-{production,staging} Synced 확인
                            ↓
수동 작업                  ─ 구 PVC 삭제 (PV는 reclaimPolicy=Retain으로
                            미리 패치해둠 → 데이터 보존)
                          ─ 새 longhorn-ssd PVC pre-seed (이름 일치)
                          ─ helper pod 마운트 → tar.gz 복원
                          ─ helper 종료
                            ↓
[후속 PR]                  ─ overlay에 ../../base 참조 복원 (Tenant 재생성)
                            ↓
머지 후                    ─ operator가 새 PVC adopt → minio Ready
                          ─ amang API → minio 접근 복구
```

## 백업 (이미 확보)

이 PR 작성 전에 양 ns \`/export\`를 tar.gz로 백업해 raspi-1 host + WSL
양쪽에 보관:

- \`amang-prod-minio-20260529-134209.tar.gz\` (51MB compressed / 54MB raw)
- \`amang-staging-minio-20260529-134209.tar.gz\` (1.9MB / 2.2MB)
- \`.minio.sys/{format.json,pool.bin,buckets,...}\` 메타 포함 확인

PVC 삭제 + PV Retain 안전망까지 합쳐 데이터는 3중 안전망 (raspi-1 hostPath
+ Retained PV + tar 백업).

## Maintenance window

- **머지 시점 = amang prod + staging minio outage 시작**
- amang API의 minio 의존 경로는 5xx로 떨어짐 (양쪽 환경)
- 후속 PR 머지 + operator adoption까지 outage 유지
- 사용량이 낮아 영향 작음 (사용자 합의)

## Test plan (post-merge)

- [ ] amang-minio-production / staging 양쪽 hard refresh + sync 대기
- [ ] \`kubectl -n amang-api-production get tenant,sts,pod\` → 없음 확인
- [ ] essentia-minio Healthy 유지 (regression 체크)
- [ ] 후속 PR(2/2) 작업 진행

Refs: #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)