### PR TITLE
fix(hermes): seed 모델 gpt-5.6-sol (ChatGPT 계정 지원)

### DIFF
--- a/k8s/hermes/manifests/config.yaml
+++ b/k8s/hermes/manifests/config.yaml
@@ -6,7 +6,7 @@ model:
   # OpenAI Codex via ChatGPT subscription OAuth (billing: subscription_included,
   # no metered/overage). Credential lives in /opt/data/auth.json (seeded), not env.
   provider: openai-codex
-  default: gpt-5.3-codex
+  default: gpt-5.6-sol
 terminal:
   # local = agent shell runs INSIDE this pod (the pod is the sandbox).
   # docker backend would need docker-in-docker → avoided in K8s.


### PR DESCRIPTION
gpt-5.3-codex는 ChatGPT-account Codex 미지원. 계정 라이브 지원 모델 첫번째 gpt-5.6-sol로 seed 갱신. 라이브 실추론 CODEX_OK 검증 완료 — seed는 DR 재현용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)