### PR TITLE
feat(minio-operator): lease-staleness watchdog로 leader wedge 자동 복구

### DIFF
--- a/k8s/argocd/applications/infra/minio-operator-watchdog.yaml
+++ b/k8s/argocd/applications/infra/minio-operator-watchdog.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: minio-operator-watchdog
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/manamana32321/homelab
+    targetRevision: main
+    path: k8s/minio-operator-watchdog
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: minio-operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/minio-operator-watchdog/cronjob.yaml
+++ b/k8s/minio-operator-watchdog/cronjob.yaml
@@ -1,0 +1,82 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: minio-operator-watchdog
+  namespace: minio-operator
+  labels:
+    app.kubernetes.io/name: minio-operator-watchdog
+    app.kubernetes.io/part-of: minio-operator
+spec:
+  # 알림 임계(MinIOOperatorLeaseStale, 5m)와 정렬. 감지 후 다음 tick에 복구.
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 120
+      ttlSecondsAfterFinished: 600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: minio-operator-watchdog
+        spec:
+          serviceAccountName: minio-operator-watchdog
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: watchdog
+              image: alpine/k8s:1.34.5
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+
+                  LEASE=minio-operator-lock
+                  DEPLOY=minio-operator
+                  NS=minio-operator
+                  THRESHOLD=300  # 초. 알림 임계와 동일
+
+                  renew=$(kubectl -n "$NS" get lease "$LEASE" \
+                    -o jsonpath='{.spec.renewTime}')
+                  if [ -z "$renew" ]; then
+                    echo "lease $LEASE renewTime 비어있음 — 스킵"
+                    exit 0
+                  fi
+
+                  # 2026-07-10T02:10:43.708810Z → 2026-07-10 02:10:43
+                  # (소수초·T·Z 제거 → busybox/GNU date 양쪽 파싱 안전)
+                  clean=$(echo "$renew" | sed 's/\.[0-9]*Z$//; s/Z$//; s/T/ /')
+                  renew_epoch=$(date -u -d "$clean" +%s)
+                  now_epoch=$(date -u +%s)
+                  age=$(( now_epoch - renew_epoch ))
+                  echo "lease age: ${age}s (threshold ${THRESHOLD}s)"
+
+                  if [ "$age" -le "$THRESHOLD" ]; then
+                    echo "fresh — 조치 없음"
+                    exit 0
+                  fi
+
+                  echo "STALE — operator leader wedge 추정, rollout restart 실행"
+                  kubectl -n "$NS" rollout restart "deployment/$DEPLOY"
+                  echo "restart 트리거 완료"

--- a/k8s/minio-operator-watchdog/rbac.yaml
+++ b/k8s/minio-operator-watchdog/rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: minio-operator-watchdog
+  namespace: minio-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: minio-operator-watchdog
+  namespace: minio-operator
+rules:
+  # lease renewTime 나이 측정
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get"]
+    resourceNames: ["minio-operator-lock"]
+  # stale 감지 시 rollout restart (spec.template annotation patch)
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "patch"]
+    resourceNames: ["minio-operator"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: minio-operator-watchdog
+  namespace: minio-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: minio-operator-watchdog
+subjects:
+  - kind: ServiceAccount
+    name: minio-operator-watchdog
+    namespace: minio-operator


### PR DESCRIPTION
## 문제

minio-operator가 [j1 thrash 인시던트](https://github.com/manamana32321/homelab)(2026-07-10, apiserver 자살) 이후 leader 잠금(lease `minio-operator-lock`)을 **3.5일째 갱신하지 못하고** 있습니다. `MinIOOperatorLeaseStale` 알림이 계속 울리는 상태입니다.

다만 실제 저장소(tenant) 3개는 전부 **정상(green)** — 데이터는 멀쩡하고, "설정 반영 담당자"만 멈춘 상태입니다.

## 왜 멈췄나

인터넷(공유기)이 끊겼을 때처럼 클러스터 두뇌(apiserver)가 잠깐 죽자, operator 두 개가 **동시에** 리더 자리를 놓쳤고, 그 뒤 스스로 다시 리더를 못 잡고 얼어붙었습니다(알려진 버그).

기존 대비책은 "operator 하나가 죽으면 다른 하나가 이어받기"였는데, 이번엔 **둘 다 동시에** 죽어서 소용이 없었습니다.

## 왜 간단한 헬스체크로 못 고치나

operator 프로그램 자체가 "나 살아있어요" 신호를 밖으로 내주지 않습니다(공식 확인). 그래서 쿠버네티스 표준 헬스체크(livenessProbe)를 붙일 수가 없습니다.

## 이 PR이 하는 일 — 자동 감시원

5분마다 도는 작은 감시 작업을 추가합니다:

1. operator의 리더 잠금이 마지막으로 갱신된 시각을 확인
2. 5분 넘게 방치됐으면 → operator를 자동으로 재시작
3. 새 operator가 리더 자리를 다시 잡음 → 알림 해소

배포되는 즉시 지금 얼어붙은 상태도 스스로 풀립니다. 앞으로 어떤 이유로 얼어붙든 같은 방식으로 자동 복구됩니다.

## 구성

| 파일 | 내용 |
|---|---|
| `k8s/minio-operator-watchdog/cronjob.yaml` | 5분 주기 감시 CronJob |
| `k8s/minio-operator-watchdog/rbac.yaml` | 최소 권한 (잠금 읽기 + operator 재시작만) |
| `k8s/argocd/applications/infra/minio-operator-watchdog.yaml` | ArgoCD Application |

- 이미지 `alpine/k8s:1.34.5` (클러스터 버전 일치, amd64+arm64)
- 보안: 비루트(1000), 읽기전용 파일시스템, 모든 권한 drop, seccomp RuntimeDefault
- 권한은 `resourceNames`로 `minio-operator-lock` 잠금과 `minio-operator` 배포에만 한정

## 검증

- 세 매니페스트 server-side dry-run 통과
- 날짜/임계 판정 로직 실측: 현재 stale lease(3.6일) → 재시작 트리거 / 30초 전 → 무동작 / 301초 → 재시작 (경계 정확)

🤖 Generated with [Claude Code](https://claude.com/claude-code)