### PR TITLE
feat(observability): gbrain-sync 신선도 알림 + KubeJobFailed nuisance 차단

### DIFF
--- a/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
+++ b/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
@@ -7,7 +7,11 @@ metadata:
 spec:
   schedule: "*/5 * * * *"          # every 5 minutes
   successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 3
+  # 0: 실패 잡 오브젝트를 남기지 않는다. kube-prometheus-stack의 KubeJobFailed는
+  # kube_job_failed>0 (= 실패 잡 오브젝트 존재)로 발화하는데, 5분 cron의 일시적
+  # 실패가 남긴 잡이 새 실패로 rotate되거나 수동 삭제될 때까지 알림이 안 꺼져 nuisance가 된다.
+  # 지속 장애 감지는 alert-rules.yaml의 GbrainSyncStale(last_successful_time 신선도)이 담당.
+  failedJobsHistoryLimit: 0
   concurrencyPolicy: Forbid         # never overlap
   startingDeadlineSeconds: 300      # skip schedule if not started within 5m (prevents stuck-job cascade)
   jobTemplate:

--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -245,3 +245,21 @@ spec:
           annotations:
             summary: "minio-operator leader lease 5분+ stale"
             description: "lease {{ $labels.namespace }}/{{ $labels.lease }}이 {{ $value | humanizeDuration }} 동안 갱신 안 됨. replicas=2 failover가 작동하지 않은 경우. zombie pod 확인 후 `kubectl -n minio-operator rollout restart deploy/minio-operator`."
+
+    # gbrain-sync cron 신선도 감지 — git(brain repo) → Postgres 인덱스 동기화가
+    # 지속적으로 실패하면 brain 검색 결과가 stale해진다.
+    # kube-prometheus-stack의 KubeJobFailed는 잡 오브젝트 존재로 발화해 일시적
+    # 실패에도 잔재 알림이 남는다(→ CronJob failedJobsHistoryLimit=0으로 소스 차단).
+    # 대신 "마지막 성공 이후 경과 시간"으로 지속 장애만 잡고 성공 시 자동 해소.
+    # 정상 cadence 주의: sync ~17분 + concurrencyPolicy=Forbid → 성공 완료 간격이
+    # ~20분으로 벌어지므로 임계를 넉넉히(1h) 잡아 false positive를 피한다.
+    - name: gbrain
+      rules:
+        - alert: GbrainSyncStale
+          expr: (time() - kube_cronjob_status_last_successful_time{cronjob="gbrain-sync"}) > 3600
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "gbrain-sync 1시간+ 성공 없음"
+            description: "gbrain-sync cron이 {{ $value | humanizeDuration }} 동안 성공하지 못함. brain 인덱스가 stale해지는 중. `kubectl -n gbrain get jobs`로 최근 실패 확인 후 로그(`kubectl -n gbrain logs job/<name>`) 점검."


### PR DESCRIPTION
## 배경

홈랩 알림 점검 중 firing 발견:

| Alert | Sev | 상태 |
|---|---|---|
| `KubeJobFailed` ×3 | warning | gbrain-sync 옛 실패 잡 (2026-06-21 라우터 인시던트분) 잔재 |
| `MinIOOperatorLeaseStale` | warning | minio-operator zombie (별도 런타임 조치로 해소) |

`MinIOOperatorLeaseStale`은 `rollout restart deploy/minio-operator`로 이미 해소 (lease 새 홀더 `xktb2`/json-server-2 획득, renewTime 최신). 이 PR은 **gbrain-sync 알림 재발 방지** 담당.

## 문제

`KubeJobFailed`(kube-prometheus-stack 기본)는 `kube_job_failed > 0`, 즉 **실패 잡 오브젝트 존재**로 발화. 5분 cron의 일시적 실패가 남긴 잡은 새 실패로 rotate되거나 수동 삭제되기 전까지 알림이 안 꺼짐. 최근 sync는 정상인데 6/21 실패분 3개가 `failedJobsHistoryLimit=3`에 걸려 상시 firing.

`failedJobsHistoryLimit`을 낮춰도 반쪽: 단일 실패가 1건 남아 계속 firing. `0`으로만 하면 지속 장애 시 모든 잡이 즉시 삭제돼 **알림 자체가 안 뜸** → 진짜 장애에 눈멀음.

## 변경

- **`sync-cronjob.yaml`**: `failedJobsHistoryLimit` 3→0 — 실패 잡 잔재(nuisance 소스) 제거
- **`alert-rules.yaml`**: `GbrainSyncStale` 규칙 추가 — `last_successful_time` 신선도로 지속 장애만 발화 + 성공 시 자동 해소. 잡 오브젝트 존재 여부에 의존하지 않는 견고한 신호

```promql
(time() - kube_cronjob_status_last_successful_time{cronjob="gbrain-sync"}) > 3600
```

`for: 15m`, severity warning.

## 임계값 근거

정상 sync ~17분 + `concurrencyPolicy: Forbid` + `startingDeadlineSeconds: 300` → 성공 완료 간격이 **~20분**으로 벌어짐 (`last_successful_time` age가 정상에서도 0→20분 진동). 30분 임계는 false positive 위험 → **3600s(1h)** 로 넉넉히 잡아 진짜 다중 시간 outage만 발화.

## 검증

- 옛 실패 잡 3개 삭제 완료 → 현재 firing은 `Watchdog`(정상)만
- 머지 후: `argocd app wait prometheus --sync --health` + PromQL 평가 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)