### PR TITLE
feat(hermes): 상태 백업 CronJob + 자격증명 SealedSecret 추가

### DIFF
--- a/k8s/hermes/README.md
+++ b/k8s/hermes/README.md
@@ -96,4 +96,11 @@ kubectl -n hermes logs deploy/hermes -c gateway | grep -i "anthropic\|telegram\|
   seed 전용 — 라이브 파일을 덮지 않음.
 - 이미지 핀: 제3자 공개 이미지 → 수동 태그 업데이트 ([manifests/deployment.yaml](manifests/deployment.yaml)
   의 `v2026.6.5`). Image Updater 미사용.
-- 백업: `/opt/data` = 기억/스킬/세션/인증 전부. PVC 유실 시 seed에서 재구성하되 OAuth는 재로그인 필요.
+- 백업: `hermes-state-backup` CronJob이 매일 03:00 KST에 재생성 불가한 상태만 골라
+  `s3://hermes-backup-json-server/state/`로 올린다 (30일 보관, [aws/s3.tf](../../aws/s3.tf)).
+  - 담는 것: `state.db`·`kanban.db`·`response_store.db`(전부 `sqlite3 .backup`으로 일관 스냅샷 —
+    WAL 모드라 `cp`는 찢어진 사본을 만든다), `sessions/`·`pairing/`·`memory/`·`identity/`
+  - 빼는 것: `bin/`(22M)·`skills/`(13M)·캐시 — 이미지와 init이 복원한다. 74M → ~3.5M
+  - **`auth.json`은 의도적으로 제외** — 백업이 크레덴셜 저장소가 되지 않도록. 복구 시
+    `hermes auth add openai-codex` device-code 재발급이 필요하다 (Phase B 참조)
+  - `hermes-data`는 ReadWriteOnce라 백업 파드는 `podAffinity`로 hermes 파드와 같은 노드에 붙는다

--- a/k8s/hermes/manifests/backup-cronjob.yaml
+++ b/k8s/hermes/manifests/backup-cronjob.yaml
@@ -1,0 +1,107 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hermes-state-backup
+  namespace: hermes
+  labels:
+    app.kubernetes.io/name: hermes
+    job-type: state-backup
+spec:
+  # 03:00 KST. immich(02:00) / health-hub(02:20) / seafile(02:40) 다음 슬롯 —
+  # 20분 간격 유지 (2026-07-22 인시던트: 백업 동시 실행 → node_load1 112).
+  schedule: "0 18 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: hermes
+            job-type: state-backup
+        spec:
+          restartPolicy: Never
+          # hermes-data는 ReadWriteOnce(longhorn-ssd)라 이미 마운트 중인 노드에서만
+          # 추가 마운트가 가능하다. hermes Deployment는 nodeSelector가 없어 노드를
+          # 옮길 수 있으므로, 고정 nodeSelector 대신 파드를 따라가도록 affinity를 건다.
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: hermes
+                  topologyKey: kubernetes.io/hostname
+          containers:
+            - name: state-backup
+              image: alpine:3.21
+              command:
+                - sh
+                - -c
+                - |
+                  set -eo pipefail
+                  apk add --no-cache sqlite rclone
+
+                  mkdir -p /root/.config/rclone
+                  cat > /root/.config/rclone/rclone.conf <<CONF
+                  [s3]
+                  type = s3
+                  provider = AWS
+                  access_key_id = ${AWS_ACCESS_KEY_ID}
+                  secret_access_key = ${AWS_SECRET_ACCESS_KEY}
+                  region = ap-northeast-2
+                  location_constraint = ap-northeast-2
+                  no_check_bucket = true
+                  CONF
+
+                  TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+                  STAGE="/tmp/hermes-${TIMESTAMP}"
+                  mkdir -p "${STAGE}"
+
+                  # SQLite는 WAL 모드다. 라이브 파일을 cp로 뜨면 쓰기 도중의 찢어진
+                  # 스냅샷이 잡혀 복구 시점에 깨진다. .backup은 백업 API를 써서
+                  # 일관성 있는 사본을 만든다 (동시 쓰기와 안전하게 공존).
+                  for DB in state.db kanban.db response_store.db; do
+                    [ -f "/opt/data/${DB}" ] || continue
+                    sqlite3 "/opt/data/${DB}" ".backup '${STAGE}/${DB}'"
+                    echo "snapshot: ${DB}"
+                  done
+
+                  # 재생성 불가한 일반 파일만. bin/ skills/ 캐시는 이미지·init이
+                  # 복원하므로 제외한다 (74M → ~3.5M).
+                  for P in sessions pairing memory identity; do
+                    [ -e "/opt/data/${P}" ] || continue
+                    cp -a "/opt/data/${P}" "${STAGE}/"
+                    echo "copied: ${P}"
+                  done
+
+                  # auth.json(Codex OAuth 크레덴셜)은 의도적으로 제외한다.
+                  # 백업이 크레덴셜 저장소가 되는 것을 막는다. PVC 유실 시
+                  # `hermes auth add openai-codex` device-code 재발급으로 복구
+                  # (README Phase B). 기억·세션·pairing은 이 아카이브로 복원된다.
+
+                  ARCHIVE="/tmp/hermes-state-${TIMESTAMP}.tar.gz"
+                  tar -czf "${ARCHIVE}" -C "${STAGE}" .
+
+                  rclone copy "${ARCHIVE}" s3:hermes-backup-json-server/state/ \
+                    --s3-no-check-bucket
+
+                  echo "state backup uploaded: state/${ARCHIVE##*/} ($(du -h "${ARCHIVE}" | cut -f1))"
+              envFrom:
+                - secretRef:
+                    name: hermes-backup-credentials
+              volumeMounts:
+                - name: data
+                  mountPath: /opt/data
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: hermes-data

