### PR TITLE
feat(hermes): Hermes Agent 개인 비서 K3s 배포 (코어 — Telegram 후속)

### DIFF
--- a/cloudflare/dns.tf
+++ b/cloudflare/dns.tf
@@ -75,6 +75,15 @@ resource "cloudflare_record" "db" {
   comment = "CloudBeaver DB admin"
 }
 
+resource "cloudflare_record" "hermes" {
+  zone_id = cloudflare_zone.main.id
+  name    = "hermes"
+  type    = "A"
+  content = var.default_ip
+  proxied = true
+  comment = "Hermes Agent admin dashboard (Authentik forward-auth)"
+}
+
 resource "cloudflare_record" "minecraft" {
   zone_id = cloudflare_zone.main.id
   name    = "mc"

--- a/k8s/argocd/applications/apps/hermes.yaml
+++ b/k8s/argocd/applications/apps/hermes.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hermes
+  namespace: argocd
+  # No Image Updater: third-party public image pinned to an explicit tag
+  # (per k8s/CLAUDE.md — Image Updater is for our own GHCR images only).
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/manamana32321/homelab
+    targetRevision: main
+    path: k8s/hermes/manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hermes
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/hermes/README.md
+++ b/k8s/hermes/README.md
@@ -1,0 +1,98 @@
+# Hermes Agent
+
+개인 상시 AI 비서 ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent), MIT).
+영구기억 + 자율 스킬 + 메신저 게이트웨이 + credential pool. Claude **Max 구독 OAuth**로 추론
+(종량제 API 키 미사용).
+
+- 대시보드: https://hermes.json-server.win (Authentik forward-auth 게이트)
+- 이미지: `nousresearch/hermes-agent:v2026.6.5` (Docker Hub, multiarch)
+- 데이터: PVC `hermes-data` (longhorn-ssd, 5Gi) → `/opt/data` (`HERMES_HOME`/`HOME`)
+
+## 구조
+
+파드 1개 / 컨테이너 2개가 PVC `/opt/data`를 공유 (RWO → 단일 노드, `strategy: Recreate`):
+
+| 컨테이너 | 명령 | 포트 | 노출 |
+|---|---|---|---|
+| `gateway` | `gateway run` | 8642 (OpenAI 호환 API) | ClusterIP 내부 전용 |
+| `dashboard` | `dashboard --host 0.0.0.0 --port 9119 --no-open` | 9119 | Ingress (Authentik) |
+
+Telegram은 **롱폴링 아웃바운드** → ingress 불필요. `terminal.backend: local` → 에이전트 셸이
+파드 내부에서 실행 (파드 = 샌드박스, kubeconfig 미주입).
+
+## 인증 / 시크릿
+
+- **Claude Max OAuth**: `hermes model` → Anthropic → OAuth는 `claude setup-token`을 돌려
+  장수명 토큰 `sk-ant-oat01-...`(~1년)을 발급, `.env`의 `ANTHROPIC_TOKEN`에 저장. 파드에는
+  이 값을 **env var `ANTHROPIC_TOKEN`으로 주입** (`config.yaml` provider: anthropic + 이 토큰 +
+  `ANTHROPIC_API_KEY` 미설정 → 구독 OAuth, 종량제 아님). 정적 장수명이라 refresh-rotation 무관.
+- **seed-if-absent**: `seed` initContainer는 첫 부팅에만 `config.yaml`을 `/opt/data`로 복사.
+  재시작 시 존재하면 건너뜀 → Hermes가 마이그레이션한 라이브 config를 stale seed가 덮지 않음.
+  (크레덴셜은 파일 seed 아님 — env var.)
+- **SealedSecret `hermes-secrets`** (ns hermes): `HERMES_ADMIN_USERNAME`, `HERMES_ADMIN_PASSWORD`,
+  `ANTHROPIC_TOKEN`. (`TELEGRAM_BOT_TOKEN`은 후속 PR — env `optional: true`로 배선됨.)
+
+> ℹ️ setup-token은 정적 장수명(~1년)이라 rotation 충돌 없음. 만료 시 `hermes model` 재발급 →
+> `ANTHROPIC_TOKEN` 재봉인. 기존 `~/.claude/.credentials.json`(Claude Code 세션 토큰)은
+> **재사용 금지** — scope·rotation 충돌 + 무관 MCP 토큰 다수 포함.
+
+---
+
+## Phase B — 데스크톱에서 크레덴셜 생산 (사람 작업)
+
+헤드리스 파드는 브라우저 OAuth 불가. 데스크톱(또는 WSL `docker run`)에서 토큰을 받아 주입.
+
+### Claude Max 토큰 (격리 컨테이너 — 호스트 `~/.claude` 안 건드림)
+```bash
+mkdir -p ~/hermes-data
+docker run --rm -it -v ~/hermes-data:/opt/data \
+  -e HERMES_UID=$(id -u) -e HERMES_GID=$(id -g) \
+  nousresearch/hermes-agent:v2026.6.5 model
+# → 1. Claude Pro/Max subscription (OAuth login) 선택
+#    실제로는 `claude setup-token`을 돌려 sk-ant-oat 토큰 붙여넣기 흐름.
+# 결과: ~/hermes-data/.env 의 ANTHROPIC_TOKEN (장수명 oat, ~1년)
+```
+
+### 산출물 (Phase A 입력)
+- `~/hermes-data/.env` 의 `ANTHROPIC_TOKEN` (sk-ant-oat, 구독 OAuth — 종량제 아님)
+- admin user/pass (직접 정하거나 생성 위임)
+- (후속) Telegram 봇 토큰 — [reference_telegram_bot_reuse]는 유출 이력 있으니 revoke 후 신규
+
+---
+
+## Phase A — 봉인 + 배포
+
+cert는 `k8s/sealed-secrets/cert.pem`에 커밋되어 있어 VPN/클러스터 접근 없이 sealing 가능.
+
+**코어 3키 봉인 완료** (채워짐): `HERMES_ADMIN_USERNAME`, `HERMES_ADMIN_PASSWORD`, `ANTHROPIC_TOKEN`.
+→ PR 머지하면 ArgoCD가 `apps/hermes.yaml` 자동 sync (Telegram 없이도 파드 Running).
+
+Telegram 추가(후속 PR):
+```bash
+seal() { KUBECONFIG=~/.kube/config-json kubeseal --raw --cert k8s/sealed-secrets/cert.pem \
+  --name hermes-secrets --namespace hermes --scope strict; }
+echo -n "$TELEGRAM_BOT_TOKEN" | seal   # → sealed-secret.yaml encryptedData.TELEGRAM_BOT_TOKEN 추가
+kubectl -n hermes rollout restart deploy/hermes   # optional env가 키를 집음
+```
+
+## 검증 (post-merge, hard-refresh 먼저)
+
+```bash
+kubectl -n argocd patch app hermes --type=merge \
+  -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
+argocd app wait hermes --sync --health --timeout=600
+# SealedSecret 복호화 확인 (empty 함정):
+kubectl -n hermes get secret hermes-secrets -o json | jq '.data | map_values(@base64d | length)'
+kubectl -n hermes logs deploy/hermes -c gateway | grep -i "anthropic\|telegram\|provider"
+```
+- Claude Max로 추론 동작 (종량제 API 키 미사용)
+- `hermes.json-server.win` → Authentik 통과 후 대시보드 (admin: hermes / 봉인된 pass)
+- (후속) Telegram 봇 ↔ 파드 대화 왕복
+
+## 운영 메모
+
+- 모델 변경: 대시보드 또는 파드 내 `hermes config set model.default <id>`. `config.yaml`(ConfigMap)은
+  seed 전용 — 라이브 파일을 덮지 않음.
+- 이미지 핀: 제3자 공개 이미지 → 수동 태그 업데이트 ([manifests/deployment.yaml](manifests/deployment.yaml)
+  의 `v2026.6.5`). Image Updater 미사용.
+- 백업: `/opt/data` = 기억/스킬/세션/인증 전부. PVC 유실 시 seed에서 재구성하되 OAuth는 재로그인 필요.

