### PR TITLE
fix(essentia): amd64 단일 아키텍처 이미지를 nodeSelector 로 고정

### DIFF
--- a/.github/workflows/essentia-discord-relay-build.yaml
+++ b/.github/workflows/essentia-discord-relay-build.yaml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v3
-
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -40,10 +38,6 @@ jobs:
       - uses: docker/build-push-action@v5
         with:
           context: k8s/essentia/discord-relay
-          # 클러스터에 amd64(json-server-1/2)와 arm64(raspi-1)가 섞여 있다.
-          # 단일 아키텍처로 빌드하면 반대편 노드에 스케줄될 때
-          # "no match for platform in manifest" 로 ImagePullBackOff 가 난다.
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/k8s/essentia/api/deployment.yaml
+++ b/k8s/essentia/api/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app: essentia-api
     spec:
+      # 이미지가 amd64 단일 아키텍처다. raspi-1(arm64)에 스케줄되면
+      # ImagePullBackOff 또는 exec format error 로 죽는다.
+      nodeSelector:
+        kubernetes.io/arch: amd64
       imagePullSecrets:
         - name: ghcr-essentia
       containers:

--- a/k8s/essentia/discord-relay/deployment.yaml
+++ b/k8s/essentia/discord-relay/deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: essentia-discord-relay
     spec:
+      # 이미지가 amd64 단일 아키텍처다. raspi-1(arm64)에 스케줄되면
+      # ImagePullBackOff 또는 exec format error 로 죽는다.
+      nodeSelector:
+        kubernetes.io/arch: amd64
       containers:
         - name: relay
           image: ghcr.io/manamana32321/essentia-discord-relay:latest

--- a/k8s/essentia/web/deployment.yaml
+++ b/k8s/essentia/web/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app: essentia-web
     spec:
+      # 이미지가 amd64 단일 아키텍처다. raspi-1(arm64)에 스케줄되면
+      # ImagePullBackOff 또는 exec format error 로 죽는다.
+      nodeSelector:
+        kubernetes.io/arch: amd64
       imagePullSecrets:
         - name: ghcr-essentia
       containers:


### PR DESCRIPTION
## 요약

[#296](https://github.com/manamana32321/homelab/pull/296)(릴레이 멀티아치 빌드)을 되돌리고, essentia 의 amd64 단일 아키텍처 이미지 셋을 `nodeSelector` 로 고정합니다.

## 왜 되돌리나

#296 은 릴레이 하나만 해결했습니다. `essentia-edu/api` 와 `web` 은 **다른 레포에서 빌드**돼 여기서 손댈 수 없습니다. 셋 중 하나만 멀티아치면 일관성이 없고, 나머지 둘은 여전히 arm64 노드에서 죽습니다.

## 놓치고 있던 고장

`essentia-web` 이 raspi-1 에서 crash-loop 중이었습니다.

```
restarts: 12
exec /usr/local/bin/docker-entrypoint.sh: exec format error
```

릴레이는 `ImagePullBackOff` 로 즉시 드러났지만, 이쪽은 **pull 은 되고 실행에서 죽는** 형태라 파드가 `Running` 으로 보였습니다. 그래서 발견이 늦었습니다.

## 이미지 실측

레지스트리 매니페스트를 직접 조회했습니다.

| 이미지 | 아키텍처 | 처리 |
|---|---|---|
| `essentia-edu/api` | 단일 (amd64) | 고정 |
| `essentia-edu/web` | 단일 (amd64) | 고정 |
| `manamana32321/essentia-discord-relay` | 멀티아치 (되돌림) | 고정 |
| `postgres:17-alpine` | 공식 멀티아치 | **제외** |

`postgres` 는 raspi-1 에서 정상 동작 중이고 PVC 도 그 노드에 있어 건드리지 않습니다. 옮기면 볼륨 재연결 비용만 생깁니다.

## 변경 내용

```yaml
      nodeSelector:
        kubernetes.io/arch: amd64
```

`api` · `web` · `discord-relay` 세 Deployment 에 추가하고, #296 의 워크플로 변경을 revert 합니다.

레포의 기존 선례와도 맞습니다.

```
k8s/gbrain-mcp/manifests/sync-cronjob.yaml   # image is amd64-only; raspi-1 would ImagePullBackOff
k8s/health-hub/manifests/deployment.yaml
k8s/minio-tenants/base/tenant.yaml
```

## 검증

- 레지스트리 매니페스트 직접 조회로 아키텍처 확인
- `kubectl kustomize k8s/essentia` 빌드 통과, 렌더 결과에서 세 Deployment 의 `nodeSelector` 확인
- `kubectl apply --dry-run=server` 통과

머지 후 세 파드가 amd64 노드로 재스케줄되는지, `essentia-web` crash-loop 이 멎는지 확인하겠습니다.
