### PR TITLE
fix(storage): hostPath 디스크 미마운트 침묵 차단 — type Directory + 마운트/재부팅 알림

### DIFF
--- a/docs/node-disk-mount-runbook.md
+++ b/docs/node-disk-mount-runbook.md
@@ -1,0 +1,77 @@
+# 노드 디스크 마운트 런북 (json-server-1)
+
+hostPath PV가 올라탄 물리 디스크의 마운트를 보장하기 위한 노드 설정. `/etc/fstab`은 Git으로 관리되지 않으므로 여기에 목표 상태를 기록한다.
+
+## 대상
+
+| 디스크 | 마운트 지점 | 사용처 |
+|---|---|---|
+| `/dev/sdb1` (Seagate 1TB, LABEL `data-1tb`) | `/mnt/hdd-seagate-1t` | immich-library, seafile-data, frigate-media |
+| `/dev/sdc1` (Samsung 640GB) | `/mnt/hdd-samsung-640g` | `local-path-hdd-samsung` StorageClass (Loki/Tempo/Grafana) |
+
+## fstab 목표 상태
+
+```
+UUID=0958b4ac-f603-4e3f-8777-a6338fd0910b  /mnt/hdd-samsung-640g  ext4  defaults  0  2
+UUID=97968160-1c0b-42f4-a94e-6a88b4014ac7  /mnt/hdd-seagate-1t    ext4  defaults,nofail,x-systemd.before=local-fs.target  0  2
+```
+
+### `x-systemd.before=local-fs.target`이 필요한 이유
+
+`nofail`은 systemd-fstab-generator가 마운트 유닛에서 `Before=local-fs.target` 순서 제약을 **빼도록** 만든다. 그 결과 fsck가 아직 돌고 있어도 부팅이 `local-fs.target`을 통과하고, 뒤늦게 마운트 job이 취소되면서 fsck가 SIGTERM으로 잘린다. 마운트 유닛은 실패가 아니라 **취소**로 끝나므로 `Dependency failed` 로그조차 남지 않는다.
+
+`x-systemd.before=`로 순서 제약만 되돌리면:
+
+- 부팅이 fsck 완료까지 기다린다 (저널 재생은 보통 수 초)
+- `Wants=`는 그대로라 디스크가 정말 죽어도 emergency mode로 빠지지 않고 부팅은 진행된다
+
+`x-systemd.device-timeout=`은 이 문제에 쓰지 않는다. 그건 **디바이스 노드가 나타날 때까지**의 대기 시간이지 fsck 대기와 무관하다.
+
+적용:
+
+```bash
+sudo cp /etc/fstab /etc/fstab.bak
+sudo sed -i 's|\(UUID=97968160-1c0b-42f4-a94e-6a88b4014ac7.*\)defaults,nofail|\1defaults,nofail,x-systemd.before=local-fs.target|' /etc/fstab
+sudo systemctl daemon-reload
+systemctl cat 'mnt-hdd\x2dseagate\x2d1t.mount' | grep -E 'Before|Options'   # Before=local-fs.target 확인
+```
+
+## 마운트 지점 스텁 차단
+
+hostPath PV에 `type: Directory`를 걸어도, 마운트 지점 **아래 루트 파일시스템에 빈 디렉토리가 남아 있으면** kubelet 검사를 통과해버린다. 컨테이너 런타임은 bind-mount 원본이 없으면 자동 생성하므로, 디스크가 안 붙은 채 파드가 뜨면 스텁이 생긴다.
+
+마운트된 상태에서는 스텁이 가려져 보이지 않는다. bind-mount로 루트 파일시스템을 직접 확인한다:
+
+```bash
+sudo mkdir -p /tmp/rootbind && sudo mount --bind / /tmp/rootbind
+ls -la /tmp/rootbind/mnt/hdd-seagate-1t/          # 비어 있어야 정상
+```
+
+스텁이 있으면 제거하고 마운트 지점 자체를 잠근다:
+
+```bash
+sudo rm -rf /tmp/rootbind/mnt/hdd-seagate-1t/*
+sudo chattr +i /tmp/rootbind/mnt/hdd-seagate-1t   # 하위 생성 차단 (마운트는 정상 동작)
+sudo umount /tmp/rootbind && sudo rmdir /tmp/rootbind
+```
+
+`chattr +i`는 디렉토리 위에 파일시스템을 마운트하는 것은 막지 않는다. 마운트가 없을 때만 쓰기를 차단한다.
+
+## 미마운트 복구
+
+```bash
+sudo e2fsck -n -f /dev/sdb1        # 1. 읽기 전용 검사. bitmap 차이만 있고 Pass 2~5가 조용하면 저널 재생으로 충분
+sudo e2fsck -p /dev/sdb1           # 2. 안전한 항목만 자동 수정 (애매하면 스스로 중단)
+sudo mount /mnt/hdd-seagate-1t
+kubectl -n immich rollout restart deploy/immich-server
+kubectl -n seafile rollout restart deploy/seafile
+```
+
+`-n` 결과 판독: 모든 차이가 `-`(비트맵은 사용 중이라는데 실제로는 빈 블록) 방향이면 반영 안 된 free 공간 회계이므로 안전하다. `+` 방향이 섞여 있거나 Pass 1에서 `illegal block`·`multiply-claimed block`이 나오면 실제 손상이므로 진행 전 백업 상태를 먼저 확인한다.
+
+## 감시
+
+- `HostPathDiskUnmounted` — `/mnt/hdd-seagate-1t` 미마운트 5분 지속 시 critical
+- `NodeRebooted` — 노드 부팅 후 10분 이내 warning
+
+정의는 [alert-rules.yaml](../k8s/observability/prometheus/manifests/alert-rules.yaml)의 `storage` / `node` 그룹.

