### PR TITLE
feat(amang): production MinIO 오브젝트 백업 CronJob 추가

### DIFF
--- a/k8s/minio-tenants/overlays/production/backup-cronjob.yaml
+++ b/k8s/minio-tenants/overlays/production/backup-cronjob.yaml
@@ -1,0 +1,88 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: amang-minio-backup
+  namespace: amang-api-production
+  labels:
+    app: amang
+    job-type: media-backup
+spec:
+  # 03:40 KST. immich media(03:00) 다음 슬롯 — 20분 간격 유지
+  # (2026-07-22 인시던트: 백업 동시 실행 + 러너 쏠림 → node_load1 112).
+  schedule: "40 18 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: amang
+            job-type: media-backup
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: media-backup
+              image: alpine:3.21
+              command:
+                - sh
+                - -c
+                - |
+                  set -eo pipefail
+                  apk add --no-cache rclone
+
+                  mkdir -p /root/.config/rclone
+                  # 소스는 tenant 자신(requestAutoCert:false → 평문 HTTP, ClusterIP :80).
+                  # 대상은 AWS S3. 오브젝트 단위로 미러하므로 MinIO 온디스크 포맷에
+                  # 의존하지 않는다 — 복구 시 다른 버전/다른 tenant로도 밀어넣을 수 있다.
+                  cat > /root/.config/rclone/rclone.conf <<CONF
+                  [minio]
+                  type = s3
+                  provider = Minio
+                  access_key_id = ${S3_ACCESS_KEY}
+                  secret_access_key = ${S3_SECRET_KEY}
+                  endpoint = http://minio.amang-api-production.svc.cluster.local
+                  force_path_style = true
+
+                  [s3]
+                  type = s3
+                  provider = AWS
+                  access_key_id = ${AWS_ACCESS_KEY_ID}
+                  secret_access_key = ${AWS_SECRET_ACCESS_KEY}
+                  region = ap-northeast-2
+                  location_constraint = ap-northeast-2
+                  no_check_bucket = true
+                  CONF
+
+                  # --size-only: mtime 확인용 HEAD 요청이 S3 Tier-2 GET 으로 청구되는 것을 피한다.
+                  ionice -c 3 rclone sync minio:amang s3:amang-backup-json-server/media/ \
+                    --size-only \
+                    --s3-no-head \
+                    --s3-no-check-bucket \
+                    --transfers 4 \
+                    --stats-one-line
+
+                  echo "media backup synced: $(rclone size s3:amang-backup-json-server/media/ --s3-no-check-bucket 2>/dev/null | tail -1)"
+              env:
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-s3-credentials
+                      key: S3_ACCESS_KEY
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-s3-credentials
+                      key: S3_SECRET_KEY
+              envFrom:
+                - secretRef:
+                    name: amang-backup-credentials
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi

--- a/k8s/minio-tenants/overlays/production/backup-cronjob.yaml
+++ b/k8s/minio-tenants/overlays/production/backup-cronjob.yaml
@@ -25,13 +25,12 @@ spec:
           restartPolicy: Never
           containers:
             - name: media-backup
-              image: alpine:3.21
+              image: rclone/rclone:1.75.0
               command:
                 - sh
                 - -c
                 - |
                   set -eo pipefail
-                  apk add --no-cache rclone
 
                   mkdir -p /root/.config/rclone
                   # 소스는 tenant 자신(requestAutoCert:false → 평문 HTTP, ClusterIP :80).

--- a/k8s/minio-tenants/overlays/production/kustomization.yaml
+++ b/k8s/minio-tenants/overlays/production/kustomization.yaml
@@ -5,5 +5,7 @@ resources:
   - ../../base
   - sealed-secret.yaml
   - sealed-secret-s3-credentials.yaml
+  - sealed-secret-backup.yaml
+  - backup-cronjob.yaml
   - ingress.yaml
   - ingress-console.yaml

