### PR TITLE
fix(actions-runner): pnpm store 를 재배치 목적지에 마운트 — #269 는 무동작이었다

### DIFF
--- a/k8s/actions-runner/runner-values.yaml
+++ b/k8s/actions-runner/runner-values.yaml
@@ -53,8 +53,13 @@ template:
     # 네트워크에서 빼는 것 외에 우회로가 없다. hostPath 라 amd64 2대가 각각 한 번씩
     # 채우고, 그 이후로는 setup-node 가 다운로드도 압축해제도 하지 않는다.
     #
-    # emptyDir 인 work 볼륨(/home/runner/_work)과 같은 루트 파일시스템(/dev/sda2)에
-    # 두는 게 중요하다. 다른 fs 면 pnpm 이 하드링크를 못 걸고 복사로 떨어진다.
+    #
+    # pnpm store 마운트 위치가 /home/runner/_work/.pnpm-store 인 이유 (#269 배포 검증
+    # 에서 정정): pnpm 은 설정된 store 가 프로젝트와 다른 마운트에 있으면 그것을 버리고
+    # <프로젝트 마운트 루트>/.pnpm-store 로 store 를 재배치한다. 프로젝트는 emptyDir 인
+    # work 볼륨 위에 있으므로, 평범하게 /pnpm 등에 걸면 store 가 emptyDir 로 옮겨가
+    # 파드마다 통째로 증발한다 — 캐시가 아예 동작하지 않는다.
+    # 그 재배치 목적지에 hostPath 를 직접 걸어 재배치가 영속 볼륨으로 떨어지게 한다.
     volumes:
       - name: pnpm-store
         hostPath:
@@ -101,12 +106,12 @@ template:
         imagePullPolicy: IfNotPresent
         command: ["/home/runner/run.sh"]
         env:
-          # pnpm store 를 노드 로컬로. PNPM_STORE_DIR / npm_config_store_dir 은
-          # pnpm 11 에서 존재하지 않는다(무시됨) — PNPM_HOME 이 실측상 동작하는
-          # 환경변수 레버이고 store 는 $PNPM_HOME/store/v<major> 로 떨어진다.
-          # (.npmrc 도 안 먹는다. pnpm 10.6+ 는 설정을 pnpm-workspace.yaml 로 옮겼다.)
-          - name: PNPM_HOME
-            value: /pnpm
+          # pnpm store 를 가리키는 환경변수는 없다. PNPM_STORE_DIR·PNPM_STORE_PATH·
+          # npm_config_store_dir·PNPM_HOME·~/.npmrc·~/.config/pnpm/rc·
+          # `pnpm config set --global` 전부 재배치를 못 막는다(실측). 유일하게 통하는
+          # 건 --store-dir CLI 플래그인데 워크플로 수정이 필요하므로, 대신 재배치
+          # 목적지에 볼륨을 거는 방식을 쓴다 — 위 volumes 주석 참조.
+          #
           # 러너 툴 캐시. 기본값은 _work/_tool 인데 work 가 emptyDir 라 잡마다
           # 날아가고, 그래서 setup-node 가 매번 node 를 받아 푼다(계측 168~192초,
           # 압축해제만 110.8초). 어느 쪽 이름을 읽는지는 러너 바이너리가 단일 파일
@@ -115,9 +120,15 @@ template:
             value: /opt/hostedtoolcache
           - name: AGENT_TOOLSDIRECTORY
             value: /opt/hostedtoolcache
+        # work 를 여기서 명시하는 건 순서 때문이다. 중첩 마운트라 부모(work)가 먼저
+        # 마운트돼야 하는데, chart 는 사용자 마운트를 먼저 쓰고 work 를 뒤에 붙인다.
+        # 명시하면 chart 의 $mountWork 가 0 이 되어 재추가하지 않는다. 볼륨 자체는
+        # 선언하지 않으므로 chart 가 계속 emptyDir 로 만든다(잡 간 격리 유지).
         volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
           - name: pnpm-store
-            mountPath: /pnpm
+            mountPath: /home/runner/_work/.pnpm-store
           - name: tool-cache
             mountPath: /opt/hostedtoolcache
         # next build / gradle+testcontainers 피크 대응 상향.


