### PR TITLE
fix(minio-operator): reaper 이미지를 셸 있는 alpine/k8s 로 교체

### DIFF
--- a/k8s/minio-operator/manifests/zombie-reaper.yaml
+++ b/k8s/minio-operator/manifests/zombie-reaper.yaml
@@ -65,13 +65,19 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
+      # 30초 recheck 를 포함해도 1분이면 끝난다. 데드라인이 없으면 무언가 매달렸을 때
+      # 조용히 남는다 (loop-migrate 가 정확히 그렇게 됐다, #265).
+      activeDeadlineSeconds: 120
       template:
         spec:
           restartPolicy: Never
           serviceAccountName: minio-operator-reaper
           containers:
             - name: reaper
-              image: rancher/kubectl:v1.34.1
+              # 셸이 필요하다. rancher/kubectl 은 18MB distroless 라 `sh` 가 없어
+              # StartError 로 죽는다 (#264 배포 후 실측). alpine/k8s 는 busybox 셸 +
+              # kubectl 을 포함하고 태그가 클러스터 버전(K3s v1.34.5)과 일치한다.
+              image: alpine/k8s:1.34.5
               command:
                 - sh
                 - -c


### PR DESCRIPTION
[#264](https://github.com/manamana32321/homelab/pull/264) 로 배포한 reaper 가 첫 실행에서 죽었다.

```
Reason:    StartError
Message:   exec: "sh": executable file not found in $PATH
Exit Code: 128
```

`rancher/kubectl:v1.34.1` 은 18MB distroless — kubectl 바이너리만 있고 셸이 없다. `command: [sh, -c, ...]` 가 성립하지 않는다.

**원인은 제 검증 부실이다.** #264 에서 이 이미지에 대해 멀티아치 여부만 확인하고 셸 존재를 확인하지 않았는데, PR 본문에는 "확인"이라고만 적어 검증 범위가 실제보다 넓어 보이게 썼다.

## 변경

| | before | after |
|---|---|---|
| image | `rancher/kubectl:v1.34.1` | `alpine/k8s:1.34.5` |
| activeDeadlineSeconds | 없음 | `120` |

`alpine/k8s:1.34.5` — busybox 셸 + kubectl 포함, amd64/arm64, 태그가 클러스터 K3s 버전과 일치.

`activeDeadlineSeconds` 는 [#265](https://github.com/manamana32321/homelab/pull/265) 의 교훈을 이 Job 자신에게 적용한 것이다. 데드라인 없는 Job 은 매달렸을 때 실패로도 성공으로도 잡히지 않고 조용히 남는다. 감시 장치가 그렇게 되면 안 된다.

## 검증 — 이번엔 실제로 실행했다

**1. 이미지에 셸이 있는가**
```
$ docker run --rm --user 1000 --entrypoint sh alpine/k8s:1.34.5 -c 'echo "shell OK"; command -v kubectl; id'
shell OK
/usr/bin/kubectl
uid=1000 gid=0(root) groups=0(root)
```

**2. 스크립트 본문이 실제로 도는가** (실클러스터 대상, 삭제만 dry-run 치환)
```
no leader; rechecking in 30s to rule out a failover window
no leader for 30s — operator is zombied, deleting pods
[DRY RUN] 삭제 대상:
minio-operator-76fc79bf68-vg6r5   1/1   Running   0   8d
minio-operator-76fc79bf68-w6n8l   1/1   Running   0   8d
```
lease 판독 → 30초 recheck 분기 → 라벨 셀렉터 매칭까지 전부 정상. 지금 좀비 2개를 정확히 집어냈다.

**3. RBAC 이 실제로 통하는가**
```
$ kubectl auth can-i <verb> -n minio-operator --as=system:serviceaccount:minio-operator:minio-operator-reaper
get leases.coordination.k8s.io/minio-operator-lock → yes
list pods                                          → yes
delete pods                                        → yes
```

머지되면 다음 `*/5` 주기에 좀비 2개가 자동 회수되고 `MinIOOperatorLeaseStale` / `CPUThrottlingHigh` 가 해소된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)