### PR TITLE
fix(observability): Watchdog·InfoInhibitor 가 디스코드로 새는 문제

### DIFF
--- a/k8s/observability/prometheus/manifests/alertmanagerconfig-discord.yaml
+++ b/k8s/observability/prometheus/manifests/alertmanagerconfig-discord.yaml
@@ -16,6 +16,16 @@ metadata:
 spec:
   route:
     receiver: discord
+    # 오퍼레이터는 이 route 를 루트 routes 의 맨 앞에 continue: true 로 넣는다.
+    # 따라서 Watchdog/InfoInhibitor 차단을 루트 쪽 형제 route 에 맡길 수 없고
+    # (먼저 여기에 걸려 발송된 뒤 넘어간다) 여기서 직접 제외해야 한다.
+    matchers:
+      - name: alertname
+        matchType: "!="
+        value: Watchdog
+      - name: alertname
+        matchType: "!="
+        value: InfoInhibitor
     groupBy: [alertname, namespace]
     groupWait: 30s
     groupInterval: 5m

--- a/k8s/observability/prometheus/values.yaml
+++ b/k8s/observability/prometheus/values.yaml
@@ -31,14 +31,6 @@ alertmanager:
       # 실제 발송은 AlertmanagerConfig `discord` 가 담당 (manifests/alertmanagerconfig-discord.yaml).
       # 여기 receiver 는 그 route 에도 안 걸린 경보의 fallback 이다.
       receiver: "null"
-      routes:
-        # kube-prometheus-stack 기본 watchdog alert 무시
-        - match:
-            alertname: Watchdog
-          receiver: "null"
-        - match:
-            alertname: InfoInhibitor
-          receiver: "null"
     receivers:
       - name: "null"
 


### PR DESCRIPTION
## 요약

[#286](https://github.com/manamana32321/homelab/pull/286) 으로 디스코드 발송은 살아났습니다. 다만 생성된 config 를 확인해보니 Watchdog 과 InfoInhibitor 가 디스코드로 새고 있어 막습니다.

## 발송은 정상입니다

```
alertmanager_notifications_total{integration="discord"}        4
alertmanager_notifications_failed_total{integration="discord"} 0   (모든 reason)
```

## 무엇이 잘못됐나

오퍼레이터가 만든 최종 라우트 트리입니다.

```
root receiver: "null"
  [0] receiver=observability/discord/discord   matchers=None   continue=True
  [1] receiver="null"   match={alertname: Watchdog}
  [2] receiver="null"   match={alertname: InfoInhibitor}
```

오퍼레이터는 `AlertmanagerConfig` 의 route 를 루트 `routes` 의 **맨 앞에 `continue: true` 로** 넣습니다. `alertmanagerConfigMatcherStrategy: None` 때문에 matcher 도 없어 전부 매칭됩니다.

그래서 Watchdog 은 `[0]` 에 먼저 걸려 **디스코드로 발송된 뒤** `[1]` 로 넘어갑니다. #286 에서 "루트 routes 가 먼저 평가되니 차단은 그대로 동작한다" 고 적었는데, 순서가 반대였습니다.

Watchdog 은 Alertmanager 가 살아있음을 알리려 **상시 발화**하는 경보라 그대로 두면 12시간마다 무의미한 알림이 옵니다.

## 어떻게 고치나

CR route 에 제외 매처를 직접 답니다.

```yaml
matchers:
  - { name: alertname, matchType: "!=", value: Watchdog }
  - { name: alertname, matchType: "!=", value: InfoInhibitor }
```

두 경보는 이제 CR route 에 걸리지 않고 루트로 떨어지는데, 루트 `receiver` 가 이미 `"null"` 이라 그대로 버려집니다.

**따라서 `values.yaml` 의 `routes` 두 개가 중복이 되어 제거합니다.** 알림 블록이 이만큼 줄어듭니다.

```yaml
config:
  global:
    resolve_timeout: 5m
  route:
    receiver: "null"
  receivers:
    - name: "null"
```

## 검증

- `matchType` enum 에 `!=` 존재 확인
- `kubectl apply --dry-run=server` 통과
- 머지 후 생성된 config 의 라우트 트리를 다시 확인하고, Watchdog 이 디스코드 그룹에서 빠졌는지 보겠습니다
