### PR TITLE
fix(hermes): config seed grep 정밀화 (anthropic 잔류 버그)

### DIFF
--- a/k8s/hermes/manifests/deployment.yaml
+++ b/k8s/hermes/manifests/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - -c
             - |
               set -eu
-              if ! grep -q openai-codex /opt/data/config.yaml 2>/dev/null; then
+              if ! grep -q "provider: openai-codex" /opt/data/config.yaml 2>/dev/null; then
                 echo "seeding config.yaml (codex provider)"
                 cp /seed-config/config.yaml /opt/data/config.yaml
                 chown 10000:10000 /opt/data/config.yaml


### PR DESCRIPTION
seed-if-no-codex의 config grep이 migrated config의 provider 레지스트리 문자열에 오탐 → stale `provider: anthropic` 유지 → 추론이 anthropic 요구하며 실패. grep을 `provider: openai-codex`로 정밀화. rollout 시 config 리시드 → codex 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)