### PR TITLE
perf(actions-runner): minRunners 0 → 2 — 1차 웨이브 콜드스타트 제거 (#268)

### DIFF
--- a/k8s/actions-runner/runner-values.yaml
+++ b/k8s/actions-runner/runner-values.yaml
@@ -17,10 +17,22 @@ controllerServiceAccount:
 containerMode:
   type: "dind"
 
-# scale-from-zero. maxRunners 는 amd64 노드 2대(json-server-1/2, 각 16Gi)의 실메모리
-# 여유 기준 — minecraft 정지 + loki chunks-cache 비활성으로 확보 (#261).
-# CI 7개 잡이 1~2 웨이브로 돎.
-minRunners: 0
+# maxRunners 는 amd64 노드 2대(json-server-1/2, 각 16Gi)의 실메모리 여유 기준 —
+# minecraft 정지 + loki chunks-cache 비활성으로 확보 (#261). CI 7개 잡이 1~2 웨이브로 돎.
+#
+# minRunners 2 (#268 3순위). 캐시를 회선에서 빼기 전에 러너를 늘리면 같은 경합이
+# 반복되므로 #269·#270 배포·검증 뒤로 미뤄뒀던 항목이다.
+#
+# 실측: 런 생성 → 잡 시작이 1차 웨이브 37~44초. ci-career 는 needs: changes 라
+# 파드 콜드스타트를 두 번 물어 80~104초. 이미지 핀 + IfNotPresent 로 레지스트리
+# 왕복은 이미 사라졌고, 남은 시간은 스케줄링 + init-dind-externals + dockerd 기동
+# + cache-perms + 러너 등록이다. 2 를 미리 띄워 1차 웨이브를 덮는다 — 게이트인
+# changes 와 동시 디스패치되는 format 을 둘 다 커버하려면 1 로는 부족하다.
+#
+# maxRunners 는 그대로라 피크 부하는 불변이다. 대가는 유휴 파드 2개의 영구 예약
+# (request 300m/1Gi each = 600m/2Gi)과 idle dockerd 2개 상주. json-server-2 기준
+# requests 가 55%→66% CPU, 38%→51% memory 로 오른다.
+minRunners: 2
 maxRunners: 6
 
 template:


### PR DESCRIPTION
[#268](https://github.com/manamana32321/homelab/issues/268) 3순위. 마지막 항목이다.

캐시를 회선에서 빼기 전에 러너를 늘리면 같은 경합이 반복되므로 [#269](https://github.com/manamana32321/homelab/pull/269)·[#270](https://github.com/manamana32321/homelab/pull/270) 배포·검증 뒤로 미뤄뒀던 항목이고, 그 전제가 충족됐다.

## 무엇을 잡는가

`mortonCareer/bconnect` 런 생성 → 잡 시작 실측:

| 잡 | 대기 |
| --- | ---: |
| `changes` / `format` (1차 웨이브) | 37s / 44s |
| `ci-career` (2차 웨이브) | 80s / 104s |

`ci-career` 는 `needs: changes` 라 **파드 콜드스타트를 두 번** 문다. 이미지 핀 + `IfNotPresent` 로 레지스트리 왕복은 [#269](https://github.com/manamana32321/homelab/pull/269) 에서 이미 사라졌고, 남은 37초는 스케줄링 + `init-dind-externals` + dockerd 기동(startupProbe) + `cache-perms` + 러너 등록이다. 이슈 본문의 큐 중앙값 80초보다 이미 절반으로 줄어 있다.

`minRunners: 2` 가 덮는 건 **1차 웨이브 35~40초**다. 2차 웨이브는 ARC 가 유휴분 소진 직후 대체 파드를 만들기 시작하므로 부분적으로만 먹는다. 런 전체 184s → 약 145s 예상.

## 왜 1 이 아니라 2 인가

GitHub 이 게이트인 `changes` 와 `format` 을 **동시에** 디스패치한다. 유휴 1개를 어느 쪽이 잡을지 임의라 이득이 반반이 된다. `ci-career` 를 포함한 모든 후속 잡이 `changes` 를 기다리므로 그쪽을 확실히 덮어야 한다.

## 대가

`maxRunners` 는 6 그대로다 — **피크 부하는 불변**이고, 6개 중 2개를 미리 띄워둘 뿐이다.

| | 전 | 후 (최악 = 둘 다 json-server-2 착륙) |
| --- | ---: | ---: |
| json-server-2 cpu requests | 3345m (55%) | 3945m (66%) |
| json-server-2 mem requests | 5952Mi (38%) | 8000Mi (51%) |

실사용은 현재 1538m / 6167Mi. 유휴 러너의 실메모리는 러너 프로세스 + idle dockerd 합쳐 파드당 ~200Mi 수준이라 영향이 미미하다. 부수적으로 privileged dockerd 2개가 상시 상주하게 된다.

## 검증 계획

1. hard-refresh → `Synced + Healthy`
2. 유휴 러너 파드 2개가 `Running` 으로 상주하는지, 어느 노드에 앉는지
3. CI 1회 → 1차 웨이브 대기가 37~44초에서 줄었는지
4. json-server-2 실메모리가 예상대로 미미하게만 오르는지