### PR TITLE
fix(hosts): json-server-1 NIC TX 큐 행 자동 복구 유닛 추가

### DIFF
--- a/docs/nic-tx-hang-runbook.md
+++ b/docs/nic-tx-hang-runbook.md
@@ -1,0 +1,115 @@
+# NIC TX 큐 행 자동 복구 런북 (json-server-1)
+
+## 배경
+
+2026-08-21, json-server-1 의 온보드 Realtek NIC(`enp3s0`, r8169)이 송신 큐를 물고 놓지 않는
+상태에 빠졌다. 커널 netdev watchdog 이 5초마다 이를 고발했지만 드라이버 자체 리셋은 계속 실패했다.
+
+```
+r8169 0000:03:00.0 enp3s0: NETDEV WATCHDOG: CPU: 7: transmit queue 0 timed out 5567 ms
+r8169 0000:03:00.0 enp3s0: rtl_txcfg_empty_cond == 0 (loop: 666, delay: 100).
+```
+
+21분간 153회 반복, 자력 복구 0회. 노드는 살아있었지만 송신이 막혀 SSH·apiserver 모두 응답
+불가였고, 결국 손으로 전원을 끊어야 했다. json-server-1 은 단일 control-plane 이므로
+NIC 하나가 클러스터 API 전체를 멈춰 세웠다.
+
+이 런북은 그 상황을 사람 없이 수초 안에 빠져나오기 위한 호스트 레벨 유닛을 다룬다.
+
+## 동작
+
+`hosts/json-server-1/nic-tx-watchdog.sh` 가 커널 저널을 따라가다 해당 인터페이스의
+`NETDEV WATCHDOG` 라인을 만나면 3단계로 올라간다.
+
+| 단계 | 동작 | 부작용 | 판정 |
+|---|---|---|---|
+| 1 | `ip link set enp3s0 down/up` | 없음 | 20초 내 회복 여부 |
+| 2 | `modprobe -r/-a r8169` + `systemctl restart k3s` | API 30초 블립 | 60초 내 회복 여부 |
+| 3 | `systemctl reboot` | 노드 재부팅 | 누적 실패 300초 초과 시 |
+
+**1단계가 먼저인 이유**: `ip -d link show flannel.1` 을 보면 flannel VXLAN 이
+`vxlan id 1 local 192.168.0.27 dev enp3s0` 로 물리 NIC 을 언더레이로 직접 참조한다.
+모듈을 내리면 netdev 가 사라져 터널도 같이 무너지므로, NIC 이 살아 돌아와도 파드 네트워킹은
+죽은 채 남는다. 링크 바운스는 netdev 를 유지한 채 칩만 재초기화하므로 이 문제가 없다.
+2단계로 내려갈 때 k3s 를 재시작하는 것도 같은 이유다.
+
+**3단계가 재부팅인 이유**: 실패 시 대안이 "손으로 전원 끊기"였다. clean reboot 은 Longhorn
+볼륨을 정상 언마운트하고 kine SQLite 가 체크포인트를 남긴다. 루트가 DRAM-less SSD 라
+이 차이가 크다. `/run` 마커로 **부팅당 1회**만 허용되므로 재부팅 루프에 빠지지 않는다.
+
+### 오탐 방지
+
+- 트리거는 게이트웨이 ping 실패가 아니라 **커널의 `NETDEV WATCHDOG` 라인**이다. 공유기가
+  죽어도 이 라인은 안 나오므로 공유기 장애로는 복구 동작이 돌지 않는다.
+- 회복 판정은 캐리어 up + (게이트웨이 응답 **또는** TX 카운터 전진). 공유기가 같이 죽은
+  상황에서 NIC 만 살아난 경우를 실패로 오판하지 않기 위함이다.
+- 행 중에는 watchdog 라인이 ~5초마다 쏟아지므로 복구 사이클 간 `COOLDOWN_SEC`(기본 120초)
+  간격을 둔다.
+
+## 설치
+
+```bash
+sudo install -m 0755 hosts/json-server-1/nic-tx-watchdog.sh /usr/local/sbin/nic-tx-watchdog.sh
+sudo install -m 0644 hosts/json-server-1/nic-tx-watchdog.service /etc/systemd/system/nic-tx-watchdog.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now nic-tx-watchdog.service
+```
+
+## 검증
+
+실제 복구를 돌리지 않고 매칭 로직·연결 상태만 점검한다.
+
+```bash
+sudo /usr/local/sbin/nic-tx-watchdog.sh --self-test
+```
+
+전부 `OK` 여야 한다. 서비스 상태와 시작 로그:
+
+```bash
+systemctl status nic-tx-watchdog.service
+journalctl -u nic-tx-watchdog.service -n 20
+```
+
+### 실제 복구 경로까지 확인하고 싶을 때
+
+1단계(링크 바운스)를 손으로 재현하면 된다. **enp3s0 이 수초간 끊기므로 apiserver 와
+Longhorn 에 블립이 생긴다.** 한가한 시간에만 할 것.
+
+```bash
+sudo ip link set dev enp3s0 down; sleep 3; sudo ip link set dev enp3s0 up
+```
+
+## 튜닝
+
+`/etc/systemd/system/nic-tx-watchdog.service` 의 `Environment=` 로 조정한다.
+
+| 변수 | 기본값 | 의미 |
+|---|---|---|
+| `IFACE` | `enp3s0` | 감시 대상 인터페이스 |
+| `MODULE` | `r8169` | 2단계에서 재적재할 드라이버 |
+| `GATEWAY` | `192.168.0.1` | 회복 판정용 ping 대상 |
+| `COOLDOWN_SEC` | `120` | 복구 사이클 간 최소 간격 |
+| `REBOOT_AFTER_SEC` | `300` | 누적 실패가 이 시간을 넘으면 재부팅. **`0` 이면 재부팅 폴백 비활성** |
+
+변경 후 `sudo systemctl daemon-reload && sudo systemctl restart nic-tx-watchdog.service`.
+
+## 제거
+
+```bash
+sudo systemctl disable --now nic-tx-watchdog.service
+sudo rm /etc/systemd/system/nic-tx-watchdog.service /usr/local/sbin/nic-tx-watchdog.sh
+sudo systemctl daemon-reload
+```
+
+## 이건 임시방편이다
+
+근본 원인은 2011년 엔트리 칩셋(ASUS P8H61-M) 온보드 Realtek 컨트롤러 + 2012년 펌웨어
+(`rtl8168e-3_0.0.4`)다. 흔한 회피책(오프로드 끄기, ASPM 끄기)은 이미 적용된 상태라 남은
+근본 해결은 둘뿐이다.
+
+- NIC 물리 교체 (인텔 PCIe NIC 또는 USB3 GbE 어댑터)
+- control-plane 을 json-server-2 로 이전 — 단, 그 전에 j2 의 `eno1` 이 100 Mb/s 로 링크되는
+  문제를 먼저 잡아야 한다
+
+재발 이력은 `journalctl -u nic-tx-watchdog.service | grep '복구 시작'` 으로 센다.
+자주 뜨기 시작하면 임시방편의 수명이 끝난 것이다.