--- a/k8s/hermes/manifests/config.yaml
+++ b/k8s/hermes/manifests/config.yaml
@@ -1,0 +1,17 @@
+# Hermes Agent seed config — copied to /opt/data/config.yaml by the seed
+# initContainer ONLY if that file does not already exist. After first boot
+# Hermes owns the live file on the PVC; edits here do NOT overwrite it.
+# To change live settings, use the dashboard or `hermes config` in the pod.
+model:
+  # Claude Max via OAuth (provider: anthropic + ~/.claude/.credentials.json,
+  # NO ANTHROPIC_API_KEY env → uses subscription OAuth, not metered API).
+  provider: anthropic
+  default: claude-sonnet-4-6
+terminal:
+  # local = agent shell runs INSIDE this pod (the pod is the sandbox).
+  # docker backend would need docker-in-docker → avoided in K8s.
+  backend: local
+  timeout: 180
+memory:
+  memory_enabled: true
+  user_profile_enabled: true

--- a/k8s/hermes/manifests/deployment.yaml
+++ b/k8s/hermes/manifests/deployment.yaml
@@ -1,0 +1,176 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes
+  namespace: hermes
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+spec:
+  replicas: 1
+  # RWO PVC shared by both containers → single node, no rolling.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hermes
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hermes
+        app.kubernetes.io/part-of: hermes
+    spec:
+      # Hermes user is uid/gid 10000; fsGroup makes the PVC group-writable.
+      securityContext:
+        fsGroup: 10000
+
+      initContainers:
+        # Seed-if-absent: copy the default config onto the PVC ONLY on first
+        # boot. On restart it already exists → skipped, so Hermes' migrated
+        # live config (schema bumps, curator defaults) is never clobbered.
+        # The Claude credential is NOT seeded as a file — it is injected as the
+        # ANTHROPIC_TOKEN env var below (sk-ant-oat subscription token).
+        - name: seed
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              if [ ! -f /opt/data/config.yaml ]; then
+                echo "seeding config.yaml (first boot)"
+                cp /seed-config/config.yaml /opt/data/config.yaml
+                chown 10000:10000 /opt/data/config.yaml
+              else
+                echo "config.yaml present — skip (preserve live config)"
+              fi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+            - name: seed-config
+              mountPath: /seed-config
+              readOnly: true
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+
+      containers:
+        # Messaging gateway (Telegram long-poll, outbound) + OpenAI-compat API :8642
+        - name: gateway
+          image: nousresearch/hermes-agent:v2026.6.5
+          args: ["gateway", "run"]
+          env:
+            - name: HERMES_UID
+              value: "10000"
+            - name: HERMES_GID
+              value: "10000"
+            # Claude subscription OAuth token (sk-ant-oat) — NOT a metered key.
+            # ANTHROPIC_API_KEY is intentionally left unset.
+            - name: ANTHROPIC_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-secrets
+                  key: ANTHROPIC_TOKEN
+            # Telegram deferred to a follow-up PR (needs a revoked/fresh bot
+            # token). optional=true → gateway runs without it now; adding the
+            # sealed TELEGRAM_BOT_TOKEN key later + restart enables the gateway.
+            - name: TELEGRAM_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-secrets
+                  key: TELEGRAM_BOT_TOKEN
+                  optional: true
+            - name: HERMES_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-secrets
+                  key: HERMES_ADMIN_USERNAME
+            - name: HERMES_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-secrets
+                  key: HERMES_ADMIN_PASSWORD
+          ports:
+            - containerPort: 8642
+              name: api
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+          livenessProbe:
+            tcpSocket:
+              port: api
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: api
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 2Gi
+
+        # Admin dashboard :9119 (gated by Authentik forward-auth at the Ingress)
+        - name: dashboard
+          image: nousresearch/hermes-agent:v2026.6.5
+          args: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open"]
+          env:
+            - name: HERMES_UID
+              value: "10000"
+            - name: HERMES_GID
+              value: "10000"
+            - name: ANTHROPIC_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-secrets
+                  key: ANTHROPIC_TOKEN
+            - name: HERMES_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-secrets
+                  key: HERMES_ADMIN_USERNAME
+            - name: HERMES_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-secrets
+                  key: HERMES_ADMIN_PASSWORD
+          ports:
+            - containerPort: 9119
+              name: dashboard
+          livenessProbe:
+            tcpSocket:
+              port: dashboard
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: dashboard
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 512Mi
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hermes-data
+        - name: seed-config
+          configMap:
+            name: hermes-config

