### PR TITLE
perf(actions-runner): pnpm store + tool cache 를 노드 로컬 hostPath 로 (#268)

### DIFF
--- a/k8s/actions-runner/runner-values.yaml
+++ b/k8s/actions-runner/runner-values.yaml
@@ -48,10 +48,78 @@ template:
                   operator: In
                   values:
                     - "true"
+    # 노드 로컬 캐시 (#268). 집 회선 100Mbps 가 하드 상한이라 — 동시 6잡의 합산
+    # 전송률이 12.9 MB/s 에서 멈추고 이는 이론 상한 12.5 MB/s 와 일치 — 캐시를
+    # 네트워크에서 빼는 것 외에 우회로가 없다. hostPath 라 amd64 2대가 각각 한 번씩
+    # 채우고, 그 이후로는 setup-node 가 다운로드도 압축해제도 하지 않는다.
+    #
+    # emptyDir 인 work 볼륨(/home/runner/_work)과 같은 루트 파일시스템(/dev/sda2)에
+    # 두는 게 중요하다. 다른 fs 면 pnpm 이 하드링크를 못 걸고 복사로 떨어진다.
+    volumes:
+      - name: pnpm-store
+        hostPath:
+          path: /var/lib/gha-runner-cache/pnpm
+          type: DirectoryOrCreate
+      - name: tool-cache
+        hostPath:
+          path: /var/lib/gha-runner-cache/tool
+          type: DirectoryOrCreate
+    # kubelet 이 hostPath 를 root:root 0755 로 만들어 runner(uid 1001)가 못 쓴다.
+    # 최상위 두 디렉토리만 넘기면 되고(재귀 아님 — 하위는 전부 1001 이 만든다),
+    # 러너와 같은 이미지라 추가 pull 이 없다.
+    #
+    # chart 0.13.1 은 dind 의 init-dind-externals·dind 를 먼저 넣고 이 목록을 뒤에
+    # 덧붙인다(덮어쓰지 않음). k8s 1.34 에서 dind 는 native sidecar 라 여기 도달
+    # 시점엔 이미 기동돼 있다.
+    initContainers:
+      - name: cache-perms
+        image: ghcr.io/actions/actions-runner:2.336.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
+        command:
+          - sh
+          - -c
+          - set -eu; chown 1001:1001 /pnpm /opt/hostedtoolcache; chmod 755 /pnpm /opt/hostedtoolcache
+        volumeMounts:
+          - name: pnpm-store
+            mountPath: /pnpm
+          - name: tool-cache
+            mountPath: /opt/hostedtoolcache
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
     containers:
       - name: runner
-        image: ghcr.io/actions/actions-runner:latest
+        # latest 는 kubelet 이 pullPolicy Always 로 해석해 파드마다 레지스트리 왕복이
+        # 강제된다. 2.336.0 은 이 커밋 시점 latest 와 동일 digest.
+        image: ghcr.io/actions/actions-runner:2.336.0
+        imagePullPolicy: IfNotPresent
         command: ["/home/runner/run.sh"]
+        env:
+          # pnpm store 를 노드 로컬로. PNPM_STORE_DIR / npm_config_store_dir 은
+          # pnpm 11 에서 존재하지 않는다(무시됨) — PNPM_HOME 이 실측상 동작하는
+          # 환경변수 레버이고 store 는 $PNPM_HOME/store/v<major> 로 떨어진다.
+          # (.npmrc 도 안 먹는다. pnpm 10.6+ 는 설정을 pnpm-workspace.yaml 로 옮겼다.)
+          - name: PNPM_HOME
+            value: /pnpm
+          # 러너 툴 캐시. 기본값은 _work/_tool 인데 work 가 emptyDir 라 잡마다
+          # 날아가고, 그래서 setup-node 가 매번 node 를 받아 푼다(계측 168~192초,
+          # 압축해제만 110.8초). 어느 쪽 이름을 읽는지는 러너 바이너리가 단일 파일
+          # 압축이라 정적으로 확인이 안 돼 둘 다 준다. 첫 CI 런에서 실측 확인할 것.
+          - name: RUNNER_TOOL_CACHE
+            value: /opt/hostedtoolcache
+          - name: AGENT_TOOLSDIRECTORY
+            value: /opt/hostedtoolcache
+        volumeMounts:
+          - name: pnpm-store
+            mountPath: /pnpm
+          - name: tool-cache
+            mountPath: /opt/hostedtoolcache
         # next build / gradle+testcontainers 피크 대응 상향.
         resources:
           limits:


### PR DESCRIPTION
[#268](https://github.com/manamana32321/homelab/issues/268) 1·2순위. 3순위(minRunners 상향)는 이 PR 배포·검증 후 별도로.

## 왜

집 회선 100Mbps 가 캐시 전송의 하드 상한이다. 동시 6잡의 합산 전송률이 12.9 MB/s 에서 멈추고 이는 이론 상한 12.5 MB/s 와 일치한다 — 캐시 저장소 제한이나 클러스터 네트워크 오버헤드가 아니라 회선 자체다. 캐시를 네트워크에서 빼는 것 외에 우회로가 없다.

## 무엇

| | 전 | 후 |
|---|---|---|
| pnpm store | GitHub 캐시(291MB 압축)를 매 잡마다 인터넷 너머에서 전송 | `PNPM_HOME=/pnpm` → hostPath `/var/lib/gha-runner-cache/pnpm` |
| 러너 툴 캐시 | 기본 `_work/_tool` = emptyDir → 매 잡마다 node 재다운로드+압축해제 | `RUNNER_TOOL_CACHE`/`AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache` → hostPath `/var/lib/gha-runner-cache/tool` |
| 이미지 태그 | `:latest` (kubelet 이 pullPolicy Always 로 해석 → 파드마다 레지스트리 왕복) | `:2.336.0` + `imagePullPolicy: IfNotPresent` |
| hostPath 소유권 | — | `cache-perms` initContainer 가 최상위를 uid 1001 로 (러너와 같은 이미지 → 추가 pull 0) |

hostPath 는 `work` emptyDir 와 같은 루트 파일시스템(`/dev/sda2`)에 둔다. 다른 fs 면 pnpm 이 하드링크를 못 걸고 복사로 떨어진다.

## 툴 캐시를 같이 넣은 이유

[#268](https://github.com/manamana32321/homelab/issues/268) 1순위는 pnpm store 만이었으나, 계측상 가장 큰 항목인 **도구 설치 11초 → 3분 4초(17배)** 는 pnpm store 가 아니라 node 다운로드+압축해제다. 정전 복구 직후 버스트에서 잰 압축해제 단독 110.8초가 그 증거다. `work` 가 emptyDir 라 기본 툴 캐시가 잡마다 날아가는 게 원인이라, pnpm store 만 옮기면 `setup-node` 스텝(현 168~192초)은 그대로 남는다. 같은 볼륨 메커니즘이라 diff 증가는 미미하다.

## 실측으로 확인한 것 (핸드오프 가정 정정 포함)

- **러너 uid/gid = 1001** — `uid=1001(runner) gid=1001(runner) groups=1001(runner),27(sudo),100(users),123(docker)`. kubelet 은 hostPath 를 root:root 0755 로 만든다
- **`PNPM_STORE_DIR` 은 존재하지 않는다.** `PNPM_STORE_PATH`·`npm_config_store_dir` 도 전부 무시됐다. `.npmrc` 도 안 먹는다 — pnpm 10.6+ 는 설정을 `pnpm-workspace.yaml` 로 옮겼다. 동작하는 레버는 `--store-dir` 플래그, `PNPM_HOME`, `XDG_DATA_HOME` 셋뿐이고 그중 가장 좁은 `PNPM_HOME` 을 골랐다
- **dind 는 안 깨진다.** chart 0.13.1 의 병합은 전부 additive — `initContainers` 는 `init-dind-externals`·`dind` 뒤에 덧붙고, 볼륨은 `name != "work"` 면 통과하고, runner 의 `env`/`volumeMounts` 는 사용자 것을 먼저 쓴 뒤 `DOCKER_HOST`·`work`·`dind-sock` 을 없을 때만 추가한다. `helm template --kube-version 1.34.5` 로 렌더 확인
- **k8s 1.34 ≥ 1.29** 라 `dind` 는 native sidecar 다. `cache-perms` 는 dind 기동 후 실행되므로 순서 위험 없음
- **`2.336.0` == 이 시점 `latest`** (동일 digest `sha256:0cfdcc70…`)

## 알려진 트레이드오프

- **툴 캐시 동시 쓰기** — 콜드 노드의 첫 웨이브에서 파드 여러 개가 같은 툴 캐시에 동시에 node 를 설치한다. `actions/tool-cache` 의 copy + `.complete` 마커가 원자적이지 않아 중복 추출이 날 수 있다. 노드당 1회뿐이고 실패 모드는 '헛일'이다
- **`RUNNER_TOOL_CACHE` vs `AGENT_TOOLSDIRECTORY`** — 러너 바이너리가 단일 파일 압축이라 어느 쪽을 읽는지 정적으로 확인이 안 돼 둘 다 준다. 첫 CI 런에서 실측 확인
- **노드별 워밍** — hostPath 라 amd64 2대가 각각 한 번씩 채운다. 첫 잡만 느린 게 정상
- **store 증식** — 정리 크론은 넣지 않았다. day-1 약 1.2 GiB, 연 1.5~4 GiB 로 추정되는데 여유가 가장 적은 json-server-2 가 26.8 GiB 라 최소 6년치다. 배포 후 실제 `du` 를 재고 기울기가 예상을 벗어나면 별도 PR

## 배포 순서 (중요)

**이 PR 이 먼저 배포·검증되어야 한다.** [mortonCareer/bconnect#1102](https://github.com/mortonCareer/bconnect/pull/1102) 가 `cache: 'pnpm'` 을 제거하는데, 순서가 뒤집히면 워크플로가 존재하지 않는 볼륨을 참조해 CI 가 전면 실패한다.

## 검증 계획

1. 러너 파드에서 `/pnpm`·`/opt/hostedtoolcache` 존재 + uid 1001 쓰기 가능
2. CI 1회 → `Run actions/setup-node@v6` 스텝 시간 (현 168~192초 → 목표 10초 내외, 2회차부터)
3. `ci-api` 통과 (dind 정상)
4. 노드 2대 hostPath `du` 로 실제 store 크기 기록