### PR TITLE
fix(gbrain): sync 에서 임베딩 생성 비활성화 (--no-embed)

### DIFF
--- a/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
+++ b/k8s/gbrain-mcp/manifests/sync-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
                   git clone --depth 1 \
                     "https://x-access-token:${GH_PAT}@github.com/manamana32321/brain.git" \
                     /tmp/brain
-                  gbrain sync --repo /tmp/brain
+                  gbrain sync --repo /tmp/brain --no-embed
               env:
                 - name: GH_PAT
                   valueFrom:


### PR DESCRIPTION
## 무엇이 바뀌나

brain 자동 동기화(5분마다 도는 작업)가 **글 내용만 색인**하고, **의미 검색용 벡터(임베딩) 생성은 건너뛴다**.

## 왜

OpenAI 크레딧이 바닥나서 임베딩 요청이 계속 거부(429)된다. 거부될 때마다 파일 단위로 재시도가 붙어 동기화 한 번이 17분 → 29분으로 늘어났다.

이 작업은 `concurrencyPolicy: Forbid`(겹쳐 돌지 않음) + `startingDeadlineSeconds: 300`(5분 안에 못 시작하면 그 회차 스킵) 설정이라, 한 번이 29분 걸리면 그 사이 5분 주기 스케줄이 전부 버려진다. 실제로 오늘 **7시간 넘게 동기화가 한 번도 안 돌았고** `GbrainSyncStale` 알람이 켜졌다.

## 영향

| 항목 | 상태 |
|---|---|
| 키워드 검색 (`gbrain search`) | 영향 없음 — 임베딩 없이 갱신됨 |
| 기존 의미 검색 | 유지 — 이미 만들어둔 3896/4005 청크는 DB에 그대로 |
| 새로 쓴 글의 의미 검색 | 크레딧 충전 전까지 미적용 (키워드 검색으로는 잡힘) |

크레딧을 채우면 `gbrain embed --stale` 한 번으로 밀린 것만 백필된다. 되돌리려면 `--no-embed` 만 지우면 됨.

## 검증

- [ ] ArgoCD sync 후 다음 CronJob 실행이 30분 데드라인 안에 완료
- [ ] `GbrainSyncStale` 알람 해제