--- a/k8s/hermes/manifests/ingress.yaml
+++ b/k8s/hermes/manifests/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hermes
+  namespace: hermes
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns01
+    traefik.ingress.kubernetes.io/redirect-entry-point: https
+    # Authentik SSO/MFA in front of Hermes' own admin login (defense-in-depth).
+    traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: hermes.json-server.win
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hermes
+                port:
+                  number: 9119
+  tls:
+    - secretName: hermes-tls
+      hosts:
+        - hermes.json-server.win

--- a/k8s/hermes/manifests/kustomization.yaml
+++ b/k8s/hermes/manifests/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - sealed-secret.yaml
+
+configMapGenerator:
+  - name: hermes-config
+    files:
+      - config.yaml
+
+generatorOptions:
+  # Stable name so deployment can reference `hermes-config`.
+  # Change config.yaml → manual rollout restart required.
+  disableNameSuffixHash: true

--- a/k8s/hermes/manifests/pvc.yaml
+++ b/k8s/hermes/manifests/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-data
+  namespace: hermes
+  labels:
+    app.kubernetes.io/part-of: hermes
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-ssd
+  resources:
+    requests:
+      storage: 5Gi

--- a/k8s/hermes/manifests/sealed-secret.yaml
+++ b/k8s/hermes/manifests/sealed-secret.yaml
@@ -1,0 +1,48 @@
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │  PLACEHOLDER — NOT YET SEALED. Do not merge/deploy until filled.           │
+# │  encryptedData below is invalid; sealed-secrets controller will reject it  │
+# │  until replaced with real values produced in Phase B (see ../README.md).   │
+# └─────────────────────────────────────────────────────────────────────────┘
+#
+# Seal each value with kubeseal --raw (strict scope, ns=hermes, name=hermes-secrets).
+# cert is committed at k8s/sealed-secrets/cert.pem → no VPN/cluster access needed.
+#
+#   ADMIN_USER=hermes
+#   echo -n "$ADMIN_USER"   | KUBECONFIG=~/.kube/config-json kubeseal --raw \
+#     --cert k8s/sealed-secrets/cert.pem \
+#     --name hermes-secrets --namespace hermes --scope strict
+#   # → paste output under encryptedData.HERMES_ADMIN_USERNAME
+#
+#   read -rs ADMIN_PASS; echo -n "$ADMIN_PASS" | KUBECONFIG=~/.kube/config-json kubeseal --raw \
+#     --cert k8s/sealed-secrets/cert.pem \
+#     --name hermes-secrets --namespace hermes --scope strict
+#   # → encryptedData.HERMES_ADMIN_PASSWORD
+#
+#   echo -n "$TELEGRAM_BOT_TOKEN" | KUBECONFIG=~/.kube/config-json kubeseal --raw \
+#     --cert k8s/sealed-secrets/cert.pem \
+#     --name hermes-secrets --namespace hermes --scope strict
+#   # → encryptedData.TELEGRAM_BOT_TOKEN
+#
+#   # Claude subscription OAuth token (sk-ant-oat..., from `hermes model` →
+#   # Anthropic → OAuth setup-token). Injected as the ANTHROPIC_TOKEN env var,
+#   # NOT a file. Long-lived (~1yr), so no refresh-rotation concern.
+#   echo -n "$ANTHROPIC_TOKEN" | KUBECONFIG=~/.kube/config-json kubeseal --raw \
+#     --cert k8s/sealed-secrets/cert.pem \
+#     --name hermes-secrets --namespace hermes --scope strict
+#   # → encryptedData.ANTHROPIC_TOKEN   (already filled)
+#
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: hermes-secrets
+  namespace: hermes
+spec:
+  encryptedData:
+    HERMES_ADMIN_USERNAME: AgDNWLGKOF09T10pbPeu05NtUw4vccgvnHyKaYcXvaXKPMMAGlrRmHDJi8c9YQzptsISEceqZbU9FnH9mcDp2OwQob5pRfDh6mProH+BvYo0EPFnAvleF3ZFByCOoHviQMxE1Kmu+GilaNI6n6dQZzOQ+VfTS9CHznoq66aTnV/0cD3dOGkWT9dEOoVAFDmsbpK34zFzGF3DxE6wII63PfZQ9WbJ/ECz06HUpV+MAq/cp/t62LyglkI7eoWR0cVD1GE6Z3DzZgL490VrnZe0/98St/8hmBaEiXq21AUGGMGyrSdZ1bUImc2f3cbT75qd5+AmXpCJIQI+khdcNSRUOSFiS+QmmVRtVx6t4TLPtHJRGgRtArTDSeZf/xxoh6xR9BCpcw+NR+5JiA43qoJJHWYBA8z6pigGPy1n1ktdgMBGbsYGdMg0jus8MyTV3k+H7VqQ0PWCw55MMUvxqMD7jvL0CvaC3yIkZo+0er+oi0FIvqsPUU+JUreTq1Ae13x7OatKZD+12e/j/LdjyNrh/pcFcSHbC+YF43h4eFjDK79TQxY4+bEzjVChomePfEltOyKuEA2O8awxrA0uNoTNBfTXyC12uzLVOFriYrZj8Fs+XMqI6bS9YoUGm0NiqtwQ6ygNaANRzdA6KK7mfI0rSuGczxLm8jvFGe2n587AkKNvPKZjGqtKGuGlJxYuGlF6uLQVQVDTBp0=
+    HERMES_ADMIN_PASSWORD: AgAiRKEHQNOwavozLTUq09deuEsCkoWJO1GBIjBgsYMkidn1vvMREiwAyv0RR2OzYAU0LqcOscG6f8nbdAFAWNcDeaMDgvu7VDwp7x/4K0+FSRcLb7qj/VeuwTCDEtZM/KH/RvJuTyNFRXlp+Cc4LnnDFXhtrbQoHY6pM8meEnbsv1QC5m/NcBl9CXIEbT8panRgkm/3YFRNdIqsLY9TGkEgaCNsDuon8LtuLf3Rw3RGjDO9gwLVsy/WrzdT4SrAmo4eJLZbM4ApoObA2aTALs1doUwipQppuIU0cFEslX/Bi98QOvUMODjnYjUVkuijxIE3kiRPoDEMpoj+/Fa+4hpFcz1zEhUGFbpBE/iCCz7XxdBcTvXsd8JXc3+AtYHKG7uxuiFkIkUiGZshkC8nWJ16mkWyloAKAz4A28PMGI0y89yVstNzmf5Kkpax/dIRUbBoouWvGlf5yiEn2sJ20fraKFfsbqccLuxmyPvNvllodm+J7g+il9ZlbyFJClRjmz+gcacKswhX7wHYEHe0RhVHrtxJ8z+ze5caq++1woBPR+WwwfLMA7QE/gUpzP8ReKDJ1vm5EFm9ErapVw7nN1w7J3evoGAMIcKz84xdYQa1+fznp9LUwGmj4j5nTZ/uRwtn2lqxAePpcb+tWxceIvCAlH8OJtHkku2LEUwb2IJ/uV7qq8dcFttNpF/nO2h16rJ1+ctCWnEiULHNRhRRB+H1N2FsiAYMOpdr08rBskhEDw==
+    ANTHROPIC_TOKEN: AgCoLi1tHQNlPW16VLu+wMcMwxB2KauEBPO4Gju0NoFvf7vpfZzZvrZuwnxDBjqOVRlW5cwXGrP+ylIzg2mqJ0FjgqGPg4VE5UiBAV+HVonZ1a0AIsjuJ1MhYjMlX4vViNZ73PTdnY3tFnJN+Q+VG+PETjBVEAAreSPCm1YhrCLnwKVaPguSi+tEQCku0laUc1OVlmX7+eDM62IuuDJl0IfA2TK7exIqGGaW/2b4N3zh/duRbjDfKjXeSDyTuqwxHimqaxC4/9BbOEHKxMTl6jzcYmqXd5iORDPu2VyA7G2aiLq4MekO1QmfZJ12fgLXe5lSe3jp6RuQaNVg94AeX41E3wND/8IxbH3JsFVW36EYY/ieS9YnPS6FJ9rPDstSYfl0PR5zMBSIw9Y39i9xK8Ne6Wm/4jrKqDMYt2/JtT/YFD4kpRLD7kfMPpr4Wwj9Tzrne4t34oCBwAwNVJW5oY+9oxAOsbqhQthXAwac9498NUTNEEOan9yoXKu4BvKf0A+LWc5+NVYw1NcEkyfxCiiDrm5sPqVUZJ6x/5eEOD+IaIcvZ3aaVGI2cbxYovZC5bkIa8PZfbxZUmKCxE8f1OKjD+oIvTdMY7e2uz1qJIY+5CQ6PhXgwNqU1it8zUW7iZh7KImR4PGg914mYrJZWVW3/ztKPfLbPSmIoz2o3wN5JiH9UbW7bOpuCZnqfeEBptY9Ifg8JyPQcBGdznWm9sUObSS4vBpvvN/OeYvsaUAQhCVfJnHuCTAdIR7UMHRwdUNxJLKuDnNfyFOdQPRX1UNaIXRz0aNrg7ns3kpvHID87Ck1Y8t7wNBJjshWF832WsctDAcCOZiS
+  template:
+    metadata:
+      name: hermes-secrets
+      namespace: hermes
+    type: Opaque

