### PR TITLE
fix(cluster): 2026-07-22 알림 7건 정리 — 좀비 operator 자동 회수 + 부하 트리거 제거

### DIFF
--- a/k8s/actions-runner/runner-values.yaml
+++ b/k8s/actions-runner/runner-values.yaml
@@ -25,11 +25,29 @@ maxRunners: 6
 
 template:
   spec:
-    # 2026-07-21 control-plane(json-server-1) 개방 (#261) — 동시성 확대.
-    # 2026-06-21 인시던트 안전망(worker-only, #252)은 러너별 limit(2CPU/4Gi)이 대체.
-    # arm64(raspi-1)는 계속 제외.
-    nodeSelector:
-      kubernetes.io/arch: amd64
+    # arm64(raspi-1)는 하드 제외. control-plane(json-server-1)은 #261 에서 개방했으나,
+    # 2026-07-22 인시던트에서 러너 6개가 전량 json-server-1 로 착륙 + 백업 크론 3개 동시
+    # 실행이 겹쳐 node_load1 112 까지 치솟아 apiserver 응답이 지연됐다. 그 여파로
+    # minio-operator 의 leader lease 갱신(15s deadline)이 두 replica 연속 실패.
+    # → worker(json-server-2) 를 선호하고 control-plane 은 오버플로우 전용으로 강등.
+    #   soft preference 라 #261 의 동시성 6 목표는 그대로 유지된다.
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/worker
+                  operator: In
+                  values:
+                    - "true"
     containers:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest

--- a/k8s/argocd/applications/apps/essentia.yaml
+++ b/k8s/argocd/applications/apps/essentia.yaml
@@ -3,17 +3,20 @@ kind: Application
 metadata:
   name: essentia
   namespace: argocd
-  annotations:
-    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/essentia-edu/api:latest, web=ghcr.io/essentia-edu/web:latest, telegram-relay=ghcr.io/manamana32321/essentia-telegram-relay:latest
-    argocd-image-updater.argoproj.io/api.update-strategy: digest
-    argocd-image-updater.argoproj.io/web.update-strategy: digest
-    argocd-image-updater.argoproj.io/telegram-relay.update-strategy: digest
-    argocd-image-updater.argoproj.io/api.force-update: "true"
-    argocd-image-updater.argoproj.io/web.force-update: "true"
-    argocd-image-updater.argoproj.io/telegram-relay.force-update: "true"
-    argocd-image-updater.argoproj.io/api.pull-secret: pullsecret:essentia/ghcr-essentia
-    argocd-image-updater.argoproj.io/web.pull-secret: pullsecret:essentia/ghcr-essentia
-    argocd-image-updater.argoproj.io/write-back-method: argocd
+  # 앱 전면 정지(k8s/essentia/kustomization.yaml)에 맞춰 Image Updater 해제.
+  # 남겨두면 ghcr-essentia 의 PAT 가 만료된 상태라 30분마다 tags/list 401 로
+  # ImageUpdaterImageErrors 가 계속 발화한다. 되살릴 때 PAT 재발급 →
+  # ghcr-pull-sealed-secret.yaml 재봉인 → 아래 annotation 복구 순서.
+  #   argocd-image-updater.argoproj.io/image-list: api=ghcr.io/essentia-edu/api:latest, web=ghcr.io/essentia-edu/web:latest, telegram-relay=ghcr.io/manamana32321/essentia-telegram-relay:latest
+  #   argocd-image-updater.argoproj.io/api.update-strategy: digest
+  #   argocd-image-updater.argoproj.io/web.update-strategy: digest
+  #   argocd-image-updater.argoproj.io/telegram-relay.update-strategy: digest
+  #   argocd-image-updater.argoproj.io/api.force-update: "true"
+  #   argocd-image-updater.argoproj.io/web.force-update: "true"
+  #   argocd-image-updater.argoproj.io/telegram-relay.force-update: "true"
+  #   argocd-image-updater.argoproj.io/api.pull-secret: pullsecret:essentia/ghcr-essentia
+  #   argocd-image-updater.argoproj.io/web.pull-secret: pullsecret:essentia/ghcr-essentia
+  #   argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/k8s/argocd/applications/apps/loop.yaml
+++ b/k8s/argocd/applications/apps/loop.yaml
@@ -3,15 +3,18 @@ kind: Application
 metadata:
   name: loop
   namespace: argocd
