### PR TITLE
fix(traefik): replicas 2 + node anti-affinity — 단일 replica SPOF 제거 (523 사고)

### DIFF
--- a/k8s/traefik/manifests/helmchartconfig.yaml
+++ b/k8s/traefik/manifests/helmchartconfig.yaml
@@ -23,6 +23,10 @@ spec:
     # bouncer plugin can read the LAPI key from a file path instead of
     # inlining the plaintext in the Middleware CRD.
     deployment:
+      # HA: 2 replicas so a single node going NotReady cannot leave the
+      # ingress with 0 backends (caused a site-wide Cloudflare 523 on 2026-06-21
+      # when json-server-2 briefly flapped and the lone traefik pod was evicted).
+      replicas: 2
       additionalVolumes:
         - name: crowdsec-bouncer-key
           secret:
@@ -34,3 +38,13 @@ spec:
       - name: crowdsec-bouncer-key
         mountPath: /run/secrets/crowdsec
         readOnly: true
+    # Force the two replicas onto distinct nodes. Required (not preferred) so the
+    # scheduler can never stack both on one node — which would re-create the SPOF.
+    # Satisfiable: 3 nodes, 2 replicas.
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: traefik
+            topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## 배경 — 2026-06-21 사이트 전체 523

`grafana.json-server.win` 등 **모든 서브도메인**이 ~21:23–21:33 KST Cloudflare **523 (origin unreachable)**. 디버깅 시점엔 이미 자연 복구된 상태였음.

## 근본 원인 (2겹)

| 층 | 내용 |
|---|---|
| 트리거 | 단일 컨트롤플레인(json-server-1, i7-3770 + 임베디드 etcd)이 잠깐 느려짐 → **json-server-2 kubelet의 node lease 갱신 지연** → CP가 json-server-2를 `NotReady` 마킹 (재부팅 아님, uptime 106일) |
| **증폭기 (이 PR이 고치는 것)** | 하필 **유일한 traefik replica**가 json-server-2에 있어 NotReady 톨러런스(300s) 후 evict → 인그레스 백엔드 0 → 전 서브도메인 523 |

`json-server-2` Ready `lastTransitionTime` = `2026-06-21T12:27:28Z`(21:27 KST), traefik 재스케줄 21:33 → 복구. 노드 블립 1회가 단일 replica 때문에 사이트 전체 다운으로 증폭된 것이 핵심.

## 변경

[k8s/traefik/manifests/helmchartconfig.yaml](../blob/fix/traefik-ha/k8s/traefik/manifests/helmchartconfig.yaml):
- `deployment.replicas: 1 → 2`
- top-level `affinity.podAntiAffinity` (**required**, `topologyKey: kubernetes.io/hostname`) — 두 replica를 서로 다른 노드에 강제 분산. `preferred`가 아니라 `required`인 이유: 스케줄러가 한 노드에 둘 다 쌓으면 SPOF가 그대로 부활하기 때문. 3노드/2replica라 항상 스케줄 가능.

crowdsec bouncer 볼륨·플러그인 설정은 그대로 보존.

## 검증 계획 (머지 후)

1. `argocd app` hard-refresh → `traefik` HelmChart 재적용
2. traefik pod 2개가 **서로 다른 노드**에 Running
3. 외부 probe: grafana/argocd 등 200/302
4. crowdsec 미들웨어 정상 (websecure entrypoint)

## 범위 밖 (후속)

- 단일 컨트롤플레인 SPOF (json-server-1) — 별도 이슈로 분리. 이번 PR은 노드 블립이 사이트 전체를 죽이지 못하게 하는 데까지만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)