### PR TITLE
fix(observability): 디스코드 발송을 AlertmanagerConfig CRD 로 전환

### DIFF
--- a/k8s/observability/prometheus/manifests/alertmanagerconfig-discord.yaml
+++ b/k8s/observability/prometheus/manifests/alertmanagerconfig-discord.yaml
@@ -1,0 +1,36 @@
+# 디스코드 발송 경로.
+#
+# raw config(values.yaml)의 discord_configs 를 쓰지 못하는 이유:
+# prometheus-operator 의 discordConfig 타입에 webhook_url_file 이 없어(main 기준)
+# 웹훅 URL 을 파일로 넘길 수 없다. 평문을 git 에 두지 않으려면 CRD 의
+# apiURL(SecretKeySelector) 경로를 써야 한다.
+#
+# 이 route 는 alertmanagerConfigMatcherStrategy: None 덕분에 namespace matcher 없이
+# 전체 경보를 받는다. Watchdog/InfoInhibitor 차단은 values.yaml 의 루트 routes 가
+# 먼저 평가되어 처리한다.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: discord
+  namespace: observability
+spec:
+  route:
+    receiver: discord
+    groupBy: [alertname, namespace]
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 12h
+  receivers:
+    - name: discord
+      discordConfigs:
+        - apiURL:
+            name: alertmanager-discord
+            key: webhook-url
+          sendResolved: true
+          title: '{{ if eq .Status "firing" }}🔴{{ else }}🟢{{ end }} [K8s] {{ .Status | toUpper }}'
+          message: |-
+            {{ range .Alerts }}
+            **{{ .Labels.alertname }}** ({{ .Labels.severity }})
+            {{ .Annotations.summary }}
+            {{ .Annotations.description }}
+            {{ end }}

--- a/k8s/observability/prometheus/values.yaml
+++ b/k8s/observability/prometheus/values.yaml
@@ -31,10 +31,6 @@ alertmanager:
       # 실제 발송은 AlertmanagerConfig `discord` 가 담당 (manifests/alertmanagerconfig-discord.yaml).
       # 여기 receiver 는 그 route 에도 안 걸린 경보의 fallback 이다.
       receiver: "null"
-      group_by: [alertname, namespace]
-      group_wait: 30s
-      group_interval: 5m
-      repeat_interval: 12h
       routes:
         # kube-prometheus-stack 기본 watchdog alert 무시
         - match:

--- a/k8s/observability/prometheus/values.yaml
+++ b/k8s/observability/prometheus/values.yaml
@@ -20,13 +20,17 @@ alertmanager:
   alertmanagerSpec:
     nodeSelector:
       kubernetes.io/hostname: json-server-1
-    secrets:
-      - alertmanager-discord
+    # AlertmanagerConfig CR 의 route 에 namespace matcher 를 붙이지 않는다.
+    # discord CR 이 전체 경보를 받아야 하므로.
+    alertmanagerConfigMatcherStrategy:
+      type: None
   config:
     global:
       resolve_timeout: 5m
     route:
-      receiver: discord
+      # 실제 발송은 AlertmanagerConfig `discord` 가 담당 (manifests/alertmanagerconfig-discord.yaml).
+      # 여기 receiver 는 그 route 에도 안 걸린 경보의 fallback 이다.
+      receiver: "null"
       group_by: [alertname, namespace]
       group_wait: 30s
       group_interval: 5m
@@ -41,16 +45,6 @@ alertmanager:
           receiver: "null"
     receivers:
       - name: "null"
-      - name: discord
-        discord_configs:
-          - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord/webhook-url
-            title: '{{ if eq .Status "firing" }}🔴{{ else }}🟢{{ end }} [K8s] {{ .Status | toUpper }}'
-            message: |-
-              {{ range .Alerts }}
-              **{{ .Labels.alertname }}** ({{ .Labels.severity }})
-              {{ .Annotations.summary }}
-              {{ .Annotations.description }}
-              {{ end }}
 
 prometheus:
   prometheusSpec:


### PR DESCRIPTION
## 요약

[#283](https://github.com/manamana32321/homelab/pull/283) 이 오퍼레이터에 거부당해 알림이 아직 무음입니다. 발송 경로를 `AlertmanagerConfig` CRD 로 바꿔 복구합니다.

## 무엇이 잘못됐나

머지 후 오퍼레이터가 config 갱신을 반복 실패했습니다.

```
sync "observability/prometheus-kube-prometheus-alertmanager" failed:
  provision alertmanager configuration: failed to initialize from secret:
  yaml: unmarshal errors:
    line 37: field webhook_url_file not found in type alertmanager.discordConfig
```

오퍼레이터는 `alertmanager.config` 를 그대로 전달하지 않고 **자체 Go 타입으로 파싱·검증한 뒤 재직렬화**합니다. 그 `discordConfig` 에 `webhook_url_file` 이 없습니다. `main` 브랜치도 동일하고, `mattermostConfig`·`msTeamsV2Config` 에는 있는 필드라 버전 문제가 아니라 기능 공백입니다.

즉 raw config 로는 **웹훅 URL 을 파일로 넘길 방법이 없습니다.** 평문을 git 에 두지 않으려면 다른 경로가 필요합니다.

**영향**: 오퍼레이터가 잘못된 config 를 거부하고 기존 설정을 유지해서, 파드가 죽거나 빈 config 로 뜨지는 않았습니다. 알림이 복구되지 않았을 뿐 추가 장애는 없습니다.

## 어떻게 고치나

`AlertmanagerConfig` CRD 의 `discordConfigs.apiURL` 은 `SecretKeySelector` 라 오퍼레이터가 시크릿을 직접 읽어 주입합니다. raw config 검증을 아예 거치지 않습니다.

- 새 파일 `manifests/alertmanagerconfig-discord.yaml` — route + discord receiver
- `values.yaml` 의 루트 `receiver` 는 `"null"` fallback 으로. 실제 발송은 CR 담당
- `alertmanagerSpec.secrets` 제거 — 볼륨 마운트가 더 이상 필요 없음
- `alertmanagerConfigMatcherStrategy: None` — CR route 가 전체 경보를 받도록 (기본값 `OnNamespace` 는 namespace matcher 를 붙여 observability ns 경보만 받게 됨)

Watchdog/InfoInhibitor 차단은 루트 `routes` 가 먼저 평가되어 그대로 동작합니다.

## 검증

이번엔 머지 전에 네 가지를 확인했습니다.

- `AlertmanagerConfig` CRD 스키마의 `route` / `discordConfigs` 필드 실측 대조
- `alertmanagerConfigMatcherStrategy.type` enum 에 `None` 존재 확인
- `kubectl apply --dry-run=server` 통과
- 차트 80.14.4 템플릿이 `alertmanagerConfigMatcherStrategy` 를 CR 로 passthrough 하는지 확인

머지 후에는 오퍼레이터가 생성한 최종 config 에 `discord` receiver 가 들어갔는지, 실제 발송이 되는지까지 확인하겠습니다.
