### PR TITLE
chore(aws): Hermes 백업 S3 버킷 + IAM 유저 제거

### DIFF
--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -157,42 +157,6 @@ resource "aws_iam_access_key" "probe" {
   user = aws_iam_user.probe.name
 }
 
-# Hermes agent state backup
-resource "aws_iam_user" "hermes_backup" {
-  name = "hermes-backup"
-}
-
-resource "aws_iam_policy" "hermes_backup" {
-  name        = "hermes-backup-s3"
-  description = "Allow Hermes backup CronJob to sync agent state to S3"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Action = [
-        "s3:PutObject",
-        "s3:GetObject",
-        "s3:ListBucket",
-        "s3:DeleteObject",
-      ]
-      Resource = [
-        aws_s3_bucket.hermes_backup.arn,
-        "${aws_s3_bucket.hermes_backup.arn}/*",
-      ]
-    }]
-  })
-}
-
-resource "aws_iam_user_policy_attachment" "hermes_backup" {
-  user       = aws_iam_user.hermes_backup.name
-  policy_arn = aws_iam_policy.hermes_backup.arn
-}
-
-resource "aws_iam_access_key" "hermes_backup" {
-  user = aws_iam_user.hermes_backup.name
-}
-
 # AMANG production backup
 resource "aws_iam_user" "amang_backup" {
   name = "amang-backup"

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -77,23 +77,6 @@ output "probe_secret_access_key" {
   sensitive   = true
 }
 
-# Hermes backup
-output "hermes_backup_access_key_id" {
-  description = "Access Key ID for hermes-backup IAM user"
-  value       = aws_iam_access_key.hermes_backup.id
-}
-
-output "hermes_backup_secret_access_key" {
-  description = "Secret Access Key for hermes-backup IAM user"
-  value       = aws_iam_access_key.hermes_backup.secret
-  sensitive   = true
-}
-
-output "hermes_backup_bucket" {
-  description = "S3 bucket name for Hermes agent state backups"
-  value       = aws_s3_bucket.hermes_backup.bucket
-}
-
 # AMANG backup
 output "amang_backup_access_key_id" {
   description = "Access Key ID for amang-backup IAM user"

--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -112,38 +112,6 @@ resource "aws_s3_bucket_public_access_block" "minecraft_backup" {
   restrict_public_buckets = true
 }
 
-# Hermes agent state backup
-resource "aws_s3_bucket" "hermes_backup" {
-  bucket = "hermes-backup-json-server"
-}
-
-resource "aws_s3_bucket_lifecycle_configuration" "hermes_backup" {
-  bucket = aws_s3_bucket.hermes_backup.id
-
-  # State archives: keep 30 days only
-  rule {
-    id     = "state-retention"
-    status = "Enabled"
-
-    filter {
-      prefix = "state/"
-    }
-
-    expiration {
-      days = 30
-    }
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "hermes_backup" {
-  bucket = aws_s3_bucket.hermes_backup.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
 # AMANG production backup (postgres 논리 덤프 + MinIO 오브젝트 미러)
 resource "aws_s3_bucket" "amang_backup" {
   bucket = "amang-backup-json-server"


### PR DESCRIPTION
## 배경

헤르메스 백업은 하지 않기로 결정해 #285 를 닫았다. 실측상 보호 대상이 메시지 102개·세션 7개뿐이라 CronJob 운영 부담(실패 시 `KubeJobFailed` 알람, 크레덴셜 회전 대상 증가) 대비 값이 낮다는 판단이었다.

그 결과 #284 에서 만든 리소스가 고아가 됐다. 빈 버킷 하나와 **S3 쓰기 권한을 가진 미사용 IAM 유저**가 남아 있어 정리한다. 쓰지 않는 자격증명은 그 자체로 공격 표면이다.

## 삭제 전 확인

```
$ aws s3 ls s3://hermes-backup-json-server/ --recursive --summarize
Total Objects: 0
   Total Size: 0
```

버킷이 비어 있어 데이터 손실 없음.

## 변경

`hermes_backup` 블록만 제거 (85줄 삭제, 추가 0).

```
terraform validate  → Success
terraform plan      → Plan: 0 to add, 0 to change, 7 to destroy
```

destroy 대상 7개 전부 `hermes_backup` 접두. immich·seafile·health-hub·minecraft·amang 리소스는 무영향.

## 머지 후

`terraform apply` 로 실제 삭제 (`7 destroyed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