-  annotations:
-    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/manamana32321/loop-api:latest, web=ghcr.io/manamana32321/loop-web:latest
-    argocd-image-updater.argoproj.io/api.update-strategy: digest
-    argocd-image-updater.argoproj.io/api.force-update: "true"
-    argocd-image-updater.argoproj.io/api.pull-secret: pullsecret:loop/ghcr-pull
-    argocd-image-updater.argoproj.io/web.update-strategy: digest
-    argocd-image-updater.argoproj.io/web.force-update: "true"
-    argocd-image-updater.argoproj.io/web.pull-secret: pullsecret:loop/ghcr-pull
-    argocd-image-updater.argoproj.io/write-back-method: argocd
+  # 앱 전면 정지(k8s/loop/kustomization.yaml)에 맞춰 Image Updater 해제.
+  # 남겨두면 ghcr-pull 의 PAT 가 만료된 상태라 30분마다 tags/list 401 로
+  # ImageUpdaterImageErrors 가 계속 발화한다. 되살릴 때 PAT 재발급 →
+  # ghcr-pull-sealed-secret.yaml 재봉인 → 아래 annotation 복구 순서.
+  #   argocd-image-updater.argoproj.io/image-list: api=ghcr.io/manamana32321/loop-api:latest, web=ghcr.io/manamana32321/loop-web:latest
+  #   argocd-image-updater.argoproj.io/api.update-strategy: digest
+  #   argocd-image-updater.argoproj.io/api.force-update: "true"
+  #   argocd-image-updater.argoproj.io/api.pull-secret: pullsecret:loop/ghcr-pull
+  #   argocd-image-updater.argoproj.io/web.update-strategy: digest
+  #   argocd-image-updater.argoproj.io/web.force-update: "true"
+  #   argocd-image-updater.argoproj.io/web.pull-secret: pullsecret:loop/ghcr-pull
+  #   argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/k8s/argocd/applications/infra/minio-operator.yaml
+++ b/k8s/argocd/applications/infra/minio-operator.yaml
@@ -18,6 +18,9 @@ spec:
     - repoURL: https://github.com/manamana32321/homelab
       targetRevision: main
       ref: homelab
+    - repoURL: https://github.com/manamana32321/homelab
+      targetRevision: main
+      path: k8s/minio-operator/manifests
   destination:
     server: https://kubernetes.default.svc
     namespace: minio-operator

--- a/k8s/essentia/kustomization.yaml
+++ b/k8s/essentia/kustomization.yaml
@@ -1,5 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# 2026-07-22 전면 정지. 사용 빈도가 낮은데 GHCR PAT 만료(2026-07-18)로 Image
+# Updater 만 4일째 에러를 뿜고 있었다. 데이터는 PVC(essentia-postgres-data)와
+# MinIO Tenant 에 그대로 남는다 — 되살릴 때 아래 replicas 블록만 지우면 된다.
+# 주의: 매일 07:00 KST 텔레그램 다이제스트도 함께 멈춘다 (telegram-relay 앱 내부 스케줄러).
+replicas:
+  - name: essentia-api
+    count: 0
+  - name: essentia-web
+    count: 0
+  - name: essentia-telegram-relay
+    count: 0
+  - name: essentia-postgres
+    count: 0
+
 resources:
   - namespace.yaml
   - api/configmap.yaml

--- a/k8s/health-hub/manifests/backup-cronjob.yaml
+++ b/k8s/health-hub/manifests/backup-cronjob.yaml
@@ -7,7 +7,9 @@ metadata:
     app: health-hub
     job-type: db-backup
 spec:
-  schedule: "0 17 * * *"
+  # 02:20 KST. immich(02:00) / seafile(02:40) 과 20분 간격 — 동시 IO 폭주 회피
+  # (2026-07-22 인시던트: 3개 동시 실행 + CI 러너 쏠림 → node_load1 112).
+  schedule: "20 17 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/k8s/immich/manifests/db-backup-cronjob.yaml
+++ b/k8s/immich/manifests/db-backup-cronjob.yaml
@@ -6,6 +6,8 @@ metadata:
     app: immich
     job-type: db-backup
 spec:
+  # 02:00 KST. DB 백업 3종(health-hub/immich/seafile)이 같은 분에 몰리면 IO 폭주로
+  # apiserver 가 밀린다 (2026-07-22 인시던트). 20분 간격으로 분산.
   schedule: "0 17 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3

--- a/k8s/loop/kustomization.yaml
+++ b/k8s/loop/kustomization.yaml
@@ -1,5 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# 2026-07-22 전면 정지. 사용 빈도가 낮은데 GHCR PAT 만료(2026-07-18)로 Image
+# Updater 만 4일째 에러를 뿜고 있었다. 데이터는 PVC(loop-postgres-data)에 남는다 —
+# 되살릴 때 아래 replicas 블록만 지우면 된다.
+replicas:
+  - name: loop-api
+    count: 0
+  - name: loop-web
+    count: 0
+  - name: loop-postgres
+    count: 0
+
 resources:
   - namespace.yaml
   - ghcr-pull-sealed-secret.yaml