--- a/k8s/hermes/manifests/service.yaml
+++ b/k8s/hermes/manifests/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes
+  namespace: hermes
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+spec:
+  selector:
+    app.kubernetes.io/name: hermes
+  ports:
+    # Admin dashboard — exposed via Ingress behind Authentik forward-auth.
+    - name: dashboard
+      port: 9119
+      targetPort: dashboard
+    # OpenAI-compat gateway API — ClusterIP-internal only (no Ingress).
+    - name: api
+      port: 8642
+      targetPort: api


### PR DESCRIPTION
## 무엇
[Hermes Agent](https://github.com/NousResearch/hermes-agent) (Nous Research, MIT) 개인 상시 비서를 homelab K3s에 선언적 배포. 영구기억 + 40+ 툴 + MCP. **Claude Max 구독 OAuth**로 추론 (종량제 API 미사용).

## 구조
- 파드 1개 / 컨테이너 2개(`gateway` + `dashboard`)가 PVC `/opt/data` 공유. RWO → `strategy: Recreate`, `fsGroup: 10000`.
- 이미지 `nousresearch/hermes-agent:v2026.6.5` (Docker Hub multiarch). 공개 이미지 태그 핀 → Image Updater 미사용.
- 영구기억: PVC `hermes-data` (`longhorn-ssd` 5Gi).
- `gateway` API :8642 = ClusterIP 내부 전용. `dashboard` :9119만 Ingress 노출.

## 인증 / 시크릿
- **Claude Max**: `hermes model` → Anthropic OAuth = `claude setup-token`(sk-ant-oat, 장수명 ~1년) → env `ANTHROPIC_TOKEN` 주입. `ANTHROPIC_API_KEY` 미설정 → 구독 경로. 정적 장수명이라 refresh-rotation 무관.
- **대시보드**: `hermes.json-server.win` — Authentik forward-auth(SSO/MFA) + Hermes 자체 admin 로그인 이중.
- **SealedSecret `hermes-secrets`**: `HERMES_ADMIN_USERNAME`, `HERMES_ADMIN_PASSWORD`, `ANTHROPIC_TOKEN`. 평문 시크릿 0 (gitleaks 클린).
- `seed` init: `config.yaml` seed-if-absent (Hermes 마이그레이션 라이브 config 미덮음). 크레덴셜은 파일 아닌 env.

## 범위
- ✅ 코어: Claude Max 추론 + Authentik 게이트 대시보드 + 영구 PVC
- ⏳ **Telegram = 후속 PR** — env `optional: true`로 배선. 기존 Jarvis 봇 토큰은 openclaw-state 히스토리에 평문 유출 이력 → **revoke 후 신규 토큰**으로 추가 예정.

## 배포 후 (머지 → 사용자)
1. DNS: `cd cloudflare && terraform apply` (hermes A 레코드 — 외부 접근용)
2. ArgoCD 자동 sync. 검증은 hard-refresh 먼저 → `argocd app wait hermes --sync --health`.

상세: [k8s/hermes/README.md](k8s/hermes/README.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)