--- a/k8s/frigate/manifests/media-pv.yaml
+++ b/k8s/frigate/manifests/media-pv.yaml
@@ -8,7 +8,9 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
+    # type: Directory — 경로가 없으면 kubelet이 마운트를 거부한다. immich library-pv.yaml 참조.
     path: /mnt/hdd-seagate-1t/frigate-media
+    type: Directory
   nodeAffinity:
     required:
       nodeSelectorTerms:

--- a/k8s/immich/manifests/library-pv.yaml
+++ b/k8s/immich/manifests/library-pv.yaml
@@ -8,7 +8,11 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
+    # type: Directory — 경로가 없으면 kubelet이 마운트를 거부한다.
+    # type 미지정("")이면 컨테이너 런타임이 bind-mount 원본을 자동 생성하므로,
+    # Seagate가 미마운트일 때 루트 파일시스템 위에 빈 스텁이 생기고 앱이 거기에 쓴다.
     path: /mnt/hdd-seagate-1t/immich-library
+    type: Directory
   nodeAffinity:
     required:
       nodeSelectorTerms:

--- a/k8s/observability/prometheus/manifests/alert-rules.yaml
+++ b/k8s/observability/prometheus/manifests/alert-rules.yaml
@@ -70,6 +70,21 @@ spec:
             summary: "HDD almost full: {{ $labels.instance }} {{ $labels.mountpoint }}"
             description: "{{ $labels.mountpoint }} on {{ $labels.instance }} is {{ $value | humanizePercentage }} full."
 
+        - alert: HostPathDiskUnmounted
+          # hostPath PV(immich/seafile/frigate)가 올라탄 Seagate 1TB가 마운트되지 않은 상태.
+          # fstab `nofail`은 마운트 실패를 부팅 시 침묵시켜서 부팅 로그로는 안 잡힌다.
+          # 2026-08-08: 하드 컷 → fsck 중단 → 미마운트 → 루트fs에 빈 스텁 생성 → immich/seafile 다운.
+          # node-exporter가 사라지면(노드 다운) absent()가 같이 참이 되므로 `up` 가드로 분리.
+          expr: >-
+            absent(node_filesystem_size_bytes{mountpoint="/mnt/hdd-seagate-1t"})
+            and on() (up{job="node-exporter", instance="192.168.0.27:9100"} == 1)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Seagate 1TB unmounted (json-server-1)"
+            description: "/mnt/hdd-seagate-1t is not mounted. immich/seafile/frigate media PVs now point at empty directories on the root filesystem — risk of silent data divergence. Recover: `sudo e2fsck -p /dev/sdb1 && sudo mount /mnt/hdd-seagate-1t`."
+
     # SMART 디스크 건강 알림 (ATA HDD 특화 — NVMe 기본 알림은 smartctl-exporter chart에 내장)
     - name: smart
       rules:
