### PR TITLE
fix(health-hub): nodeSelector arch=amd64 — raspi-1 스케줄링 회피

### DIFF
--- a/k8s/health-hub/manifests/deployment.yaml
+++ b/k8s/health-hub/manifests/deployment.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: health-hub
     spec:
+      # health-hub 이미지는 amd64-only — raspi-1(arm64) 배치 시 exec format error로
+      # crashloop. 롤아웃 때 스케줄러가 raspi-1에 올려 노출됨 (#248 동일 패턴)
+      nodeSelector:
+        kubernetes.io/arch: amd64
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## 문제

[#249](https://github.com/manamana32321/homelab/pull/249) 머지 → 롤아웃 중 새 ReplicaSet pod가 **raspi-1(arm64)** 에 배치되어 crashloop:

```
exec /usr/local/bin/health-hub: exec format error      # health-hub 컨테이너
exec /usr/local/bin/health-hub-mcp: exec format error  # mcp 컨테이너
```

health-hub 이미지는 **amd64 단일 아키텍처** 빌드. nodeSelector가 없어 스케줄러가 arm64 노드에 올릴 수 있었음. 직전까지 멀쩡했던 건 구 pod가 우연히 json-server-2(amd64)에 있었을 뿐 — 잠복 버그가 롤아웃으로 노출됨.

- initContainer `wait-for-db`는 정상 통과(Exit 0) — #249 변경 자체는 무결.
- 구 pod(json-server-2) 2/2 Running 유지 → **서비스 무중단**, 롤아웃만 Progressing 정지.

## 변경

deployment 템플릿에 `nodeSelector: kubernetes.io/arch=amd64` 추가 → amd64 노드(json-server-1/2)에만 배치. amang-minio [#248](https://github.com/manamana32321/homelab/pull/248)과 동일 패턴.

## 검증 계획 (post-merge)

1. hard-refresh → `argocd app wait health-hub --sync --health`
2. 새 pod가 amd64 노드 착지 → initContainer 통과 → 2/2 Ready, RestartCount 안정
3. 구 ReplicaSet 정리, `/healthz` 200, timescaledb Healthy 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)