### PR TITLE
fix(amang-minio): overlay base 참조 복원 — PVC longhorn-ssd 이관 완료 (2/2)

### DIFF
--- a/k8s/minio-tenants/overlays/production/kustomization.yaml
+++ b/k8s/minio-tenants/overlays/production/kustomization.yaml
@@ -2,8 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: amang-api-production
 resources:
-  # ../../base 일시 제거 — PR #236 후속 PVC 마이그레이션 동안 Tenant CR을 GitOps로 비워야 함.
-  # 작업 종료 직후 PR로 복원. 자세한 경위는 PR 본문 참조.
+  - ../../base
   - sealed-secret.yaml
   - sealed-secret-s3-credentials.yaml
   - ingress.yaml

--- a/k8s/minio-tenants/overlays/staging/kustomization.yaml
+++ b/k8s/minio-tenants/overlays/staging/kustomization.yaml
@@ -2,8 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: amang-api-staging
 resources:
-  # ../../base 일시 제거 — PR #236 후속 PVC 마이그레이션 동안 Tenant CR을 GitOps로 비워야 함.
-  # 작업 종료 직후 PR로 복원. 자세한 경위는 PR 본문 참조.
+  - ../../base
   - sealed-secret.yaml
   - sealed-secret-s3-credentials.yaml
   - ingress.yaml


### PR DESCRIPTION
## 무엇

[PR #245](https://github.com/manamana32321/homelab/pull/245)에서 일시 제거했던
`../../base` 참조를 두 overlay에 복원한다. 머지하면 ArgoCD가 Tenant CR을
재생성하고 minio-operator가 이름 일치하는 새 PVC를 adopt한다.

## 그동안 한 일

PR #245 머지 → ArgoCD prune → Tenant/STS/Pod 회수 → PVC만 남음 → 수동:

1. 구 local-path PVC 2개 삭제 (PV는 `reclaimPolicy=Retain`이라 Released로 보존)
2. 새 longhorn-ssd PVC 2개 생성:
   - `amang-api-production/data0-minio-pool-0-0` → `pvc-3ffc8a90-...`
   - `amang-api-staging/data0-minio-pool-0-0` → `pvc-add59dee-...`
3. helper pod (alpine + busybox tar, runAsUser=1000/fsGroup=1000)에 stdin
   stream으로 백업 복원:
   - `amang-prod-minio-20260603-102032.tar.gz` (51MB → 53.1M)
   - `amang-staging-minio-20260603-102032.tar.gz` (1.9MB → 2.0M)
   - `.minio.sys/{format.json,pool.bin,buckets,config}` + `amang/` 버킷 포함
4. helper pod 종료

## 머지 후 검증

- [ ] hard-refresh 즉시: \`kubectl -n argocd patch app amang-minio-{production,staging} ...refresh=hard\`
- [ ] \`argocd app wait amang-minio-production --sync --health --timeout=600\` (staging 동일)
- [ ] Tenant Initialized + STS Ready
- [ ] minio pod이 raspi-1이 아닌 server-1/server-2에서 기동
- [ ] amang API의 minio 의존 경로(장비 이미지 로드) 200
- [ ] 인접 essentia-minio Healthy 유지

## 정리 (후속)

머지 + 검증 OK 확인되면:
- 구 Released PV 2개 삭제 (raspi-1 hostPath 데이터 회수)
- raspi-1 \`/tmp/amang-*-minio-*.tar.gz\` 백업 삭제
- WSL \`/tmp/raspi1-retire-backup/\` 백업 삭제

Refs: #245, #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)