### PR TITLE
fix(essentia): 릴레이 이미지를 멀티아치로 빌드

### DIFF
--- a/.github/workflows/essentia-discord-relay-build.yaml
+++ b/.github/workflows/essentia-discord-relay-build.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -38,6 +40,10 @@ jobs:
       - uses: docker/build-push-action@v5
         with:
           context: k8s/essentia/discord-relay
+          # 클러스터에 amd64(json-server-1/2)와 arm64(raspi-1)가 섞여 있다.
+          # 단일 아키텍처로 빌드하면 반대편 노드에 스케줄될 때
+          # "no match for platform in manifest" 로 ImagePullBackOff 가 난다.
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## 요약

[#295](https://github.com/manamana32321/homelab/pull/295) 로 essentia 가 살아났는데 릴레이만 `ImagePullBackOff` 입니다. 이미지를 멀티아치로 빌드해 해결합니다.

## 증상

```
Failed to pull image "ghcr.io/manamana32321/essentia-discord-relay:latest":
  no match for platform in manifest: not found
```

클러스터에 아키텍처가 섞여 있습니다.

```
json-server-1   amd64
json-server-2   amd64
raspi-1         arm64   ← 릴레이가 여기 스케줄됨
```

GitHub 호스팅 러너가 amd64 라 빌드 결과도 amd64 단일 이미지였고, arm64 노드에서 매니페스트를 못 찾습니다.

나머지 세 파드는 정상입니다 — `essentia-api` 는 amd64 노드에 떴고, `essentia-web` 과 `essentia-postgres` 는 raspi-1 에 떴는데도 잘 돕니다 (그쪽 이미지는 멀티아치).

## 왜 nodeSelector 가 아니라 멀티아치인가

레포에는 amd64 전용 이미지를 노드에 고정하는 선례가 있습니다.

```
k8s/gbrain-mcp/manifests/sync-cronjob.yaml   # image is amd64-only; raspi-1 would ImagePullBackOff
k8s/health-hub/manifests/deployment.yaml
k8s/minio-tenants/base/tenant.yaml
```

다만 이것들은 **외부 이미지**라 빌드를 바꿀 수 없어 우회한 경우입니다. 릴레이는 우리가 빌드하므로 제약 자체를 없애는 편이 낫습니다. 노드 배치 제약이 사라지고, 나중에 라즈베리파이만 남아도 동작합니다.

비용도 거의 없습니다. Dockerfile 이 이렇습니다.

```dockerfile
FROM node:22-alpine
WORKDIR /app
COPY relay.mjs ./
USER node
CMD ["node", "relay.mjs"]
```

`RUN` 단계가 하나도 없어 크로스 빌드에 에뮬레이션이 필요 없고, `node:22-alpine` 은 이미 멀티아치입니다.

## 변경 내용

```yaml
- uses: docker/setup-qemu-action@v3      # 추가
...
  platforms: linux/amd64,linux/arm64     # 추가
```

## 머지 후

워크플로가 자동으로 돌아 새 매니페스트를 올립니다. 그 뒤 릴레이 파드를 재시작하면 붙습니다.