--- a/k8s/hermes/manifests/kustomization.yaml
+++ b/k8s/hermes/manifests/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - service.yaml
   - ingress.yaml
   - sealed-secret.yaml
+  - sealed-secret-backup.yaml
+  - backup-cronjob.yaml
 
 configMapGenerator:
   - name: hermes-config

--- a/k8s/hermes/manifests/sealed-secret-backup.yaml
+++ b/k8s/hermes/manifests/sealed-secret-backup.yaml
@@ -1,0 +1,19 @@
+# hermes-backup IAM 유저 자격증명 (aws/iam.tf가 발급).
+# 재봉인이 필요하면:
+#   terraform -chdir=aws output -raw hermes_backup_access_key_id | KUBECONFIG=~/.kube/config-json \
+#     kubeseal --raw --cert k8s/sealed-secrets/cert.pem \
+#     --name hermes-backup-credentials --namespace hermes --scope strict
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: hermes-backup-credentials
+  namespace: hermes
+spec:
+  encryptedData:
+    AWS_ACCESS_KEY_ID: AgA4uoUP3ohK2QVxViUrpNRx1mu535jZCqfhKRGhpJDfh+kSWxYp9OzfLRfS5c8J7+vix0VqtHuftg+eptiD0Fp0BPULRUP47JUpJfOZHWvc4hnfLLsT5dJyFohTEO31LzENC+XbZXI1He6gJ6536PMKErrq6mXEkU+VA3llPLOeVAEj5nnR0a+nSJUU7a0GFQQuF57pCkCSmewTVrnuduTWo9D7A6uYa4zNbMyiCZ/+ivYU509RwBSbU3GzOxk62qZXp31xDk9T5OgFkBCBlApJGUou/yrG7CTxZKlzp6hhz2SSJ6gUgnyUmLrzO8vS4hjObzNVNtJzpBtFLZB73sJYJaF5zBm9eoK4YyonDADtJ5VBUKrSniP7BMdfXeBgrt6w5YwfTDxP7dk2MU6Dot4sOM9B43iBH4WSCb7caveshw+AJGXbkjIj39jXXySN0V9aUfXPaTzY28FSBiPNeBWmF2yBtBCefOaGF75LuOx4UkjccOUfp+BTZeXPCPP4/m+NPpGVq+32YyiVuqh5H+d//ZfL2oPwSGSflKd+DK/10295T6LSCt2QfRqTWDI+DSgg0ivv/aGDmZMi4m0tM5hq/E+m0uJOLGEDNMGVOIAy5W9wfyo8JsfyeJQXCS40ix8LybsvzveWTyhn4wEUaag3wj2vh53ZoonLKN3xE0kW3VAWFKYDjv99LGX6AVRBptyLhh7WwKhF28M0+ltyg65x2XQlbQ==
+    AWS_SECRET_ACCESS_KEY: AgANCHQLryCYIZ3YxcCjJecwi/gZCJOskDHwawWbX51HxVXbamoPdK/0vN8+zsvwXX1DlLsYWHJziOJZ2l4qn9UtMWV+LXOlxNpuMF9xrJtRHxhXMhsXSQ/AYHZ5VqXJpvUItQVeEFHMLXue20Z6Z3PWJiPd8a4bf4ZiUNFvRh8TTPGtIXFzqUwj7MGqoxTm/l9c7nsECt0pqjSJpqqOQWmHhz7kwVfGEPW7O2CuIfXyMTThsDYJengYKs0yfpQTqb88lo7uzcXDo3bgq0ZkPWfcyVUOVWdJQvAF79YWrFtxpKuXBLiIasJo4AxWk9cnsEVtWQ4rQYOq6+khxzcIps4TzCCAsJ7tuaFgWjQ3N3CfR/tENJMs0hWuDKu9GLemJFcf5PqdtX9qMulP/lai2UpF18sN371y2gZAuYnAAGtxk90hQ3h3sHrbO68LcFrWp3VmWgTZhXqX9NFFpUeZgMz4ECfAZM1ZzgksfxvaTGTMX+cmbYN9VsKtFeUpJr/v03LA52z4DuCaNDj5Cd1julmfl2mKp+rNsYK4lxbUhTHx2BHwBZxRWgFLObGVyAHMtrvV69uUjgaVW3cHoZhzls2Tndyw2PMT/NFckXE7ukNbSK5FTCVOoQ3abU2iIv4D9d5WMuO1o2kQZjesFkdNsV3r0tgmEZYpzfdMcku+mBpQBh9IGdwVVKd0/8YDcJT5zjA1X17oXN2bKKQXYejfqWLb5Xg6VzpGku3XdZ98MBnZXwXfdzXCd8nn
+  template:
+    metadata:
+      name: hermes-backup-credentials
+      namespace: hermes
+    type: Opaque