### PR DESCRIPTION
[#269](https://github.com/manamana32321/homelab/pull/269) 배포 후 검증에서 **pnpm store hostPath 가 전혀 쓰이지 않고 있는 것**을 발견했다. tool cache 는 무관하게 정상.

## 무엇이 잘못됐나

러너와 동일한 볼륨 구성으로 파드를 띄워 확인:

```
pnpm store path = /home/runner/_work/.pnpm-store/v11   ← emptyDir. 파드마다 증발
```

`PNPM_HOME=/pnpm` 을 줬는데도 store 가 거기 안 생긴다. pnpm 은 설정된 store 가 프로젝트와 **다른 마운트**에 있으면 그것을 버리고 `<프로젝트 마운트 루트>/.pnpm-store` 로 store 를 재배치한다. 프로젝트는 emptyDir 인 `work` 볼륨 위에 있으므로 store 가 매 파드마다 통째로 사라졌다. 캐시 이득 0.

## 왜 "같은 디스크"로는 부족했나

[#269](https://github.com/manamana32321/homelab/pull/269) 는 "hostPath 를 work emptyDir 와 같은 루트 fs(`/dev/sda2`)에 두면 하드링크가 걸린다"고 적었다. **틀렸다.**

```
store dev=2050
work  dev=2050        ← stat 상 같은 device
HARDLINK FAILED       ← 그런데 link() 는 EXDEV
```

커널 `link()` 는 device 가 아니라 **mount** 를 본다 (`old_path.mnt != new_path.mnt` → `EXDEV`). 별개 볼륨은 같은 디스크여도 별개 bind mount다. 그리고 pnpm 의 재배치 판정도 device 비교가 아니라 이 하드링크 가능 여부다.

## 수정

재배치를 막을 수 없으니, **재배치 목적지 자체에 hostPath 를 건다.**

| | 전 | 후 |
|---|---|---|
| pnpm-store 마운트 | `/pnpm` | `/home/runner/_work/.pnpm-store` |
| `PNPM_HOME` | `/pnpm` | 제거 (무동작) |
| `work` volumeMount | chart 가 자동 추가 | **명시** — 아래 |

`work` 를 명시하는 건 순서 때문이다. 중첩 마운트라 부모(`work`)가 먼저 마운트돼야 하는데 chart 는 사용자 마운트를 먼저 쓰고 `work` 를 뒤에 붙인다. 명시하면 chart 의 `$mountWork` 가 0 이 되어 재추가하지 않는다. **볼륨 자체는 선언하지 않으므로** chart 가 계속 emptyDir 로 만든다 — 잡 간 격리는 그대로다.

`helm template --kube-version 1.34.5` 로 순서 확인: `work` → `.pnpm-store` → `tool-cache` → `dind-sock`.

## 실측

json-server-2, next15 + react19 + typescript + eslint + tailwind 등 직접 의존 10개, `node_modules` 396MB. "fresh-pod" = emptyDir 를 완전히 비우고 hostPath store 만 남긴 상태 = 실제 새 러너 파드 조건.

| 설정 | store 위치 | fresh-pod install | 네트워크 |
| --- | --- | ---: | --- |
| `PNPM_HOME` ([#269](https://github.com/manamana32321/homelab/pull/269) 배포본) | emptyDir | 13.6s | 매번 full fetch |
| **재배치 목적지에 마운트 (이 PR)** | **hostPath** | **5.3s** | **없음** |
| `--store-dir` CLI 플래그 | hostPath | 5.9s | 없음 |
| (참고) 프로젝트와 같은 마운트 | hostPath | 2.1s | 없음 |

## 왜 환경변수로 안 고쳤나

전부 시도했고 전부 재배치를 못 막았다:

`PNPM_STORE_DIR` · `PNPM_STORE_PATH` · `npm_config_store_dir` · `PNPM_HOME` · `~/.npmrc` · `~/.config/pnpm/rc` · `pnpm config set --global`

유일하게 통하는 건 `--store-dir` CLI 플래그인데 워크플로 수정이 필요하다. 이 PR 은 homelab 단독으로 닫는 쪽을 택했다. 워크플로가 나중에 `--store-dir` 를 쓰더라도 같은 경로를 가리키면 그대로 동작하므로 상충하지 않는다.

## 남는 트레이드오프

- **하드링크는 여전히 안 걸린다** (cross-mount). 복사 폴백 비용은 5.3s vs 2.1s = 약 3.2초. 대체 대상인 캐시 전송 중앙값 110초에 비하면 무시할 수준
- **pnpm 내부 규약 의존** — 재배치 목적지가 `<마운트 루트>/.pnpm-store` 라는 건 문서화된 계약이 아니다. pnpm 메이저 업그레이드 시 검증 필요. 깨지면 워크플로에 `--store-dir=/home/runner/_work/.pnpm-store` 를 박으면 같은 볼륨을 그대로 쓴다

## 검증 계획

1. 러너 파드에서 `findmnt /home/runner/_work/.pnpm-store` 로 중첩 마운트 확인
2. CI 1회 → `pnpm store path` 가 `.pnpm-store` 인지, 노드 hostPath 에 실제로 바이트가 쌓이는지
3. 2회차에서 의존성 설치 시간 + `ci-api` 통과 (dind)