### PR TITLE
feat(minecraft): 화이트리스트에 SEOM 추가

### DIFF
--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -47,7 +47,7 @@ minecraftServer:
   onlineMode: true
   # 화이트리스트 — 등록된 친구만 접속 (그리퍼 차단). WHITELIST env → whitelist.json 동기화.
   # 친구 추가 시 이 줄에 쉼표로 닉네임 추가 후 PR. git이 SSOT.
-  whitelist: "EddieDawn,Dinudi,JinuStar0"
+  whitelist: "EddieDawn,Dinudi,JinuStar0,SEOM"
   # k3s ServiceLB(klipper)가 노드 호스트의 25565를 직접 바인딩 → 공유기 포트포워딩 1:1
   serviceType: LoadBalancer
   servicePort: 25565


### PR DESCRIPTION
## 무엇

마인크래프트 서버 화이트리스트에 `SEOM` 추가.

[k8s/minecraft/values.yaml](k8s/minecraft/values.yaml#L50):
```diff
-  whitelist: "EddieDawn,Dinudi,JinuStar0"
+  whitelist: "EddieDawn,Dinudi,JinuStar0,SEOM"
```

## 왜 선언적

- itzg 이미지가 기동 시 `WHITELIST` env → `whitelist.json` 동기화. git이 SSOT
- `ENFORCE_WHITELIST=true` (L94) — 명단 외 접속자 즉시 강퇴. 추가 안 하면 못 들어옴
- in-game `/whitelist add`는 비선언적 → Recreate 롤아웃 시 소실되므로 금지

## 적용

머지 → ArgoCD sync → `strategyType: Recreate` 롤아웃 → 새 whitelist 반영

## 검증 (머지 후)

```bash
kubectl -n argocd patch app minecraft --type=merge \
  -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
argocd app wait minecraft --sync --health --timeout=600
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)