--- a/k8s/minio-tenants/overlays/production/sealed-secret-backup.yaml
+++ b/k8s/minio-tenants/overlays/production/sealed-secret-backup.yaml
@@ -1,0 +1,19 @@
+# amang-backup IAM 유저 자격증명 (aws/iam.tf 가 발급).
+# 재봉인:
+#   terraform -chdir=aws output -raw amang_backup_access_key_id | KUBECONFIG=~/.kube/config-json \
+#     kubeseal --raw --cert k8s/sealed-secrets/cert.pem \
+#     --name amang-backup-credentials --namespace amang-api-production --scope strict
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: amang-backup-credentials
+  namespace: amang-api-production
+spec:
+  encryptedData:
+    AWS_ACCESS_KEY_ID: AgAOaVN3BoE8TUdtgdEUPwYmOqxxlLJDt8xiCvIa5b25uSzzpUM/zGCKYM9BkBLToGTSIw2ywHVsm6TMNfPPY3ez0zUlRHsteg8PCjf9Csjq8I8L8bO+/BsicLH6lEHkHG5tL5MxBJnSxid5ygFGEt2CK3/rq106h4kRk+G5jCxDWCDbPGp9C8llOO6ET+TOSjPwlYRrfQlsq22fFWvJ+1VZkTKvM7kzPQy76mkrStNDK0XIIzmKzplonZRxGLuThmSFY+zyZjJDmznwFxhlxtsyuSWmOhHJEs3OYMKsxjc3iljPpT/QXUrPQ5HpicY7ThLZKc/i5DhdSxmLxHJmp3WbiOpzF2Emkjo08zJB4hcc0s/jA6WdixWm2X5VXim2QRogiBwd9+OTSP9LuwH36zQuiAECqTGwIVbgKDhuD5lXOR0TvcAsb6dYBVlXhlG/1s0h9KYzWnPSa027ru3uev98CF18MvpAHblEOLLKdpYk+w8UcFiq5YposPj16NlTLFtWQwSpCWN3dMyOUojUPjbq8k5rcxWifIFnyrTGdzm70b/uAIzbqfWdL9VdfYx609Vo+NiNUuMaPUTEi2D/Z+Om/FIGmS3FfR+wlMsuUUZySQ4qnWAUf33g6n6NWnZp20pRAWAgtGdthZZtDe+/Q99rN7QXiyPglFLOARiTL7Yr2MHSACmOoWqxjF4RBMhmi/7lXD1kux3rfqLWxP5O5GkL4dHHKw==
+    AWS_SECRET_ACCESS_KEY: AgCYomAl/Z1AoWB6rE0N+DGg7hBf2Jy2pj53+BDsQhtmgM8uEUa8FozM4ltHTuPlCxCZeB98tbhowlxKsBOU6YQD73ljbAveuJBwzxaGa8Vv/vf8aVM21yNPM4riArqgfMGiGUcBNdA4z/dG9Dz4BAD71nxj7l/F2OLYPHyyuvlb+vcEz8YGAa+4UGYbQXZ3DkLt0fhLED2LHiX5kb3Plwlp2lpxQrnWARHZceMhSo0UX0c24LDSHHI/LJLgz/IsbMcJZPdiv+EYY46pFGPTY4pPWJeOg/kI3GgcIAp8sGScwsZiDa0Pvs77tn5do5/JAxvF49/h3/PXfxmLpiAlamcaTm1aLOYS2xsmGETU57nAU3o1eCc+ZKuU0DNehMzMV+DpQU3hCSulghSWC88oG73prRISPEbS/dfyvQCF5g/oBUWZoq/fhiU7dWHeNYNTlY3ToqHfcra2GhEx+qACSQSidOlFwmtvpvqhNjMM7aSrdV6Nd8gXUEzKIYV/GbRMcYgKTTevWRPiP2iHH10UZy/NhjnQUdNffFCVLWGnGdYm8bQHVRXM1cIOv+nxq3BUh4Ng4i2k2yZV9Oqib+arE9RWNk2MOzJc0emni4N74bqMAX2ZuMPfPR/BGXLHKMdaIJTcJ/4S61ir0BSFX4LRQa7iykiTUDVCcYIOjWX+2a6mR6H1KYqFUPPbTNtC06PgLa8aRxUtYS0bfVLuh/k4KPxWYOrvJms+LSIhU9SMEICqFa7DSU9Slaie
+  template:
+    metadata:
+      name: amang-backup-credentials
+      namespace: amang-api-production
+    type: Opaque

