### PR TITLE
chore(brain-agent): morning brief CronJob suspend — 미사용 알림 정지

### DIFF
--- a/k8s/brain-agent/cronjob.yaml
+++ b/k8s/brain-agent/cronjob.yaml
@@ -7,6 +7,11 @@ metadata:
     app: brain-agent
     job-type: morning-brief
 spec:
+  # 2026-08-10 정지. 브리핑을 거의 보지 않아 매일 아침 알림이 노이즈만 됐다.
+  # 스크립트·시크릿 참조는 그대로 두므로 되살릴 때 이 줄만 지우면 된다.
+  # 참고: essentia 07:00 KST 다이제스트는 2026-07-22부터 이미 정지 상태
+  # (k8s/essentia/kustomization.yaml replicas 0).
+  suspend: true
   # 07:30 KST = 22:30 UTC (previous day)
   schedule: "30 22 * * *"
   timeZone: "Etc/UTC"


### PR DESCRIPTION
## 무엇

매일 07:30 KST 텔레그램으로 오던 아침 브리핑을 정지한다. `brain-agent-morning` CronJob에 `spec.suspend: true` 한 줄 추가.

## 왜

브리핑을 거의 열어보지 않아 알림 노이즈만 남았다. 내용은 어제 건강 요약(health-hub) + 아이캠퍼스 최근 24h 공지·7일 내 미제출 과제(Canvas)였는데, 건강 쪽은 Grafana에서 언제든 볼 수 있고 과제는 별도로 챙기고 있다.

## 왜 삭제가 아니라 suspend

- ConfigMap 스크립트([morning-brief.py](k8s/brain-agent/morning-brief.py))와 Reflector로 당겨오는 시크릿 참조(health-hub / canvas / telegram) 전부 유지
- 되살릴 때 `suspend` 줄만 삭제
- "아이캠 과제 있는 날만 발송" 같은 재구성 여지 유지

## 사이드 이펙트

essentia 07:00 KST 다이제스트는 [k8s/essentia/kustomization.yaml](k8s/essentia/kustomization.yaml#L2-L11) 기준 2026-07-22 전면 정지(`replicas: 0`) 이후 이미 발송되지 않는다. 따라서 이 PR 머지 후 **아침 정기 알림은 0건**이 된다. Alertmanager 장애 알림은 별개로 그대로 동작.

## 검증

머지 후 ArgoCD hard-refresh → `kubectl -n automation get cronjob brain-agent-morning` 의 SUSPEND 컬럼이 `true` 인지 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)