### PR TITLE
fix(loop): 파킹 중 migrate Job 제외 — Init 무한대기 파드 방지

### DIFF
--- a/k8s/loop/kustomization.yaml
+++ b/k8s/loop/kustomization.yaml
@@ -22,4 +22,8 @@ resources:
   - web/service.yaml
   - web/deployment.yaml
   - web/ingress.yaml
-  - migrate-job.yaml
+  # 앱 파킹 중에는 제외. PostSync hook 이라 sync 마다 재생성되는데,
+  # initContainer 가 `until pg_isready ...; do sleep 2; done` 로 무한 대기하고
+  # activeDeadlineSeconds 도 없어서 loop-postgres 가 0 replica 인 동안
+  # Init:0/1 파드가 영구히 남는다. 되살릴 때 replicas 블록과 함께 복구.
+  # - migrate-job.yaml


### PR DESCRIPTION
[#264](https://github.com/manamana32321/homelab/pull/264) 배포 검증 중 발견한 회귀.

## 문제

#264 로 loop 를 `replicas: 0` 으로 내렸는데 `migrate-job.yaml` 이 kustomization 에 남아 있었다. 이 Job 은 PostSync hook 이라 sync 마다 재생성되고, initContainer 가 이렇게 대기한다:

```sh
until pg_isready -h loop-postgres -U loop -d loop; do sleep 2; done
```

`activeDeadlineSeconds` 도 없다. `loop-postgres` 가 0 replica 인 동안 **끝나지 않는다.**

배포 직후 실측:
```
NAME                 READY   STATUS      RESTARTS   AGE
loop-migrate-4j8gd   0/1     Init:0/1    0          2m
```

실패가 아니라 대기라서 `KubeJobFailed` 도 안 울리고, ArgoCD 도 Healthy 로 본다. 그냥 조용히 남는다.

## 변경

파킹 동안 `migrate-job.yaml` 을 kustomization 에서 제외. 되살릴 때 `replicas` 블록과 함께 복구하도록 주석에 명시했다.

## 검증

```
$ kubectl kustomize k8s/loop | grep -c "kind: Job"
0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)