--- a/hosts/json-server-1/nic-tx-watchdog.service
+++ b/hosts/json-server-1/nic-tx-watchdog.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=r8169 TX 큐 행 감지 후 NIC 자동 복구
+Documentation=https://github.com/manamana32321/homelab/blob/main/docs/nic-tx-hang-runbook.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/sbin/nic-tx-watchdog.sh
+Restart=always
+RestartSec=10
+
+# 복구 동작에 root 필요: ip link, modprobe, systemctl restart/reboot
+User=root
+
+Environment=IFACE=enp3s0
+Environment=MODULE=r8169
+Environment=GATEWAY=192.168.0.1
+Environment=COOLDOWN_SEC=120
+# 0 으로 두면 자동 재부팅 폴백이 꺼진다.
+Environment=REBOOT_AFTER_SEC=300
+
+[Install]
+WantedBy=multi-user.target

--- a/hosts/json-server-1/nic-tx-watchdog.sh
+++ b/hosts/json-server-1/nic-tx-watchdog.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# r8169 TX 큐 행 자동 복구.
+#
+# 커널 netdev watchdog 이 "NETDEV WATCHDOG: transmit queue N timed out" 을 찍으면
+# NIC 이 패킷을 물고 놓지 않는 상태다. r8169 는 자체 리셋(rtl_reset_work)에 실패하면
+# 스스로 못 빠져나온다 (2026-08-21 인시던트: 21분간 153회 실패, 하드 리셋으로 종료).
+#
+# 3단계로 올라간다:
+#   1. 링크 바운스   — netdev 를 유지한 채 칩만 재초기화. flannel.1 VXLAN 이 살아남는다.
+#   2. 모듈 리로드   — 칩을 완전히 재적재. netdev 가 사라지므로 flannel 재구성용 k3s 재시작 동반.
+#   3. clean reboot  — 손으로 전원을 끊는 것보다 안전 (Longhorn 언마운트 + kine SQLite 체크포인트).
+#
+set -uo pipefail
+
+IFACE="${IFACE:-enp3s0}"
+MODULE="${MODULE:-r8169}"
+GATEWAY="${GATEWAY:-192.168.0.1}"
+
+# 전체 복구 사이클 간 최소 간격. 행 중에는 watchdog 이 ~5초마다 찍히므로 필수.
+COOLDOWN_SEC="${COOLDOWN_SEC:-120}"
+# 최초 실패 후 이 시간이 지나도록 살아나지 않으면 재부팅. 0 이면 재부팅 비활성.
+REBOOT_AFTER_SEC="${REBOOT_AFTER_SEC:-300}"
+
+# /run 은 부팅 시 비워지므로 "부팅당 1회 재부팅" 가드로 그대로 쓸 수 있다.
+STATE_DIR="/run/nic-tx-watchdog"
+REBOOTED_MARKER="$STATE_DIR/rebooted"
+FIRST_FAILURE_FILE="$STATE_DIR/first-failure"
+
+log() { printf '%s\n' "$*"; }
+
+is_watchdog_line() {
+    local line="$1"
+    [[ "$line" == *"NETDEV WATCHDOG"* && "$line" == *"$IFACE"* ]]
+}
+
+tx_packets() {
+    cat "/sys/class/net/$IFACE/statistics/tx_packets" 2>/dev/null || echo 0
+}
+
+carrier_up() {
+    [[ "$(cat "/sys/class/net/$IFACE/carrier" 2>/dev/null || echo 0)" == "1" ]]
+}
+
+# 캐리어가 올라왔고, 게이트웨이가 응답하거나 최소한 TX 카운터가 전진하면 살아난 것으로 본다.
+# 게이트웨이 단독 판정은 공유기가 같이 죽었을 때 오탐이 나므로 TX 전진을 함께 본다.
+link_healthy() {
+    carrier_up || return 1
+    ping -c1 -W2 -I "$IFACE" "$GATEWAY" >/dev/null 2>&1 && return 0
+    local before after
+    before="$(tx_packets)"
+    sleep 5
+    after="$(tx_packets)"
+    (( after > before ))
+}
+
+wait_healthy() {
+    local deadline=$(( $(date +%s) + $1 ))
+    while (( $(date +%s) < deadline )); do
+        link_healthy && return 0
+        sleep 2
+    done
+    return 1
+}
+
+bounce_link() {
+    log "[1/3] 링크 바운스: $IFACE down/up"
+    ip link set dev "$IFACE" down || log "  ip link down 실패"
+    sleep 3
+    ip link set dev "$IFACE" up || log "  ip link up 실패"
+}
+
+reload_module() {
+    log "[2/3] 모듈 리로드: $MODULE"
+    if ! modprobe -r "$MODULE"; then
+        log "  modprobe -r 실패 — 모듈이 점유 중일 수 있음"
+        return 1
+    fi
+    sleep 3
+    modprobe "$MODULE" || { log "  modprobe 재적재 실패"; return 1; }
+    # netdev 가 새로 생기므로 systemd-networkd 가 DHCP 를 다시 물어야 한다.
+    networkctl reconfigure "$IFACE" >/dev/null 2>&1 || true
+    return 0
+}
+
+# flannel.1 은 vxlan 언더레이로 enp3s0 을 직접 참조한다. 모듈 리로드로 netdev 가
+# 사라지면 터널도 무너지므로, NIC 이 돌아와도 k3s 를 재시작해야 파드 네트워킹이 산다.
+rebuild_overlay() {
+    log "  flannel VXLAN 재구성을 위해 k3s 재시작"
+    systemctl restart k3s || log "  k3s 재시작 실패"
+}
+
+record_first_failure() {
+    [[ -f "$FIRST_FAILURE_FILE" ]] || date +%s > "$FIRST_FAILURE_FILE"
+}
+
+clear_first_failure() {
+    rm -f "$FIRST_FAILURE_FILE"
+}
+
+maybe_reboot() {
+    (( REBOOT_AFTER_SEC > 0 )) || { log "  재부팅 폴백 비활성 (REBOOT_AFTER_SEC=0)"; return; }
+    if [[ -f "$REBOOTED_MARKER" ]]; then
+        log "  이번 부팅에서 이미 자동 재부팅함 — 반복 방지를 위해 중단. 수동 개입 필요"
+        return
+    fi
+    local first now
+    first="$(cat "$FIRST_FAILURE_FILE" 2>/dev/null || echo 0)"
+    now="$(date +%s)"
+    if (( first > 0 && now - first >= REBOOT_AFTER_SEC )); then
+        log "[3/3] $(( now - first ))초간 복구 실패 — clean reboot 실행"
+        : > "$REBOOTED_MARKER"
+        systemctl reboot
+    else
+        log "  누적 실패 $(( now - first ))초 < ${REBOOT_AFTER_SEC}초 — 재부팅 보류"
+    fi
+}
+
+recover() {
+    log "=== $IFACE TX 큐 행 감지 — 복구 시작 ==="
+    record_first_failure
+
+    bounce_link
+    if wait_healthy 20; then
+        log "링크 바운스로 복구됨"
+        clear_first_failure
+        return
+    fi
+
+    if reload_module && wait_healthy 60; then
+        log "모듈 리로드로 복구됨"
+        rebuild_overlay
+        clear_first_failure
+        return
+    fi
+
+    log "1·2단계 복구 실패"
+    maybe_reboot
+}
+
+self_test() {
+    local sample="r8169 0000:03:00.0 $IFACE: NETDEV WATCHDOG: CPU: 7: transmit queue 0 timed out 5567 ms"
+    local benign="r8169 0000:03:00.0 $IFACE: rtl_counters_cond == 1 (loop: 1000, delay: 10)."
+    local other="r8169 0000:03:00.0 eth9: NETDEV WATCHDOG: CPU: 1: transmit queue 0 timed out 5000 ms"
+    local rc=0
+
+    is_watchdog_line "$sample"  && log "OK   watchdog 라인 매칭"          || { log "FAIL watchdog 라인 미매칭"; rc=1; }
+    is_watchdog_line "$benign"  && { log "FAIL 무해한 라인을 오탐"; rc=1; } || log "OK   무해한 라인 무시"
+    is_watchdog_line "$other"   && { log "FAIL 다른 인터페이스를 오탐"; rc=1; } || log "OK   다른 인터페이스 무시"
+
+    carrier_up   && log "OK   $IFACE 캐리어 up"        || { log "FAIL $IFACE 캐리어 down"; rc=1; }
+    link_healthy && log "OK   $GATEWAY 연결 정상"      || { log "FAIL $GATEWAY 연결 실패"; rc=1; }
+
+    log "self-test 종료 (rc=$rc) — 실제 복구 동작은 수행하지 않음"
+    return $rc
+}
+
+main() {
+    if [[ "${1:-}" == "--self-test" ]]; then
+        self_test
+        exit $?
+    fi
+
+    mkdir -p "$STATE_DIR"
+    log "$IFACE TX 큐 행 감시 시작 (모듈=$MODULE, 게이트웨이=$GATEWAY, 재부팅 임계=${REBOOT_AFTER_SEC}초)"
+
+    local last_cycle=0
+    while read -r line; do
+        is_watchdog_line "$line" || continue
+        now="$(date +%s)"
+        if (( now - last_cycle < COOLDOWN_SEC )); then
+            continue
+        fi
+        last_cycle="$now"
+        recover
+    done < <(journalctl -k -f -n0 -o cat)
+
+    log "커널 저널 스트림 종료 — 서비스 재시작 필요"
+    exit 1
+}
+
+main "$@"