@@ -263,3 +278,17 @@ spec:
           annotations:
             summary: "gbrain-sync 1시간+ 성공 없음"
             description: "gbrain-sync cron이 {{ $value | humanizeDuration }} 동안 성공하지 못함. brain 인덱스가 stale해지는 중. `kubectl -n gbrain get jobs`로 최근 실패 확인 후 로그(`kubectl -n gbrain logs job/<name>`) 점검."
+
+    # 노드 재부팅 감지. 2026-08-08 json-server-1이 종료 로그 한 줄 없이 급사한 뒤 추가.
+    # 계획된 재부팅과 구분할 방법이 없으므로 severity는 warning. 재부팅 자체를 알리는 게
+    # 목적이고, 계획에 없던 것이면 즉시 조사에 들어갈 수 있게 한다.
+    - name: node
+      rules:
+        - alert: NodeRebooted
+          expr: (time() - node_boot_time_seconds{job="node-exporter"}) < 600
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Node rebooted: {{ $labels.instance }}"
+            description: "{{ $labels.instance }} booted {{ $value | humanizeDuration }} ago. If this was not planned, check `journalctl -b -1 -e` for a shutdown sequence — its absence means an abrupt power loss or hardware stop, not a clean reboot."

--- a/k8s/seafile/manifests/seafile-data-pv.yaml
+++ b/k8s/seafile/manifests/seafile-data-pv.yaml
@@ -9,7 +9,9 @@ spec:
     - ReadWriteOnce
   storageClassName: hostpath-hdd
   hostPath:
+    # type: Directory — 경로가 없으면 kubelet이 마운트를 거부한다. library-pv.yaml 참조.
     path: /mnt/hdd-seagate-1t/seafile-data
+    type: Directory
   claimRef:
     name: seafile-data
     namespace: seafile


### PR DESCRIPTION
## 배경

2026-08-08 18:46 KST, `json-server-1`이 **종료 로그 한 줄 없이** 급사했다. 재부팅 후 Seagate 1TB(`/dev/sdb1`)가 마운트되지 않은 채 올라왔고, immich·seafile이 1시간 넘게 다운됐다.

### 원인 사슬

```
18:46:17  하드 컷 (종료 시퀀스 0줄, 마지막 로그와 다음 부팅 사이 23초)
          → sdb1·sdc1 양쪽 ext4 저널 dirty
18:46:50  Seagate fsck 저널 복구 시작
18:47:00  local-fs.target 통과          ← fsck 아직 실행 중인데 부팅이 안 기다림
18:47:06  fsck SIGTERM, 마운트 job 취소  ← 실패가 아니라 "취소"라 로그도 안 남음
18:49     런타임이 루트fs 위에 빈 스텁 디렉토리 생성
19:07~    immich CrashLoop, seafile 설정 못 읽음
```

`nofail`은 systemd-fstab-generator가 마운트 유닛에서 `Before=local-fs.target`을 **빼도록** 만든다. 그래서 fsck가 안 끝났는데 부팅이 앞질러 나갔고, 뒤늦게 취소된 마운트 job은 `Dependency failed` 로그조차 남기지 않았다.

**마운트 실패가 어느 층에서도 신호를 남기지 않은 것**이 핵심 문제다. 부팅 로그도, 알림도, 파드 상태도(seafile은 `Running`이었다) 조용했다.

## 변경

### 1. hostPath PV에 `type: Directory`

- [`k8s/immich/manifests/library-pv.yaml`](k8s/immich/manifests/library-pv.yaml)
- [`k8s/seafile/manifests/seafile-data-pv.yaml`](k8s/seafile/manifests/seafile-data-pv.yaml)
- [`k8s/frigate/manifests/media-pv.yaml`](k8s/frigate/manifests/media-pv.yaml)

