### PR TITLE
chore(hermes): replicas 0 — provider 크레덴셜 확보까지 파킹

### DIFF
--- a/k8s/hermes/manifests/deployment.yaml
+++ b/k8s/hermes/manifests/deployment.yaml
@@ -7,7 +7,11 @@ metadata:
     app.kubernetes.io/name: hermes
     app.kubernetes.io/part-of: hermes
 spec:
-  replicas: 1
+  # PARKED at 0: Claude Max OAuth needs *purchased* extra-usage credits (base Max
+  # allowance is not usable by third-party apps), so inference is blocked. Infra
+  # is complete and verified — flip to 1 once a working provider credential is
+  # seeded (Gemini free tier = only $0 path; Codex = ChatGPT-sub included).
+  replicas: 0
   # RWO PVC shared by both containers → single node, no rolling.
   strategy:
     type: Recreate


### PR DESCRIPTION
Claude Max OAuth가 구매한 extra-usage 크레딧만 소모(base Max 할당은 제3자 앱에 미개방) → 추론 차단. 인프라는 완성·검증 완료라 매니페스트/PVC/SealedSecret 보존하고 `replicas: 0`으로만 내림 (~640Mi 회수).

재개 = 크레덴셜 시드 후 replicas 1. Gemini 무료티어가 유일한 $0 경로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)