### PR TITLE
fix(health-hub): wait-for-db initContainer + liveness 타이밍 정상화

### DIFF
--- a/k8s/health-hub/manifests/deployment.yaml
+++ b/k8s/health-hub/manifests/deployment.yaml
@@ -20,6 +20,31 @@ spec:
         fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        # timescaledb가 뜨고 DNS가 풀릴 때까지 대기 — 재부팅/DB 재시작 시
+        # 앱이 DB 연결 실패로 Exit 1 crashloop 도는 startup ordering 문제 차단
+        - name: wait-for-db
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z timescaledb 5432; do
+                echo "waiting for timescaledb:5432..."
+                sleep 2
+              done
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
       containers:
         - name: health-hub
           image: ghcr.io/manamana32321/health-hub:latest
@@ -66,8 +91,10 @@ spec:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 15
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## 배경

오늘(2026-06-07 KST) json-server-1에 물리 충격 → json-1 + raspi-1 **동시 재부팅** (전원 멀티탭 공유). raspi-1에 거주하던 `timescaledb-0`가 다운되면서 health-hub가 줄줄이 crashloop.

직전 크래시 로그(smoking gun):
```
00:30:52 INFO  default timezone resolved tz=Asia/Seoul
00:31:22 ERROR failed to connect to database
  error="lookup timescaledb on 10.43.0.10:53: no such host"
```
→ DB(timescaledb) Service DNS 미해석 → 30초 ping 타임아웃 → **Exit 1** → restart backoff 누적. DB 복귀(~00:37) 후 자가 안정됨.

## 변경

| 항목 | Before | After | 근거 |
|------|--------|-------|------|
| `wait-for-db` initContainer | 없음 | `nc -z timescaledb 5432` 대기 | DB 미가용 시 앱 시작 자체를 막아 startup crashloop 원천 차단 (앱 코드 변경 X) |
| health-hub livenessProbe | initialDelay 5 / period 15 / timeout 1(기본) | 60 / 30 / 3, failureThreshold 3 | [k8s/CLAUDE.md](k8s/CLAUDE.md) "Health Probes" 권장값. 기존값은 너무 공격적 → CPU throttle·느린 시작 시 false-positive kill (8~13일 sparse 재시작 이력) |

## 범위 밖 (별도 이슈)

근본 원인 중 하나 — **timescaledb가 nodeSelector 없이 raspi-1(SD카드·전원 공유 노드)에 배치**된 점. k8s/CLAUDE.md "raspi-1엔 PV 배치 최후순위", "DB → SSD 노드" 컨벤션 위반. PVC sc=`longhorn-ssd`인데 pod가 raspi-1라 IO locality도 깨짐. 이 PR은 **앱 측 복원력만** 강화하고 DB 노드 배치는 분리.

## 검증 계획 (post-merge)

1. `argocd app wait health-hub --sync --health` (hard-refresh 선행)
2. Pod: initContainer 통과 → 2/2 Ready, RestartCount 안정
3. `/healthz` 200, 인접 앱(timescaledb) Healthy 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)