### PR TITLE
chore(health-hub): dashboard replicas 0 — arm64 오배치 CrashLoop 파킹

### DIFF
--- a/k8s/health-hub/manifests/kustomization.yaml
+++ b/k8s/health-hub/manifests/kustomization.yaml
@@ -1,5 +1,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+# 2026-08-01 대시보드만 파킹. amd64 전용 이미지가 nodeSelector 없이 raspi-1(arm64)
+# 로 스케줄돼 `exec format error` 로 1092 회 재시작 중이었다. 웹 UI 는 거의 안 쓰고
+# 실사용은 MCP(/mcp)·REST(/api/v1) 경로라, 고쳐서 띄우는 대신 껐다.
+# 되살릴 때: 아래 replicas 블록 제거 + dashboard-deployment.yaml 에
+# `nodeSelector: {kubernetes.io/arch: amd64}` 추가(안 하면 같은 증상 재발).
+# Ingress(health-hub-dashboard, path `/`)는 그대로 둔다 — 되살리기 원클릭.
+# `/` 는 파킹 동안 503. `/api/v1`·`/healthz`·`/mcp` 는 health-hub-api Ingress 라 무관.
+replicas:
+  - name: health-hub-dashboard
+    count: 0
+
 resources:
   - namespace.yaml
   - sealed-secret.yaml


### PR DESCRIPTION
## 무슨 일이 있었나

health-hub 의 웹 대시보드가 **1092번 재시작**을 반복하고 있었습니다.

원인은 "칩 종류가 안 맞는 컴퓨터에 올라갔다"입니다. 서버 3대 중 raspi-1 만 칩 계열이 다른데(ARM), 대시보드 프로그램은 나머지 두 대(Intel 계열)용으로만 만들어져 있습니다. "이 프로그램은 Intel 계열에만 올려라"는 표시가 빠져 있어서 하필 raspi-1 로 배정됐고, 실행하자마자 아래처럼 죽고 다시 켜지기를 반복했습니다.

```
exec /usr/local/bin/docker-entrypoint.sh: exec format error
```

같은 폴더의 본체(API) 설정에는 그 표시가 들어 있어서 본체는 멀쩡히 돌고 있었습니다. 대시보드에만 빠져 있었습니다.

## 무엇을 바꿨나

표시를 추가해서 되살리는 대신, **대시보드를 껐습니다**.

건강 데이터는 실제로는 대시보드 웹 화면이 아니라 다른 두 경로(앱이 데이터를 읽어가는 통로, 그리고 아침 브리핑 자동 작업)로 쓰이고 있고, 웹 화면 자체는 거의 열지 않기 때문입니다.

바꾼 건 설정 파일 한 곳, "대시보드는 0대 띄운다"는 3줄입니다.

- 대시보드 원본 설정은 손대지 않았습니다 → 다시 켤 때 이 3줄만 지우면 됩니다
- 주소 연결(`/`)은 그대로 뒀습니다. 끈 동안 그 주소는 오류 화면이 뜨지만, 데이터를 읽어가는 통로(`/api/v1`, `/mcp`)와 상태 확인(`/healthz`)은 다른 연결이라 그대로 동작합니다
- **다시 켤 때는 반드시 "Intel 계열에만"이라는 표시를 같이 추가해야 합니다.** 안 그러면 똑같은 일이 다시 벌어집니다 (같은 원인으로 이미 두 번 있었음: #248, #250)

## 확인한 것

`kubectl kustomize` 로 최종 설정을 뽑아 보니 대시보드만 0대이고, 본체와 데이터베이스는 그대로 1대입니다.

```
54:  replicas: 1   ← 데이터베이스
209:  replicas: 0  ← 대시보드 (이번에 끈 것)
264:  replicas: 1  ← 본체 API
```

## 함께 처리한 것

같은 점검에서 나온 별건이라 여기 기록만 남깁니다. loop 앱의 `loop-migrate` 작업이 7월 22일부터 열흘째 멈춰 있었습니다. loop 을 전면 정지시키면서 데이터베이스도 껐는데, 이 작업이 "데이터베이스가 켜질 때까지 무한정 기다리는" 방식이라 영원히 안 끝나고, 그 탓에 loop 앱의 자동 반영 자체가 통째로 멈춰 있었습니다. 하필 이 문제를 고치는 변경(#265)도 그 멈춘 반영에 막혀 적용되지 못한 상태였습니다. 클러스터에서 멈춘 작업을 직접 정리하는 것으로 해결하며, 이 PR 의 코드 변경과는 무관합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