--- a/k8s/minio-operator/manifests/zombie-reaper.yaml
+++ b/k8s/minio-operator/manifests/zombie-reaper.yaml
@@ -1,0 +1,112 @@
+# minio-operator zombie reaper
+#
+# 왜 필요한가 — operator v7.1.1 의 leader election 은 lease 갱신에 실패하면
+# OnStoppedLeading 에서 컨트롤러(work queue + operator:4221 / sts:4223 웹서버)를
+# 내리고 election context 를 cancel 한 뒤, StartOperator 가 `<-stopCh` 에서 영구
+# 블록된다. os.Exit 도 재선출 진입도 없다. 즉 프로세스는 살아있고 kubelet 은
+# 1/1 Running 으로 보지만 실제로는 아무 일도 하지 않는다.
+# 2026-07-22 인시던트에서 replica 2개가 6분 간격으로 연속 전사 → lease
+# holderIdentity 가 "" 인 채 17시간 방치, 그 사이 Tenant 재조정 전면 중단.
+# 좀비는 CPU limit(1코어)에 붙어서 계속 돌기까지 해 다음 재발 확률을 스스로 올린다.
+#
+# 왜 probe 가 아닌가 — 차트 7.1.1 은 operator Deployment 에 probe 필드를 노출하지
+# 않는다 (values 스키마에 없음). helm 소스를 kustomize helmCharts inflator 로
+# 갈아끼우면 patch 가 가능하지만, 4000줄짜리 CRD 를 렌더 경로째 바꾸는 위험 대비
+# 이득이 적다. 좀비 시그니처가 lease 한 필드로 정확히 판별되므로 외부 감시로 처리.
+#
+# 판정 — holderIdentity 가 "" 면 좀비. client-go leaderelection 은 정상 반납 시
+# holderIdentity 를 비우고 leaseDurationSeconds 를 1 로 낮추므로, 살아있는
+# 후보가 하나라도 있으면 1~5초 안에 다시 채워진다. 오탐을 막으려 30초 간격으로
+# 두 번 확인하고 둘 다 비어있을 때만 파드를 지운다.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: minio-operator-reaper
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: minio-operator-reaper
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["minio-operator-lock"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: minio-operator-reaper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: minio-operator-reaper
+subjects:
+  - kind: ServiceAccount
+    name: minio-operator-reaper
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: minio-operator-reaper
+  labels:
+    app: minio-operator
+    job-type: watchdog
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  # 실패 Job 은 GC 전까지 KubeJobFailed 가 firing 상태로 남는다. 감시 job 이
+  # 알람 소스가 되면 본말전도이므로 히스토리를 짧게 유지.
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: minio-operator-reaper
+          containers:
+            - name: reaper
+              image: rancher/kubectl:v1.34.1
+              command:
+                - sh
+                - -c
+                - |
+                  set -eo pipefail
+                  LEASE="lease/minio-operator-lock"
+                  JP='{.spec.holderIdentity}'
+
+                  holder=$(kubectl get $LEASE -o jsonpath="$JP")
+                  if [ -n "$holder" ]; then
+                    echo "leader=$holder — healthy"
+                    exit 0
+                  fi
+
+                  echo "no leader; rechecking in 30s to rule out a failover window"
+                  sleep 30
+                  holder=$(kubectl get $LEASE -o jsonpath="$JP")
+                  if [ -n "$holder" ]; then
+                    echo "leader=$holder — recovered on its own"
+                    exit 0
+                  fi
+
+                  echo "no leader for 30s — operator is zombied, deleting pods"
+                  kubectl delete pod \
+                    -l app.kubernetes.io/name=operator,app.kubernetes.io/instance=minio-operator
+              securityContext:
+                runAsUser: 1000
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi

--- a/k8s/minio-operator/values.yaml
+++ b/k8s/minio-operator/values.yaml
@@ -1,8 +1,8 @@
 operator:
   # 2 replicas로 leader-election failover 확보.
-  # leader pod이 CPU throttling으로 lease 잃은 뒤 재캠페인 deadlock에 빠지는
-  # zombie 패턴 (PR: fix(minio-operator) 참조)이 재발해도 다른 replica가
-  # 60s 내 lease 인수 → tenant 운영 무중단.
+  # 단, replica 2개만으로는 부족하다 — 2026-07-22 인시던트에서 apiserver 지연이
+  # 6분간 이어지자 두 replica가 순차로 같은 zombie 상태에 빠져 lease holder가
+  # 아예 사라졌다. 최종 안전망은 manifests/zombie-reaper.yaml (좀비 판별 후 파드 삭제).
   replicaCount: 2
 
   # 차트 7.1.1 default antiaffinity는 `name=minio-operator` 라벨을 찾는데
@@ -29,10 +29,9 @@ operator:
       memory: 128Mi
       ephemeral-storage: 500Mi
     limits:
-      # CFS throttling이 lease renewal (15s window in 60s lease) timeout을 유발하면
-      # leader-lost callback 후 goroutine deadlock → zombie pod. RSS는 ~25Mi라
-      # CPU 여유만 있으면 trigger 빈도 크게 감소. v7.1.1 binary는 health endpoint를
-      # 노출하지 않아 livenessProbe로 zombie 자동 감지 불가 — replicas=2 failover +
-      # PrometheusRule `MinIOOperatorLeaseStale` 알림으로 대응.
+      # lease renewal은 60s lease 안에서 15s deadline을 갖는다. CPU throttling이든
+      # apiserver 지연이든 이 창을 넘기면 leader-lost callback 이후 goroutine이
+      # deadlock되어 zombie pod이 된다. RSS는 ~25Mi라 CPU 여유만 있으면 빈도가 준다.
+      # 감지/복구는 manifests/zombie-reaper.yaml, 알림은 `MinIOOperatorLeaseStale`.
       cpu: "1"
       memory: 256Mi

--- a/k8s/observability/blackbox-exporter/values.yaml
+++ b/k8s/observability/blackbox-exporter/values.yaml
@@ -124,9 +124,12 @@ serviceMonitor:
     - name: gbrain-mcp
       url: http://gbrain-mcp.gbrain.svc.cluster.local/healthz
       module: http_2xx_no_tls
-    - name: minecraft
-      url: minecraft.minecraft.svc.cluster.local:25565
-      module: tcp_connect
-    - name: minecraft-bluemap
-      url: http://minecraft-bluemap.minecraft.svc.cluster.local:8100
-      module: http_2xx_no_tls
+    # minecraft 는 #262 에서 replicaCount 0 으로 정지 (접속 없음, 월드는 PVC 보존).
+    # probe 를 남겨두면 EndpointDown critical 이 상시 발화하므로 함께 비활성화.
+    # 서버를 다시 켤 때 아래 두 항목 주석 해제.
+    # - name: minecraft
+    #   url: minecraft.minecraft.svc.cluster.local:25565
+    #   module: tcp_connect
+    # - name: minecraft-bluemap
+    #   url: http://minecraft-bluemap.minecraft.svc.cluster.local:8100
+    #   module: http_2xx_no_tls

--- a/k8s/seafile/manifests/db-backup-cronjob.yaml
+++ b/k8s/seafile/manifests/db-backup-cronjob.yaml
@@ -7,7 +7,9 @@ metadata:
     app: seafile
     job-type: db-backup
 spec:
-  schedule: "0 17 * * *"
+  # 02:40 KST. immich(02:00) / health-hub(02:20) 과 20분 간격 — 동시 IO 폭주 회피
+  # (2026-07-22 인시던트: 3개 동시 실행 + CI 러너 쏠림 → node_load1 112).
+  schedule: "40 17 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
## 무슨 일이 있었나

2026-07-22 02:00 KST 전후로 `json-server-1`(control-plane) 의 `node_load1` 이 **4.9 → 111.99** 로 치솟았다.

| UTC (KST) | load1 |
|---|---|
| 16:50 (01:50) | 4.93 |
| 17:00 (02:00) | 17.43 |
| 17:15 (02:15) | 25.68 |
| **17:20 (02:20)** | **111.99** |

겹친 두 가지:
- DB 백업 CronJob 3종(health-hub / immich / seafile)이 전부 `0 17 * * *`
- #262 로 러너 worker-only nodeSelector 가 풀리면서 **러너 6개 전량이 control-plane 착륙**

## minio-operator 가 왜 죽었나

apiserver 가 밀리자 leader lease 갱신(60s lease 안의 15s deadline)이 두 번 실패했다.

```
w6n8l  16:59:42  Failed to update lock optimistically: context deadline exceeded
       16:59:44  leader lost → Stopping the minio controller
vg6r5  16:59:44  successfully acquired lease        ← 인수
       17:05:03  동일하게 실패 → Stopping the minio controller
```

operator v7.1.1 은 `OnStoppedLeading` 에서 컨트롤러를 내리고 election context 를 cancel 한 뒤 `<-stopCh` 에 영구 블록된다. **`os.Exit` 도, 재선출 진입도 없다.** replica 2개가 6분 간격으로 같은 상태에 빠져 lease 가 이렇게 남았다:

```yaml
holderIdentity: ""              # 리더 없음
leaseDurationSeconds: 1         # client-go release() 흔적 = 정상 반납, 크래시 아님
renewTime: 2026-07-21T17:05:03Z # 17시간 멈춤
```

`kubectl` 로는 `1/1 Running` 이라 아무 문제가 없어 보인다. 실제로는:
- Tenant 재조정 17시간 전면 중단
- 두 파드 `/proc/net/tcp` 에 **LISTEN 소켓 0개** — `operator:4221` / `sts:4223` 사망. 그런데 `sts` Service endpoints 에는 그대로 등록돼 있었다 (probe 가 없어서)
- 좀비가 CPU limit(1코어)에 붙어 계속 회전 → 다음 재발 확률을 자기가 올림

## 변경

### 1. zombie reaper (신규)

`k8s/minio-operator/manifests/zombie-reaper.yaml` — 5분 주기 CronJob.

lease `holderIdentity` 가 비어있으면 좀비다. client-go 는 정상 반납 시 holder 를 비우고 `leaseDurationSeconds` 를 1 로 낮추므로 살아있는 후보가 하나라도 있으면 수 초 안에 다시 채워진다. 오탐 방지로 30초 간격 2회 확인 후에만 파드를 지운다.

<details>
<summary>왜 livenessProbe 가 아닌가</summary>

차트 7.1.1 은 operator Deployment 에 probe 필드를 노출하지 않는다 (values 스키마에 없음). helm 소스를 kustomize `helmCharts` inflator 로 교체하면 patch 가 가능하지만, 4000줄짜리 CRD 를 렌더 경로째 바꾸는 위험 대비 이득이 적다. 좀비 시그니처가 lease 한 필드로 정확히 판별되므로 외부 감시로 처리했다.
</details>

### 2. 부하 트리거 제거

- 백업 CronJob 3종 → **02:00 / 02:20 / 02:40 KST** 분산
- 러너 `nodeSelector` → `nodeAffinity`. arm64 제외는 하드 유지, worker(`json-server-2`) 는 **soft preference**. control-plane 은 오버플로우 전용으로 강등되고 #261 의 동시성 6 목표는 그대로.

### 3. 알림 노이즈 제거

| 알림 | 처리 |
|---|---|
| `EndpointDown` ×2 (minecraft, minecraft-bluemap) | probe 주석 처리. #262 에서 서버를 껐는데 probe 가 남아 critical 상시 발화 중이었다 |
| `ImageUpdaterImageErrors` ×2 (essentia, loop) | 두 앱 전면 정지 + Image Updater 해제 |

GHCR PAT 두 개 모두 만료를 실측 확인했다 (GitHub API **401**). 2026-07-18 04:42 부터 `tags/list: denied` 가 30분마다 반복되고 있었다.

되살리는 법: `kustomization.yaml` 의 `replicas` 블록 삭제 → PAT 재발급 → SealedSecret 재봉인 → Application 의 주석 처리된 annotation 복구. 데이터는 PVC 와 MinIO Tenant 에 그대로 남는다.

> ⚠️ essentia 의 **매일 07:00 KST 텔레그램 다이제스트도 함께 멈춘다** (telegram-relay 앱 내부 스케줄러).

## 별도 수행 (이 PR 밖)

Longhorn Trim Filesystem 을 prometheus 볼륨에 실행했다. 20Gi PVC 가 실제로 34.2G 를 점유하고 있었는데, Prometheus 의 15일 retention 순환 삭제가 sparse 파일에 반영되지 않아 누적된 유령 블록이었다.

```
prometheus 볼륨      34.2G → 18.6G
json-server-2 여유   14.7G (11.8%) → 36.1G (29.1%)   ← DiskPressure 해소
```

## 검증

- `kubectl kustomize k8s/essentia` / `k8s/loop` — 전 Deployment `replicas: 0` 렌더 확인
- reaper 매니페스트 4개 문서(SA/Role/RoleBinding/CronJob) 파싱 확인
- `rancher/kubectl:v1.34.1` amd64/arm64 멀티아치 확인
- 러너 affinity — `json-server-2` 만 `node-role.kubernetes.io/worker=true` (raspi-1 은 값이 `worker` 라 매칭 안 됨, arch 로도 이미 제외)

머지 후 `minio-operator` / `essentia` / `loop` / `actions-runner` / `blackbox-exporter` hard-refresh + sync 검증 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)