--- a/k8s/minio-tenants/overlays/production/sealed-secret-backup.yaml
+++ b/k8s/minio-tenants/overlays/production/sealed-secret-backup.yaml
@@ -1,8 +1,3 @@
-# amang-backup IAM 유저 자격증명 (aws/iam.tf 가 발급).
-# 재봉인:
-#   terraform -chdir=aws output -raw amang_backup_access_key_id | KUBECONFIG=~/.kube/config-json \
-#     kubeseal --raw --cert k8s/sealed-secrets/cert.pem \
-#     --name amang-backup-credentials --namespace amang-api-production --scope strict
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:


### PR DESCRIPTION
#287 후속. 거기서 만든 버킷·IAM 유저를 실제로 사용한다. `terraform apply` 완료(`7 added`), 발급된 액세스 키는 봉인해 커밋했다.

## 동작

매일 **03:40 KST**, MinIO 버킷 `amang`(56M)을 `s3://amang-backup-json-server/media/`로 미러.

## 설계 선택

**파일시스템 복사가 아니라 오브젝트 단위 미러.** `/export` 를 통째로 뜨면 MinIO 온디스크 포맷(xl.meta 등)에 묶여 같은 버전·같은 tenant 구성으로만 복구할 수 있다. 오브젝트 미러는 그냥 파일이라 어디로든 밀어넣을 수 있다.

**소스 자격증명은 기존 것 재사용.** `minio-s3-credentials`(`S3_ACCESS_KEY`/`S3_SECRET_KEY`)가 이미 이 오버레이에 선언돼 있어 새로 만들지 않았다. 엔드포인트는 tenant가 `requestAutoCert: false`라 ClusterIP `:80` 평문 HTTP.

**플래그는 immich/seafile media-backup과 동일**:
- `--size-only` — mtime 확인용 HEAD 요청이 S3 Tier-2 GET으로 청구되는 것을 피함
- `--s3-no-head` / `--s3-no-check-bucket` — 불필요한 요청 제거
- `ionice -c 3` — 백업 IO가 다른 워크로드를 밀어내지 않게

## 알아둘 트레이드오프

기존 관례를 따라 `rclone sync`를 쓴다. **`sync`는 삭제를 전파한다** — MinIO에서 파일이 지워지면 다음 실행에서 백업본도 지워진다. 즉 하드웨어 장애·PVC 손실은 막지만 "실수로 업로드 파일 삭제"는 못 막는다.

바꾸려면 두 선택지가 있고, 지금은 immich/seafile과 일관성을 택했다:
- `rclone copy` — 삭제 안 함. 대신 무한히 자람
- `rclone sync --backup-dir` — 지워진 것을 날짜 디렉토리로 옮김. 둘의 절충이지만 관례에서 벗어남

56M 규모라 나중에 바꿔도 비용은 미미하다.

## 검증

```
kubectl kustomize k8s/minio-tenants/overlays/production   → 7개 리소스 정상 렌더
kubectl apply --dry-run=server                            → 전부 통과
                                                             cronjob/amang-minio-backup created
                                                             sealedsecret/amang-backup-credentials created
```

## Test plan
- [ ] 머지 후 hard-refresh → ArgoCD sync 확인
- [ ] SealedSecret 복호화 확인: `kubectl -n amang-api-production get secret amang-backup-credentials -o json | jq '.data | map_values(@base64d | length)'`
- [ ] 수동 트리거: `kubectl -n amang-api-production create job --from=cronjob/amang-minio-backup amang-minio-manual`
- [ ] 로그에 `media backup synced:` 확인
- [ ] S3 `media/` 에 오브젝트 생성 확인

## 남은 것

postgres(154M) 논리 덤프 CronJob은 DB 매니페스트가 있는 `skku-amang/main` 레포로 간다 (같은 ns라 DB 비밀번호 시크릿을 그대로 참조 가능). 그쪽은 팀 레포라 PR 본문 초안 승인 후 제출 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)