경로가 없으면 kubelet이 마운트를 거부한다. `type` 미지정(`""`)이면 아무 검사도 안 하고, 컨테이너 런타임이 bind-mount 원본을 자동 생성해서 **빈 스텁에 쓰기가 일어난다**. 실제 디스크와 데이터가 갈라지는 경로다.

이번엔 immich가 `.immich` 마커 파일 검사로 죽어준 덕에 막혔지만, 그건 운이었다.

### 2. 알림 2건 — [`alert-rules.yaml`](k8s/observability/prometheus/manifests/alert-rules.yaml)

| 알림 | 조건 | severity |
|---|---|---|
| `HostPathDiskUnmounted` | `/mnt/hdd-seagate-1t` 미마운트 5분 지속 | critical |
| `NodeRebooted` | 노드 부팅 후 10분 이내 | warning |

`HostPathDiskUnmounted`는 노드 다운 시 `absent()`가 같이 참이 되므로 `up` 가드로 분리했다. `NodeRebooted`는 계획된 재부팅과 구분되지 않지만, 로그 없는 급사를 즉시 인지하는 게 목적이라 warning으로 둔다.

### 3. [`docs/node-disk-mount-runbook.md`](docs/node-disk-mount-runbook.md)

`/etc/fstab`은 Git 관리 밖이라 목표 상태와 복구 절차를 문서로 남긴다.

```
UUID=97968160-...  /mnt/hdd-seagate-1t  ext4  defaults,nofail,x-systemd.before=local-fs.target  0  2
```

`x-systemd.before=`로 순서 제약만 되돌려 fsck 완료를 기다리게 하되, `nofail`은 유지해 디스크가 정말 죽었을 때 헤드리스 노드가 emergency mode로 빠지는 걸 피한다.

> `x-systemd.device-timeout=`은 이 문제에 쓰지 않는다. 그건 디바이스 노드가 나타날 때까지의 대기 시간이라 fsck 대기와 무관하다.

## 검증

- PromQL 2건 — 라이브 Prometheus에 **음성·양성 양쪽** 질의. 존재하지 않는 mountpoint로 `absent()`가 `1`을 반환하고 `up` 가드가 정상 결합되는 것, `node_boot_time_seconds`가 노드 3개를 매칭하는 것 확인
- PV `hostPath.type` — 서버 dry-run으로 변경 가능 확인 (PV 재생성 불필요)
- YAML 파싱 및 필드 반영 확인

## 남은 수동 작업 ⚠️

**이 PR만으로는 다음 하드 컷을 못 막는다.** 마운트 지점 아래 루트fs에 오늘 생긴 스텁 디렉토리가 그대로 남아 있어서, 디스크가 안 붙어도 `type: Directory` 검사를 통과해버린다.

```bash
sudo mkdir -p /tmp/rootbind && sudo mount --bind / /tmp/rootbind
ls -la /tmp/rootbind/mnt/hdd-seagate-1t/     # immich-library, seafile-data 스텁 확인됨
sudo rm -rf /tmp/rootbind/mnt/hdd-seagate-1t/*
sudo chattr +i /tmp/rootbind/mnt/hdd-seagate-1t
sudo umount /tmp/rootbind && sudo rmdir /tmp/rootbind
```

fstab 수정과 함께 노드에서 별도 수행 필요. 절차는 런북에 있다.

## 범위 밖

급사 원인 자체는 미규명이다. 소프트웨어 원인은 배제됐다 — 스왑 스래싱 ✗(로드 1.9, 스왑 활동 0), RAM/machine check ✗(0건), 디스크 물리 충격 ✗(sdb G-Sense 평생 0), pstore 비어 있음. 남은 후보는 전원 차단 / 하드웨어 급정지 / 무기록 하드락업이고, 셋은 로그 서명이 동일해서 현재 계측으로는 구분 불가하다. UPS + NUT 또는 netconsole 도입이 있어야 갈린다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)