### PR DESCRIPTION
## 왜

2026-08-21 08:05 KST, json-server-1 의 온보드 Realtek NIC(`enp3s0`, r8169)이 송신 큐를 물고 놓지 않는 상태에 빠졌다.

```
r8169 0000:03:00.0 enp3s0: NETDEV WATCHDOG: CPU: 7: transmit queue 0 timed out 5567 ms
r8169 0000:03:00.0 enp3s0: rtl_txcfg_empty_cond == 0 (loop: 666, delay: 100).
```

커널 netdev watchdog 은 5초마다 정확히 고발했지만 드라이버 자체 리셋은 계속 실패했다. **21분간 153회 반복, 자력 복구 0회.** 노드는 살아있었지만 송신이 막혀 SSH·apiserver 모두 응답 불가 → 손으로 전원을 끊어야 끝났다.

json-server-1 은 단일 control-plane 이라 NIC 하나가 클러스터 API 전체를 멈춰 세웠다.

배제한 원인들: 공유기 아님(j2 uptime 166일, 동시간대 네트워크 에러 0), 부하 아님(직전 트래픽 194→248 kB/s 평시), kine SQLite 스톨은 결과임(Slow SQL 경고가 행 전 5건 / 후 2222건), MCE·PCIe AER 0건.

## 무엇

