### PR TITLE
fix(observability): Prometheus ingress 제거 — 무인증 외부 노출 차단

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ App (OTLP) → OTel Collector → Prometheus (메트릭)
 |--------|-----|
 | ArgoCD | argocd.json-server.win |
 | Grafana | grafana.json-server.win |
-| Prometheus | prometheus.json-server.win |
+| Prometheus | (외부 노출 안 함, kubectl port-forward) |
 | K8s Dashboard | k8s.json-server.win |
 | OTel Collector | otel.json-server.win |
 

--- a/k8s/observability/CLAUDE.md
+++ b/k8s/observability/CLAUDE.md
@@ -129,8 +129,11 @@ PrometheusRule → Prometheus → Alertmanager → Telegram (chat -1003865568684
 | 서비스 | URL |
 |---|---|
 | Grafana | grafana.json-server.win |
-| Prometheus | prometheus.json-server.win |
+| Prometheus | (외부 노출 안 함, kubectl port-forward) |
 | Alertmanager | (외부 노출 안 함, kubectl port-forward) |
+
+Prometheus·Alertmanager는 자체 인증 기능이 없어 ingress가 곧 무인증 공개 API가 된다.
+둘 다 ingress를 두지 않고 port-forward로만 접근한다. 메트릭 조회는 Grafana를 쓴다.
 
 ## 앱에서 텔레메트리 전송
 

--- a/k8s/observability/prometheus/values.yaml
+++ b/k8s/observability/prometheus/values.yaml
@@ -70,21 +70,9 @@ prometheus:
     nodeSelector:
       kubernetes.io/hostname: json-server-1
 
+  # Prometheus는 자체 인증 기능이 없어 ingress가 곧 무인증 공개 API가 된다.
+  # Alertmanager와 동일하게 외부 노출하지 않고 port-forward로만 접근한다:
+  #   kubectl port-forward -n observability svc/prometheus-kube-prometheus-prometheus 9090:9090
+  # 대시보드는 Grafana(ClusterIP 스크레이프)가 담당하므로 일상 조회에 영향 없다.
   ingress:
-    enabled: true
-    hosts:
-      - prometheus.json-server.win
-    paths:
-      - /
-    annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-dns01
-      traefik.ingress.kubernetes.io/redirect-entry-point: https
-      # Prometheus는 자체 인증이 전혀 없어 ingress가 곧 무인증 공개 API였다.
-      # (익명 /api/v1/query로 내부 IP·노드명·전 워크로드 메트릭 열람 가능)
-      # Grafana는 ClusterIP로 스크레이프하므로 이 게이트의 영향을 받지 않는다.
-      traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
-    ingressClassName: traefik
-    tls:
-      - hosts:
-          - prometheus.json-server.win
-        secretName: prometheus-tls
+    enabled: false

--- a/k8s/observability/prometheus/values.yaml
+++ b/k8s/observability/prometheus/values.yaml
@@ -79,6 +79,10 @@ prometheus:
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-dns01
       traefik.ingress.kubernetes.io/redirect-entry-point: https
+      # Prometheus는 자체 인증이 전혀 없어 ingress가 곧 무인증 공개 API였다.
+      # (익명 /api/v1/query로 내부 IP·노드명·전 워크로드 메트릭 열람 가능)
+      # Grafana는 ClusterIP로 스크레이프하므로 이 게이트의 영향을 받지 않는다.
+      traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forwardauth@kubernetescrd
     ingressClassName: traefik
     tls:
       - hosts:


### PR DESCRIPTION
## 문제

`prometheus.json-server.win`이 **인증 없이 인터넷에 공개**돼 있었음. Prometheus는 자체 인증 기능이 없어 ingress가 곧 익명 공개 API였음.

외부에서 실측:
```
GET https://prometheus.json-server.win/api/v1/query?query=up  → 200
{"status":"success",...{"instance":"192.168.0.27:10250","job":"kubelet",
 "namespace":"kube-system","node":"json-server-1",...
```
내부 사설 IP·노드명·네임스페이스·전 워크로드 메트릭이 익명 열람 가능. admin API는 비활성(`{"error":"admin APIs disabled"}`)이라 변조·삭제는 불가 — 열람 노출에 한정.

## 변경

`ingress.enabled: false`. Alertmanager와 동일하게 port-forward 전용으로 전환.

```bash
kubectl port-forward -n observability svc/prometheus-kube-prometheus-prometheus 9090:9090
```

## 왜 Authentik forward-auth가 아니라 ingress 제거인가

처음엔 forward-auth 어노테이션을 붙였다가 되돌렸음. 이유:

1. **어노테이션만으론 동작하지 않음.** Authentik 쪽에 `proxyprovider`(external_host 일치) + `application` + `policybinding` + **Embedded Outpost 등록**까지 필요. 누락되면 outpost가 그 호스트를 몰라 404를 뱉음. 실증:
   ```
   $ curl -sD- https://minio.essentia.json-server.win/
   HTTP/2 404
   x-powered-by: authentik      ← MinIO가 아니라 Authentik의 404
   ```
   `minio.essentia` 콘솔이 지금 이 상태로 죽어 있음 (기존 잠복 버그, 별도 처리 필요)
2. **의존성 역설.** forward-auth로 가면 Prometheus가 Authentik 가용성에 종속됨. 장애 조사 도구가 장애 시점에 못 쓰이게 됨
3. **선례 일치.** Alertmanager가 이미 같은 판단으로 port-forward 전용

## 영향 없음 (검증 완료)

| 소비자 | 경로 | 영향 |
|---|---|---|
| Grafana 데이터소스 | `prometheus-kube-prometheus-prometheus.observability.svc.cluster.local:9090` | 없음 (ClusterIP) |
| blackbox-exporter probe | `...svc.cluster.local:9090/-/ready` | 없음 (ClusterIP) |
| Better Stack 외부 모니터 | `argocd.json-server.win`만 등록 | 없음 |

## 남는 것 (이 PR 범위 밖)

- `cloudflare/dns.tf`의 `prometheus` A 레코드 — 도메인 공개 정책 일괄 검토 시 함께 정리
- `minio.essentia` 콘솔 404 복구 (Authentik provider 등록 누락)

## Test plan
- [ ] 머지 후 hard-refresh → `argocd app wait`
- [ ] 외부 `curl -sI https://prometheus.json-server.win/` → **404** (traefik 라우트 없음, 메트릭 미노출)
- [ ] `kubectl port-forward` 후 `localhost:9090` UI 정상
- [ ] Grafana 대시보드 데이터 계속 렌더링
- [ ] blackbox `probe_success{...prometheus...}` 여전히 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)