### PR TITLE
feat(actions-runner): dind 모드 + maxRunners 상향 — bconnect CI 전체 self-hosted 이주

### DIFF
--- a/k8s/actions-runner/runner-values.yaml
+++ b/k8s/actions-runner/runner-values.yaml
@@ -1,6 +1,6 @@
-# ARC Runner Scale Set — morton 레포 전용 러너
+# ARC Runner Scale Set — bconnect 레포 전용 러너
 # GitHub App 인증 → SealedSecret으로 관리 (github-app-secret)
-githubConfigUrl: "https://github.com/mortonCareer/morton"
+githubConfigUrl: "https://github.com/mortonCareer/bconnect"
 githubConfigSecret: github-app-secret
 
 controllerServiceAccount:
@@ -9,7 +9,12 @@ controllerServiceAccount:
 
 # scale-from-zero: 워크플로우 대기 중일 때만 Pod 생성
 minRunners: 0
-maxRunners: 2
+maxRunners: 4
+
+# BE CI(ci-api/ci-api-spec)가 Testcontainers-postgresql 사용 → Docker daemon 필요.
+# dind: 러너 Pod에 docker-in-docker 사이드카 + DOCKER_HOST 자동 주입.
+containerMode:
+  type: "dind"
 
 template:
   spec:
@@ -19,8 +24,8 @@ template:
         command: ["/home/runner/run.sh"]
         resources:
           limits:
-            cpu: "1"
-            memory: 2Gi
+            cpu: "2"
+            memory: 4Gi
           requests:
             cpu: 250m
             memory: 512Mi


### PR DESCRIPTION
## Summary

bconnect(`mortonCareer/bconnect`) private 레포가 6/14 GitHub-hosted runner 무료 분(월 2000분) 소진 → 이후 모든 CI 체크 캔슬. 기존 self-hosted `morton-runner`(ARC on k3s)로 CI 전체 이주하기 위한 러너 측 변경.

의사결정 비교(3안: plan 업글 vs 종량제 vs self-hosted)는 [예산 회의 Notion](https://app.notion.com/p/372965d2888b80d99e8ffa27e7d40129) 참조.

## Why dind

기존 `morton-runner`는 `kiscon-sync`(순수 node) 전용으로만 쓰여 docker가 없는 bare `actions-runner:latest`. bconnect CI의 BE 잡(`ci-api`/`ci-api-spec`)은 `./gradlew build`가 **Testcontainers-postgresql** 사용 → Docker daemon 필수. 라벨만 바꾸면 `Cannot connect to the Docker daemon`으로 실패.

## Changes

`k8s/actions-runner/runner-values.yaml`:
- `containerMode.type: dind` — 러너 Pod에 docker-in-docker 사이드카 + DOCKER_HOST 자동 주입 ([ARC 공식 dind 모드](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller#using-docker-in-docker-mode))
- `maxRunners` 2 → 4 (ci.yml 최대 8잡 fan-out, paths-filter로 보통 3~4 동시)
- 러너 리소스 limits 2cpu/4Gi 상향 (gradle JVM + testcontainers)
- `githubConfigUrl` morton → bconnect 정합 (rename redirect 의존 제거)

## 검증 계획 (머지 후)

- [ ] ArgoCD `actions-runner-morton` Synced + Healthy (`argocd app wait`)
- [ ] dind 사이드카 주입 확인 (`kubectl get pod -n actions-runner -o jsonpath` → 2 containers)
- [ ] bconnect `runs-on` 이주 PR(별도, bconnect repo) 머지 후 BE 잡 docker 빌드 green
- [ ] 노드 메모리 압박 모니터링 (4 runner × dind, json-server 16Gi) — 필요 시 maxRunners/리소스 튜닝

## 관련

- bconnect workflow `runs-on` 이주 PR: (별도, 곧 링크)
- Closes #252
