### PR TITLE
fix(amang-minio): pool nodeSelector arch=amd64 — raspi-1 스케줄링 회피

### DIFF
--- a/k8s/minio-tenants/base/tenant.yaml
+++ b/k8s/minio-tenants/base/tenant.yaml
@@ -14,6 +14,10 @@ spec:
     - name: pool-0
       servers: 1
       volumesPerServer: 1
+      # amd64 전용 — raspi-1(arm64, SD카드) 스케줄링 회피.
+      # longhorn-ssd replica가 server-1/-2에 있어도 attachment가 raspi-1로 가면 iSCSI + SPOF.
+      nodeSelector:
+        kubernetes.io/arch: amd64
       volumeClaimTemplate:
         metadata:
           name: data


### PR DESCRIPTION
## 무엇

\`base/tenant.yaml\`의 \`spec.pools[0]\`에 \`nodeSelector: kubernetes.io/arch: amd64\` 추가.
세 tenant (amang prod/staging/essentia)가 모두 amd64 노드(server-1/-2)로만 스케줄.

## 왜

#246 (PVC longhorn-ssd 이관) 후 minio pod이 다시 raspi-1로 스케줄됨:

- PVC \`volume.kubernetes.io/selected-node\` 비웠는데도 scheduler가 가장 여유 있는
  노드 = raspi-1을 선택
- longhorn-ssd replica는 server-1/-2 SSD에 안전하지만 attachment가 raspi-1로 가면
  iSCSI 경유 + raspi-1 다운 시 minio도 함께 다운 → **SPOF 미해소**

arch 기반 nodeSelector로 해소. 미래 ARM 노드 추가에도 자동 회피.

## 머지 후 검증

- [ ] hard-refresh 두 amang-minio app + essentia-minio
- [ ] \`argocd app wait\` Synced + Healthy
- [ ] amang prod/staging minio pod이 server-1 또는 server-2에 reschedule
- [ ] essentia-minio pod은 server-1 그대로 (변경 없음, regression 체크)
- [ ] amang API health up + 이미지 로드 동작

Refs: #246, #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)