`NETDEV WATCHDOG` 라인을 감지해 3단계로 올라가는 호스트 레벨 systemd 유닛.

| 단계 | 동작 | 부작용 | 판정 |
|---|---|---|---|
| 1 | `ip link set enp3s0 down/up` | 없음 | 20초 내 회복 |
| 2 | `modprobe -r/-a r8169` + `systemctl restart k3s` | API 30초 블립 | 60초 내 회복 |
| 3 | `systemctl reboot` | 노드 재부팅 | 누적 실패 300초 초과 |

## 설계 근거

**1단계가 먼저인 이유** — `ip -d link show flannel.1` 이 `vxlan id 1 local 192.168.0.27 dev enp3s0` 을 보여준다. flannel VXLAN 이 물리 NIC 을 언더레이로 직접 참조하므로, 모듈을 내리면 netdev 가 사라져 터널도 같이 무너진다. NIC 이 살아 돌아와도 파드 네트워킹은 죽은 채 남는다. 링크 바운스는 netdev 를 유지한 채 칩만 재초기화하므로 이 문제가 없다. 2단계에서 k3s 를 재시작하는 것도 같은 이유.

**3단계가 재부팅인 이유** — 실패 시 대안이 "손으로 전원 끊기"였다. clean reboot 은 Longhorn 볼륨을 정상 언마운트하고 kine SQLite 가 체크포인트를 남긴다. 루트가 DRAM-less SSD 라 이 차이가 크다. `/run` 마커로 부팅당 1회만 허용 → 재부팅 루프 불가. `REBOOT_AFTER_SEC=0` 으로 끌 수 있다.