### PR DESCRIPTION
#284 후속. 거기서 만든 S3 버킷·IAM 유저를 실제로 사용한다. `terraform apply` 완료(`Apply complete! 7 added`), 발급된 액세스 키는 봉인해 커밋했다.

## 동작

매일 **03:00 KST**, 재생성 불가한 상태만 골라 `s3://hermes-backup-json-server/state/`로 업로드 (30일 보관).

| | 항목 | 크기 |
|---|---|---|
| **담음** | `state.db` · `kanban.db` · `response_store.db` | 2.6M |
| **담음** | `sessions/` · `pairing/` · `memory/` · `identity/` | ~1M |
| 뺌 | `bin/` | 22M — 이미지가 복원 |
| 뺌 | `skills/` | 13M — init이 74개 번들 스킬 재동기화 |
| 뺌 | `models_dev_cache.json` | 3.3M — 캐시 |
| **뺌 (의도)** | `auth.json` | Codex OAuth 크레덴셜 |

74M → **~3.5M**.

`auth.json` 제외는 백업이 크레덴셜 저장소가 되는 것을 막기 위함. 복구 시 `hermes auth add openai-codex` device-code 재발급으로 대체되고, 기억·세션·pairing은 아카이브에서 그대로 복원된다.

## 구현상 함정 둘

**1. SQLite WAL** — `state.db`는 WAL 모드다. 라이브 파일을 `cp`로 뜨면 쓰기 도중의 찢어진 스냅샷이 잡혀 "백업은 돌았는데 복구가 안 되는" 최악의 형태가 된다. `sqlite3 .backup`은 백업 API를 써서 동시 쓰기와 안전하게 공존하는 일관된 사본을 만든다.

**2. RWO 볼륨 + 이동하는 파드** — `hermes-data`는 ReadWriteOnce(longhorn-ssd). hermes Deployment에는 `nodeSelector`가 없어 노드를 옮길 수 있다. 고정 `nodeSelector`를 박으면 hermes가 이사한 순간 백업이 Multi-Attach로 깨지므로, `podAffinity`(`topologyKey: kubernetes.io/hostname`)로 hermes 파드를 따라가게 했다.

## 스케줄 근거

immich(02:00) / health-hub(02:20) / seafile(02:40) 다음 슬롯. 2026-07-22 CP 과부하 인시던트(백업 동시 실행 → `node_load1` 112) 이후의 20분 간격 컨벤션을 따른다.

## 검증

```
kubectl kustomize k8s/hermes/manifests        → 8개 리소스 정상 렌더
kubectl apply --dry-run=server                → 전부 통과
                                                 cronjob.batch/hermes-state-backup created
                                                 sealedsecret/hermes-backup-credentials created
```

## Test plan
- [ ] 머지 후 hard-refresh → `argocd app wait hermes`
- [ ] SealedSecret 복호화 확인 (empty 함정): `kubectl -n hermes get secret hermes-backup-credentials -o json | jq '.data | map_values(@base64d | length)'`
- [ ] 수동 트리거: `kubectl -n hermes create job --from=cronjob/hermes-state-backup hermes-backup-manual`
- [ ] 로그에 `snapshot: state.db` / `state backup uploaded:` 확인
- [ ] 백업 파드가 hermes와 같은 노드에 스케줄됐는지 확인
- [ ] S3에 객체 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)