### PR TITLE
feat(aws): AMANG production 백업용 S3 버킷 + IAM 유저 추가

### DIFF
--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -192,3 +192,39 @@ resource "aws_iam_user_policy_attachment" "hermes_backup" {
 resource "aws_iam_access_key" "hermes_backup" {
   user = aws_iam_user.hermes_backup.name
 }
+
+# AMANG production backup
+resource "aws_iam_user" "amang_backup" {
+  name = "amang-backup"
+}
+
+resource "aws_iam_policy" "amang_backup" {
+  name        = "amang-backup-s3"
+  description = "Allow AMANG production backup CronJobs to sync to S3"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:DeleteObject",
+      ]
+      Resource = [
+        aws_s3_bucket.amang_backup.arn,
+        "${aws_s3_bucket.amang_backup.arn}/*",
+      ]
+    }]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "amang_backup" {
+  user       = aws_iam_user.amang_backup.name
+  policy_arn = aws_iam_policy.amang_backup.arn
+}
+
+resource "aws_iam_access_key" "amang_backup" {
+  user = aws_iam_user.amang_backup.name
+}

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -93,3 +93,20 @@ output "hermes_backup_bucket" {
   description = "S3 bucket name for Hermes agent state backups"
   value       = aws_s3_bucket.hermes_backup.bucket
 }
+
+# AMANG backup
+output "amang_backup_access_key_id" {
+  description = "Access Key ID for amang-backup IAM user"
+  value       = aws_iam_access_key.amang_backup.id
+}
+
+output "amang_backup_secret_access_key" {
+  description = "Secret Access Key for amang-backup IAM user"
+  value       = aws_iam_access_key.amang_backup.secret
+  sensitive   = true
+}
+
+output "amang_backup_bucket" {
+  description = "S3 bucket name for AMANG production backups"
+  value       = aws_s3_bucket.amang_backup.bucket
+}

--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -143,3 +143,36 @@ resource "aws_s3_bucket_public_access_block" "hermes_backup" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# AMANG production backup (postgres 논리 덤프 + MinIO 오브젝트 미러)
+resource "aws_s3_bucket" "amang_backup" {
+  bucket = "amang-backup-json-server"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "amang_backup" {
+  bucket = aws_s3_bucket.amang_backup.id
+
+  # DB dumps: keep 30 days only.
+  # media/ 는 MinIO 미러라 만료 규칙을 두지 않는다 (immich/seafile 과 동일).
+  rule {
+    id     = "db-retention"
+    status = "Enabled"
+
+    filter {
+      prefix = "db/"
+    }
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "amang_backup" {
+  bucket = aws_s3_bucket.amang_backup.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
## 배경

백업 없는 PVC를 전수조사한 결과 amang production이 가장 값이 큰 축이었다. 둘 다 원본 데이터인데 백업이 없었음:

| 대상 | 사용량 | 잃으면 |
|---|---|---|
| `amang-db-production/postgres-pvc` | 154M | 프로덕션 DB 전체 |
| `amang-api-production/data0-minio-pool-0-0` | 56M (버킷 `amang`) | 업로드된 파일 — DB로 재구성 불가 |

`amang-redis-production`은 캐시 성격이라 제외.

Longhorn 복제본 2개(server-1·2)가 있지만 **복제는 백업이 아니다.** 디스크 하나 죽는 건 막아도 PVC 삭제·네임스페이스 삭제·데이터 손상은 양쪽 복제본에 똑같이 반영된다. 클러스터에 Longhorn 백업 타겟도 RecurringJob도 설정돼 있지 않아 볼륨 단위 백업 수단이 아예 없는 상태다.

## 변경

기존 앱별 백업 컨벤션 그대로:

| 리소스 | 내용 |
|---|---|
| `aws_s3_bucket.amang_backup` | `amang-backup-json-server` |
| `aws_s3_bucket_lifecycle_configuration` | `db/` 30일 만료. `media/`는 MinIO 미러라 만료 없음 (immich/seafile 동일) |
| `aws_s3_bucket_public_access_block` | 4종 전부 차단 |
| `aws_iam_user` + policy + attachment + access_key | `amang-backup`, 해당 버킷 ARN으로만 범위 제한 |

## 비용

압축 후 DB 덤프 ~30M × 30일 + MinIO 미러 56M ≈ 1GB 미만. 서울 리전 S3 Standard 기준 **월 $0.05 미만**.

## 검증

```
terraform fmt          → 적용
terraform validate     → Success
terraform plan         → Plan: 7 to add, 0 to change, 0 to destroy
```

기존 리소스 변경·삭제 없음.

## 후속 (CronJob 2개, 레포가 갈림)

| 대상 | 위치 | 이유 |
|---|---|---|
| postgres 논리 덤프 | `skku-amang/main` → `infra/k8s/db/overlays/production` | DB 매니페스트가 거기 있고, 같은 ns라 DB 비밀번호 시크릿을 그대로 참조 |
| MinIO 오브젝트 미러 | 이 레포 → `k8s/minio-tenants/overlays/production` | tenant 매니페스트가 여기 있고 `minio-s3-credentials`도 이미 선언돼 있음 |

둘 다 이 PR 머지 → `terraform apply` 후에야 액세스 키가 생겨 봉인 가능하므로 분리했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)