**오탐 방지** — 트리거가 게이트웨이 ping 실패가 아니라 커널 로그 라인이므로 공유기 장애로는 복구가 돌지 않는다(전례 2회 있음). 회복 판정은 캐리어 up + (게이트웨이 응답 **또는** TX 카운터 전진)이라, 공유기가 같이 죽은 상황에서 NIC 만 살아난 경우를 실패로 오판하지 않는다.

## 검증

json-server-1 에 설치 완료, `enabled` + `active`, 저널 팔로워 정상.

```
$ sudo /usr/local/sbin/nic-tx-watchdog.sh --self-test
OK   watchdog 라인 매칭
OK   무해한 라인 무시
OK   다른 인터페이스 무시
OK   enp3s0 캐리어 up
OK   192.168.0.1 연결 정상
self-test 종료 (rc=0) — 실제 복구 동작은 수행하지 않음
```

배포된 파일이 레포와 동일한지 md5 대조 확인.

## 한계

임시방편이다. 근본 원인은 2011년 H61 보드(ASUS P8H61-M)의 온보드 Realtek 컨트롤러 + 2012년 펌웨어(`rtl8168e-3_0.0.4`)이고, 흔한 회피책(오프로드 끄기, ASPM 끄기)은 이미 적용된 상태다. 근본 해결은 NIC 물리 교체 또는 control-plane 의 json-server-2 이전 — 후자는 j2 `eno1` 의 100 Mb/s 링크 문제(#272)를 먼저 잡아야 한다.

재발 횟수는 `journalctl -u nic-tx-watchdog.service | grep '복구 시작'` 으로 센다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)