### PR TITLE
feat(actions-runner): CI 러너 동시성 3→6 — 유휴 워크로드 정지 + control-plane 개방

### DIFF
--- a/k8s/actions-runner/runner-values.yaml
+++ b/k8s/actions-runner/runner-values.yaml
@@ -17,18 +17,19 @@ controllerServiceAccount:
 containerMode:
   type: "dind"
 
-# scale-from-zero. maxRunners 는 유일 amd64 워커(json-server-2, 16Gi)의 여유에 맞춤 —
-# CI 7개 잡은 2~3 웨이브로 직렬화. 노드 증설 시 상향.
+# scale-from-zero. maxRunners 는 amd64 노드 2대(json-server-1/2, 각 16Gi)의 실메모리
+# 여유 기준 — minecraft 정지 + loki chunks-cache 비활성으로 확보 (#261).
+# CI 7개 잡이 1~2 웨이브로 돎.
 minRunners: 0
-maxRunners: 3
+maxRunners: 6
 
 template:
   spec:
-    # 무거운 잡이 아니어도 control-plane(json-server-1, taint 없음) 회피는 유지
-    # — 2026-06-21 인시던트 재발방지 안전망.
+    # 2026-07-21 control-plane(json-server-1) 개방 (#261) — 동시성 확대.
+    # 2026-06-21 인시던트 안전망(worker-only, #252)은 러너별 limit(2CPU/4Gi)이 대체.
+    # arm64(raspi-1)는 계속 제외.
     nodeSelector:
       kubernetes.io/arch: amd64
-      node-role.kubernetes.io/worker: "true"
     containers:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest

--- a/k8s/minecraft/values.yaml
+++ b/k8s/minecraft/values.yaml
@@ -1,4 +1,6 @@
-replicaCount: 1
+# 2026-07-21 일시정지 — 최근 접속 없어 json-server-2 메모리를 CI 러너에 양보 (#261).
+# 월드는 longhorn PVC 에 보존. 재개 시 1 로 복원.
+replicaCount: 0
 
 image:
   repository: itzg/minecraft-server

--- a/k8s/observability/loki/values.yaml
+++ b/k8s/observability/loki/values.yaml
@@ -42,14 +42,10 @@ loki:
             # these keys will be indexed
             ['service.name', 'service.version', 'service.environment']}}
 
+# 2026-07-21 비활성 — 조회 빈도 낮아 memcached 2Gi 를 CI 러너에 양보 (#261).
+# 비활성 시 청크는 S3(minio) 직조회 — 쿼리 지연만 늘고 데이터 영향 없음.
 chunksCache:
-  allocatedMemory: 2048
-  resources:
-    requests:
-      cpu: 100m
-      memory: 2Gi
-    limits:
-      memory: 2Gi
+  enabled: false
 
 resultsCache:
   allocatedMemory: 256


### PR DESCRIPTION
## Summary

bconnect CI self-hosted 러너(#260)의 동시 잡 개수를 3→6으로 늘립니다. 노드 여유 확보를 위해 유휴 워크로드 2개를 내리고 control-plane 노드를 러너에 개방합니다.

## Changes

- **minecraft** `replicaCount: 1 → 0` — 최근 접속 없음 (CPU 26m 실측). json-server-2에서 requests 3.5Gi / 실사용 3.2Gi 회수. 월드는 longhorn PVC 보존, 재개 시 1로 복원
- **loki** `chunksCache.enabled: false` — 조회 빈도 낮음. memcached 2Gi 회수. 청크는 S3(minio) 직조회로 동작, 쿼리 지연만 증가
- **actions-runner** `maxRunners: 3 → 6` + `node-role.kubernetes.io/worker` nodeSelector 제거 — json-server-1(8C/16Gi, 메모리 requests 32%) 개방. 2026-06-21 인시던트 안전망(#252)은 러너별 limit(2CPU/4Gi)이 대체. arm64(raspi-1)는 `kubernetes.io/arch: amd64`로 계속 제외

## Test

- [ ] ArgoCD 3개 앱(minecraft/loki/actions-runner-morton) hard-refresh 후 Synced + Healthy
- [ ] minecraft·loki-chunks-cache pod 제거 확인 (prune)
- [ ] AutoscalingRunnerSet maxRunners=6 반영 확인

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)