### PR TITLE
fix(crowdsec): agent를 Traefik co-located Deployment로 전환 — register 충돌 crashloop 해소

### DIFF
--- a/k8s/crowdsec/values.yaml
+++ b/k8s/crowdsec/values.yaml
@@ -1,6 +1,23 @@
 container_runtime: containerd
 
 agent:
+  # Run as a single Deployment co-located with Traefik (podAffinity) instead of a
+  # per-node DaemonSet. The agent's only job is reading Traefik access logs, and
+  # Traefik runs on exactly one node. A DaemonSet also placed agents on raspi-1/j1
+  # where there are no Traefik logs to read — pure overhead — and their stable pod
+  # names caused a permanent `cscli lapi register: user already exist` crashloop
+  # after restarts wiped the emptyDir credentials (LAPI machine DB persists on PV).
+  # podAffinity makes the single agent follow Traefik wherever it is scheduled.
+  isDeployment: true
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+          namespaces:
+            - kube-system
+          topologyKey: kubernetes.io/hostname
   acquisition:
     - namespace: kube-system
       podName: traefik-*


### PR DESCRIPTION
## 문제 (5일째 텔레그램 알림 3개)

`crowdsec` ns에서 2026-05-29부터 반복 — 셋 다 **단일 근본 원인**의 다른 각도:

| 알림 | 내용 |
|---|---|
| `KubeContainerWaiting` | raspi-1 `crowdsec-agent-xjcrt` init **1377회** 재시작 |
| `KubeDaemonSetRolloutStuck` | DaemonSet 롤아웃 멈춤 |
| `TargetDown` | agent 타겟 66.67%(2/3) down |

## 근본 원인

1. **잉여 배치** — crowdsec-agent의 유일한 임무는 Traefik access 로그 파싱인데, Traefik은 **json-server-2 단 1노드**에만 존재. agent는 DaemonSet이라 raspi-1·j1에도 떴고 거긴 읽을 Traefik 로그가 없음 → 순수 오버헤드.
2. **비대칭 영속성 → register 충돌** — agent creds는 `emptyDir`(비영속), LAPI 머신 DB는 `longhorn-ssd` PV로 영속. 파드 재시작으로 creds 증발 → init이 재등록 시도 → DaemonSet 파드명은 노드별 안정적이라 LAPI에 같은 이름 잔존 → \`cscli lapi register: 403 user already exist\` → 영구 CrashLoopBackOff.

## 해결 — agent를 Traefik co-located Deployment로

\`agent.isDeployment: true\` + \`podAffinity(→traefik, topologyKey=hostname)\`:

- 단일 agent가 **항상 Traefik 노드에 co-locate**, 재스케줄 시 따라감 (hostname 정적 pin이 아니라 "Traefik을 향함").
- raspi-1·j1 무의미 파드 제거 → **알림 3개 구조적 차단**.
- Deployment 파드는 recreate마다 이름이 바뀜(RS hash+suffix) → 매번 새 머신 등록 → **충돌 근본 소멸**.
- \`hostVarLog\`(기본 true)로 \`/var/log\` hostPath 유지 → containerd 로그 읽기 정상 (차트 deployment 템플릿 검증 완료).

차트 0.23.0 네이티브 \`agent.isDeployment\` 사용. \`replicas: 1\`·\`strategy: Recreate\`는 차트 기본값.

## 검증 계획 (머지 후)

1. ArgoCD hard-refresh → \`argocd app wait crowdsec --sync --health\`
2. 새 agent 파드가 **json-server-2(Traefik 노드)** 에 1개 Ready, RestartCount 0
3. \`cscli metrics\` / \`cscli machines list\` 에 새 agent 등록 + Traefik acquisition 정상
4. 3개 알림 모두 resolved
5. **후속(수동)**: LAPI orphan 머신 레코드(\`xjcrt\`/\`8rzcz\`/\`7w8td\`/\`7hdr2\`/\`98gr6\`/\`8npbw\`) \`cscli machines delete\` 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)