### PR TITLE
feat(aws): Hermes 에이전트 상태 백업용 S3 버킷 + IAM 유저 추가

### DIFF
--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -156,3 +156,39 @@ resource "aws_iam_user_policy_attachment" "probe_readonly" {
 resource "aws_iam_access_key" "probe" {
   user = aws_iam_user.probe.name
 }
+
+# Hermes agent state backup
+resource "aws_iam_user" "hermes_backup" {
+  name = "hermes-backup"
+}
+
+resource "aws_iam_policy" "hermes_backup" {
+  name        = "hermes-backup-s3"
+  description = "Allow Hermes backup CronJob to sync agent state to S3"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:DeleteObject",
+      ]
+      Resource = [
+        aws_s3_bucket.hermes_backup.arn,
+        "${aws_s3_bucket.hermes_backup.arn}/*",
+      ]
+    }]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "hermes_backup" {
+  user       = aws_iam_user.hermes_backup.name
+  policy_arn = aws_iam_policy.hermes_backup.arn
+}
+
+resource "aws_iam_access_key" "hermes_backup" {
+  user = aws_iam_user.hermes_backup.name
+}

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -76,3 +76,20 @@ output "probe_secret_access_key" {
   value       = aws_iam_access_key.probe.secret
   sensitive   = true
 }
+
+# Hermes backup
+output "hermes_backup_access_key_id" {
+  description = "Access Key ID for hermes-backup IAM user"
+  value       = aws_iam_access_key.hermes_backup.id
+}
+
+output "hermes_backup_secret_access_key" {
+  description = "Secret Access Key for hermes-backup IAM user"
+  value       = aws_iam_access_key.hermes_backup.secret
+  sensitive   = true
+}
+
+output "hermes_backup_bucket" {
+  description = "S3 bucket name for Hermes agent state backups"
+  value       = aws_s3_bucket.hermes_backup.bucket
+}

--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -111,3 +111,35 @@ resource "aws_s3_bucket_public_access_block" "minecraft_backup" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# Hermes agent state backup
+resource "aws_s3_bucket" "hermes_backup" {
+  bucket = "hermes-backup-json-server"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "hermes_backup" {
+  bucket = aws_s3_bucket.hermes_backup.id
+
+  # State archives: keep 30 days only
+  rule {
+    id     = "state-retention"
+    status = "Enabled"
+
+    filter {
+      prefix = "state/"
+    }
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "hermes_backup" {
+  bucket = aws_s3_bucket.hermes_backup.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
## 배경

헤르메스는 `/opt/data` PVC(`hermes-data`, longhorn-ssd 5Gi)에 기억·세션·pairing을 전부 보관하는데 **백업이 없었음**. immich·seafile·health-hub·minecraft는 모두 백업 대상인데 헤르메스만 누락. PVC 유실 시 대화 기억과 봇 승인 목록이 함께 사라짐.

## 변경

기존 앱별 백업 컨벤션 그대로:

| 리소스 | 내용 |
|---|---|
| `aws_s3_bucket.hermes_backup` | `hermes-backup-json-server` |
| `aws_s3_bucket_lifecycle_configuration` | `state/` 접두사 30일 만료 (다른 앱 `db/` 30일과 동일) |
| `aws_s3_bucket_public_access_block` | 4종 전부 차단 |
| `aws_iam_user` + policy + attachment + access_key | `hermes-backup`, 해당 버킷 ARN으로만 범위 제한 |

## 백업 대상 설계 (후속 PR의 CronJob에서 구현)

파드 실측 결과 `/opt/data`는 74M이지만 **대체 불가능한 건 ~3.5M뿐**:

| 항목 | 크기 | 처리 |
|---|---|---|
| `bin/` | 22M | 제외 (이미지가 복원) |
| `skills/` | 13M | 제외 (init이 74개 번들 스킬 재동기화) |
| `models_dev_cache.json` | 3.3M | 제외 (캐시) |
| `state.db` (+wal) | 2.5M | **포함** — 기억·설정 |
| `sessions/` | 968K | **포함** |
| `kanban.db` / `pairing/` | 124K | **포함** |
| `auth.json` | 작음 | **의도적 제외** |

`auth.json`(Codex OAuth 크레덴셜)을 빼는 이유는 백업이 크레덴셜 저장소가 되는 것을 막기 위함. PVC 유실 시 `hermes auth add openai-codex` device-code 재발급으로 복구되고(README Phase B), 기억·세션·pairing은 아카이브에서 그대로 복원됨.

## 비용

압축 후 하루 ~1.5M × 30일 보관 ≈ 50MB. 서울 리전 S3 Standard 기준 **월 $0.01 미만**, PUT 30건/월.

## 검증

```
terraform fmt -check   → OK
terraform validate     → Success
terraform plan         → Plan: 7 to add, 0 to change, 0 to destroy
```

기존 리소스 변경·삭제 없음.

## 후속

이 PR 머지 → `terraform apply` → 출력된 액세스 키 봉인 → 후속 PR에서 `SealedSecret` + `CronJob`(03:00 KST) 추가. CronJob이 참조할 시크릿이 apply 전에는 존재하지 않으므로 분리함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)